### PR TITLE
Probe Widget Height Fix

### DIFF
--- a/src/app/widgets/Probe/index.styl
+++ b/src/app/widgets/Probe/index.styl
@@ -162,7 +162,7 @@
 }
 
 .height-override {
-    height: 100%;
+    height: 100% !important;
 }
 
 .probeDiameterWrapper {


### PR DESCRIPTION
- forced 100% height by adding `!important` keyword