### PR TITLE
Visualize SVG in Lite Mode

### DIFF
--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -534,7 +534,11 @@ class PreferencesPage extends PureComponent {
                     G1_PART
                 ];
                 parts.map((value) => {
-                    return this.visualizerConfig.set(CUST_THEME + ' ' + value, themeColours.get(value));
+                    let label = value;
+                    if (value === G1_PART) {
+                        label = 'G1-3';
+                    }
+                    return this.visualizerConfig.set(CUST_THEME + ' ' + label, themeColours.get(value));
                 });
                 this.setState({
                     visualizer: {
@@ -586,10 +590,10 @@ class PreferencesPage extends PureComponent {
                     defaultColour = themeType.G1Color;
                     break;
                 case 'G2':
-                    defaultColour = themeType.G2Color;
+                    defaultColour = themeType.G1Color;
                     break;
                 case 'G3':
-                    defaultColour = themeType.G3Color;
+                    defaultColour = themeType.G1Color;
                     break;
                 default:
                     defaultColour = '#000000';

--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -159,6 +159,7 @@ class PreferencesPage extends PureComponent {
                 objects: this.visualizerConfig.get('objects'),
                 disabled: this.visualizerConfig.get('disabled'),
                 disabledLite: this.visualizerConfig.get('disabledLite'),
+                SVGEnabled: this.visualizerConfig.get('SVGEnabled', false),
                 showSoftLimitsWarning: this.visualizerConfig.get('showSoftLimitsWarning')
             },
             showWarning: store.get('widgets.visualizer.showWarning'),
@@ -624,6 +625,17 @@ class PreferencesPage extends PureComponent {
                 }
                 pubsub.publish('visualizer:settings');
             },
+            handleSVGEnabledToggle: () => {
+                const { visualizer } = this.state;
+                const value = visualizer.SVGEnabled;
+                this.setState({
+                    visualizer: {
+                        ...visualizer,
+                        SVGEnabled: !value
+                    }
+                });
+                pubsub.publish('visualizer:settings');
+            },
             handleCutPathToggle: (liteMode = false) => {
                 const { visualizer } = this.state;
                 const { objects } = visualizer;
@@ -764,6 +776,7 @@ class PreferencesPage extends PureComponent {
         store.set('widgets.visualizer.theme', visualizer.theme);
         store.set('widgets.visualizer.disabled', visualizer.disabled);
         store.set('widgets.visualizer.disabledLite', visualizer.disabledLite);
+        store.set('widgets.visualizer.SVGEnabled', visualizer.SVGEnabled);
         store.set('widgets.visualizer.minimizeRenders', visualizer.minimizeRenders);
         store.set('workspace.units', units);
         store.replace('workspace[tools]', tools);

--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -520,6 +520,7 @@ class PreferencesPage extends PureComponent {
                 pubsub.publish('theme:change', theme.value);
             },
             handleCustThemeChange: (themeColours) => {
+                const { visualizer } = this.state;
                 const parts = [
                     BACKGROUND_PART,
                     GRID_PART,
@@ -534,6 +535,12 @@ class PreferencesPage extends PureComponent {
                 ];
                 parts.map((value) => {
                     return this.visualizerConfig.set(CUST_THEME + ' ' + value, themeColours.get(value));
+                });
+                this.setState({
+                    visualizer: {
+                        ...visualizer,
+                        theme: CUST_THEME,
+                    }
                 });
                 pubsub.publish('theme:change', CUST_THEME);
             },

--- a/src/app/containers/Preferences/Visualizer/VisualizerOptions.js
+++ b/src/app/containers/Preferences/Visualizer/VisualizerOptions.js
@@ -8,51 +8,61 @@ import Fieldset from '../components/Fieldset';
 import styles from '../index.styl';
 
 const VisualizerOptions = ({ state, actions }) => {
-    const { objects, disabled, disabledLite } = state.visualizer;
+    const { objects, disabled, disabledLite, SVGEnabled } = state.visualizer;
     const visualizerActions = actions.visualizer;
 
     return (
-        <Fieldset legend="Visualizer Options">
-            <div className={styles.addMargin}>
-                <div className={classNames(styles.vizGrid)}>
-                    <b>Option</b>
-                    <b>Regular</b>
-                    <b>Lightweight Mode</b>
-                    <Tooltip content="Toggle rendering of your project" location="default">
-                        <span>Visualize G-Code</span>
-                    </Tooltip>
-                    <ToggleSwitch checked={!disabled} onChange={() => visualizerActions.handleVisEnabledToggle()} size="sm" />
-                    <ToggleSwitch checked={!disabledLite} onChange={() => visualizerActions.handleVisEnabledToggle(true)} size="lg" />
-                    <Tooltip content="Show the Drill Bit spinning while project runs" location="default">
-                        <span>Show Bit Animation</span>
-                    </Tooltip>
-                    <ToggleSwitch checked={objects.cuttingToolAnimation.visible} onChange={() => visualizerActions.handleAnimationToggle()} size="md" />
-                    <ToggleSwitch checked={objects.cuttingToolAnimation.visibleLite} onChange={() => visualizerActions.handleAnimationToggle(true)} size="md" />
-                    <Tooltip content="Toggle rendering of the Drill Bit" location="default">
-                        <span>Show Bit</span>
-                    </Tooltip>
-                    <ToggleSwitch checked={objects.cuttingTool.visible} onChange={() => visualizerActions.handleBitToggle()} size="md" />
-                    <ToggleSwitch checked={objects.cuttingTool.visibleLite} onChange={() => visualizerActions.handleBitToggle(true)} size="md" />
-                    <Tooltip content="Show a dot in the visualizer instead of the Drill Bit" location="default">
-                        <span>Cutpath Animation</span>
-                    </Tooltip>
-                    <ToggleSwitch checked={objects.cutPath.visible} onChange={() => visualizerActions.handleCutPathToggle()} size="md" />
-                    <ToggleSwitch checked={objects.cutPath.visibleLite} onChange={() => visualizerActions.handleCutPathToggle(true)} size="md" />
+        <>
+            <Fieldset legend="Visualizer Options">
+                <div className={styles.addMargin}>
+                    <div className={classNames(styles.vizGrid)}>
+                        <b>Option</b>
+                        <b>Regular</b>
+                        <b>Lightweight Mode</b>
+                        <Tooltip content="Toggle rendering of your project" location="default">
+                            <span>Visualize G-Code</span>
+                        </Tooltip>
+                        <ToggleSwitch checked={!disabled} onChange={() => visualizerActions.handleVisEnabledToggle()} size="sm" />
+                        <ToggleSwitch checked={!disabledLite} onChange={() => visualizerActions.handleVisEnabledToggle(true)} size="lg" />
+                        <Tooltip content="Show the Drill Bit spinning while project runs" location="default">
+                            <span>Show Bit Animation</span>
+                        </Tooltip>
+                        <ToggleSwitch checked={objects.cuttingToolAnimation.visible} onChange={() => visualizerActions.handleAnimationToggle()} size="md" />
+                        <ToggleSwitch checked={objects.cuttingToolAnimation.visibleLite} onChange={() => visualizerActions.handleAnimationToggle(true)} size="md" />
+                        <Tooltip content="Toggle rendering of the Drill Bit" location="default">
+                            <span>Show Bit</span>
+                        </Tooltip>
+                        <ToggleSwitch checked={objects.cuttingTool.visible} onChange={() => visualizerActions.handleBitToggle()} size="md" />
+                        <ToggleSwitch checked={objects.cuttingTool.visibleLite} onChange={() => visualizerActions.handleBitToggle(true)} size="md" />
+                        <Tooltip content="Show a dot in the visualizer instead of the Drill Bit" location="default">
+                            <span>Cutpath Animation</span>
+                        </Tooltip>
+                        <ToggleSwitch checked={objects.cutPath.visible} onChange={() => visualizerActions.handleCutPathToggle()} size="md" />
+                        <ToggleSwitch checked={objects.cutPath.visibleLite} onChange={() => visualizerActions.handleCutPathToggle(true)} size="md" />
+                    </div>
+                    <small>Specify which visualizer features are enabled or disable in both regular mode and light-mode, in order to save computer resources</small>
                 </div>
-                <small>Specify which visualizer features are enabled or disable in both regular mode and light-mode, in order to save computer resources</small>
-            </div>
-            {
-                /*
-                            <div className={styles.flexRow}>
-                <span>Force minimal renders</span>
-                <ToggleSwitch checked={minimizeRenders} onChange={() => visualizerActions.handleMinimizeRenderToggle()} />
-            </div>
-            <small>This will force the visualizer to only re-render when new information is received from the controller during a job, increasing performance</small>
+                {
+                    /*
+                                <div className={styles.flexRow}>
+                    <span>Force minimal renders</span>
+                    <ToggleSwitch checked={minimizeRenders} onChange={() => visualizerActions.handleMinimizeRenderToggle()} />
+                </div>
+                <small>This will force the visualizer to only re-render when new information is received from the controller during a job, increasing performance</small>
 
-                 */
-            }
+                    */
+                }
 
-        </Fieldset>
+            </Fieldset>
+            <Fieldset legend="Lightweight Mode Options">
+                <div className={classNames(styles.vizGrid)}>
+                    <Tooltip content="Toggle whether the Visualizer is the classic 3D grid, or a 2D SVG" location="default">
+                        <span>Enable SVG Visualizer</span>
+                    </Tooltip>
+                    <ToggleSwitch disabled={disabledLite} checked={SVGEnabled} onChange={() => visualizerActions.handleSVGEnabledToggle()} size="sm" />
+                </div>
+            </Fieldset>
+        </>
     );
 };
 

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -303,7 +303,6 @@
     "File folder": "File folder",
     "{{extname}} File": "{{extname}} File",
     "File": "File",
-    "3D rendering": "3D rendering",
     "Top View": "Top View",
     "Front View": "Front View",
     "Right Side View": "Right Side View",
@@ -332,5 +331,6 @@
     "Server Connection Lost": "Server Connection Lost",
     "It looks like the server connection has been lost - attempt to reconnect?": "It looks like the server connection has been lost - attempt to reconnect?",
     "Attempt Reconnect": "Attempt Reconnect",
-    "Click \"Resume\" to continue execution.": "Click \"Resume\" to continue execution."
+    "Click \"Resume\" to continue execution.": "Click \"Resume\" to continue execution.",
+    "Rendering": "Rendering"
 }

--- a/src/app/sagas/controllerSagas.js
+++ b/src/app/sagas/controllerSagas.js
@@ -33,7 +33,7 @@ import { Toaster, TOASTER_INFO, TOASTER_UNTIL_CLOSE } from 'app/lib/toaster/Toas
 import EstimateWorker from 'app/workers/Estimate.worker';
 import VisualizeWorker from 'app/workers/Visualize.worker';
 import { estimateResponseHandler } from 'app/workers/Estimate.response';
-import { visualizeResponse, shouldVisualize, isLiteMode } from 'app/workers/Visualize.response';
+import { visualizeResponse, shouldVisualize, shouldVisualizeSVG } from 'app/workers/Visualize.response';
 import { isLaserMode } from 'app/lib/laserMode';
 import { RENDER_LOADING, RENDER_RENDERED, VISUALIZER_SECONDARY, GRBL_ACTIVE_STATE_RUN, GRBL_ACTIVE_STATE_IDLE, GRBL_ACTIVE_STATE_HOLD } from 'app/constants';
 import isElectron from 'is-electron';
@@ -268,7 +268,7 @@ export function* initialize() {
             });
 
             const needsVisualization = shouldVisualize();
-            const liteMode = isLiteMode();
+            const shouldRenderSVG = shouldVisualizeSVG();
 
             if (needsVisualization) {
                 const visualizeWorker = new VisualizeWorker();
@@ -276,7 +276,7 @@ export function* initialize() {
                 visualizeWorker.postMessage({
                     content,
                     visualizer,
-                    liteMode
+                    shouldRenderSVG
                 });
             } else {
                 reduxStore.dispatch({
@@ -322,7 +322,7 @@ export function* initialize() {
         });
 
         const needsVisualization = shouldVisualize();
-        const liteMode = isLiteMode();
+        const shouldRenderSVG = shouldVisualizeSVG();
 
         if (needsVisualization) {
             const visualizeWorker = new VisualizeWorker();
@@ -331,7 +331,7 @@ export function* initialize() {
                 content,
                 visualizer,
                 isLaser,
-                liteMode
+                shouldRenderSVG
             });
         } else {
             reduxStore.dispatch({

--- a/src/app/sagas/controllerSagas.js
+++ b/src/app/sagas/controllerSagas.js
@@ -33,7 +33,7 @@ import { Toaster, TOASTER_INFO, TOASTER_UNTIL_CLOSE } from 'app/lib/toaster/Toas
 import EstimateWorker from 'app/workers/Estimate.worker';
 import VisualizeWorker from 'app/workers/Visualize.worker';
 import { estimateResponseHandler } from 'app/workers/Estimate.response';
-import { visualizeResponse, shouldVisualize } from 'app/workers/Visualize.response';
+import { visualizeResponse, shouldVisualize, isLiteMode } from 'app/workers/Visualize.response';
 import { isLaserMode } from 'app/lib/laserMode';
 import { RENDER_LOADING, RENDER_RENDERED, VISUALIZER_SECONDARY, GRBL_ACTIVE_STATE_RUN, GRBL_ACTIVE_STATE_IDLE, GRBL_ACTIVE_STATE_HOLD } from 'app/constants';
 import isElectron from 'is-electron';
@@ -268,13 +268,15 @@ export function* initialize() {
             });
 
             const needsVisualization = shouldVisualize();
+            const liteMode = isLiteMode();
 
             if (needsVisualization) {
                 const visualizeWorker = new VisualizeWorker();
                 visualizeWorker.onmessage = visualizeResponse;
                 visualizeWorker.postMessage({
                     content,
-                    visualizer
+                    visualizer,
+                    liteMode
                 });
             } else {
                 reduxStore.dispatch({
@@ -320,6 +322,7 @@ export function* initialize() {
         });
 
         const needsVisualization = shouldVisualize();
+        const liteMode = isLiteMode();
 
         if (needsVisualization) {
             const visualizeWorker = new VisualizeWorker();
@@ -327,7 +330,8 @@ export function* initialize() {
             visualizeWorker.postMessage({
                 content,
                 visualizer,
-                isLaser
+                isLaser,
+                liteMode
             });
         } else {
             reduxStore.dispatch({

--- a/src/app/widgets/Visualizer/GCodeVisualizer.js
+++ b/src/app/widgets/Visualizer/GCodeVisualizer.js
@@ -102,7 +102,7 @@ class GCodeVisualizer {
     }
 
     render({ vertices, colors, frames, spindleSpeeds, isLaser = false }) {
-        const { cuttingCoordinateLines, G0Color, G1Color, G2Color, G3Color } = this.theme;
+        const { cuttingCoordinateLines, G0Color, G1Color } = this.theme;
         this.vertices = vertices;
         this.frames = frames;
         this.spindleSpeeds = spindleSpeeds;
@@ -113,8 +113,8 @@ class GCodeVisualizer {
         const motionColor = {
             'G0': new THREE.Color(G0Color),
             'G1': new THREE.Color(G1Color),
-            'G2': new THREE.Color(G2Color),
-            'G3': new THREE.Color(G3Color),
+            'G2': new THREE.Color(G1Color),
+            'G3': new THREE.Color(G1Color),
             'default': defaultColor
         };
 

--- a/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
+++ b/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
@@ -86,7 +86,6 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
                             state={state}
                             actions={actions}
                             containerID={containerID}
-                            liteMode={liteMode}
                             isSecondary={false}
                         />
                         <WorkflowControl
@@ -94,7 +93,6 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
                             state={state}
                             actions={actions}
                             invalidGcode={invalidLine.line}
-                            liteMode={liteMode}
                         />
 
 

--- a/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
+++ b/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -29,8 +29,6 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
     const { handleLiteModeToggle, handleRun, reset } = actions;
 
     const containerID = 'visualizer_container';
-
-    let visualizer = useRef();
 
     return (
         <Widget className={styles.vizWidgetOverride}>
@@ -82,7 +80,7 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
                         <VisualizerWrapper
                             show={showVisualizer}
                             cameraPosition={cameraPosition}
-                            ref={visualizer}
+                            ref={visualizerRef}
                             state={state}
                             actions={actions}
                             containerID={containerID}

--- a/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
+++ b/src/app/widgets/Visualizer/PrimaryVisualizer.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -11,7 +11,7 @@ import WorkflowControl from './WorkflowControl';
 import MachineStatusArea from './MachineStatusArea';
 import ValidationModal from './ValidationModal';
 import WarningModal from './WarningModal';
-import Visualizer from './Visualizer';
+import VisualizerWrapper from './VisualizerWrapper';
 import Loading from './Loading';
 import Rendering from './Rendering';
 import WatchDirectory from './WatchDirectory';
@@ -29,6 +29,8 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
     const { handleLiteModeToggle, handleRun, reset } = actions;
 
     const containerID = 'visualizer_container';
+
+    let visualizer = useRef();
 
     return (
         <Widget className={styles.vizWidgetOverride}>
@@ -77,20 +79,22 @@ const PrimaryVisualizer = ({ actions, state, capable, showLoading, showRendering
                             state={state}
                             actions={actions}
                         />
-                        <Visualizer
+                        <VisualizerWrapper
                             show={showVisualizer}
                             cameraPosition={cameraPosition}
-                            ref={visualizerRef}
+                            ref={visualizer}
                             state={state}
                             actions={actions}
                             containerID={containerID}
+                            liteMode={liteMode}
+                            isSecondary={false}
                         />
-
                         <WorkflowControl
                             ref={workflowRef}
                             state={state}
                             actions={actions}
                             invalidGcode={invalidLine.line}
+                            liteMode={liteMode}
                         />
 
 

--- a/src/app/widgets/Visualizer/Rendering.jsx
+++ b/src/app/widgets/Visualizer/Rendering.jsx
@@ -31,7 +31,9 @@ export default () => (
             <i className="fa fa-cube fa-spin" />
         </div>
         <div className={styles.loaderText}>
-            {i18n._('3D rendering')}
+            {
+                i18n._('Rendering')
+            }
         </div>
     </div>
 );

--- a/src/app/widgets/Visualizer/SVGVisualizer.jsx
+++ b/src/app/widgets/Visualizer/SVGVisualizer.jsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2021 Sienci Labs Inc.
+ *
+ * This file is part of gSender.
+ *
+ * gSender is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, under version 3 of the License.
+ *
+ * gSender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gSender.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact for information regarding this program and its license
+ * can be sent through gSender@sienci.com or mailed to the main office
+ * of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+ *
+ */
+
+import reduxStore from 'app/store/redux';
+import api from 'app/api';
+import { connect } from 'react-redux';
+import * as fileActions from 'app/actions/fileInfoActions';
+import _get from 'lodash/get';
+import pubsub from 'pubsub-js';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+    RENDER_RENDERED,
+    VISUALIZER_PRIMARY,
+    VISUALIZER_SECONDARY
+} from 'app/constants';
+import controller from '../../lib/controller';
+import styles from './index.styl';
+
+class SVGVisualizer extends Component {
+    static propTypes = {
+        show: PropTypes.bool,
+        cameraPosition: PropTypes.oneOf(['top', '3d', 'front', 'left', 'right']),
+        state: PropTypes.object,
+        isSecondary: PropTypes.bool,
+    };
+
+    pubsubTokens = [];
+
+    isSecondaryVisualizer = this.props.isSecondary;
+
+    bbox = {
+        max: {
+            x: 0,
+            y: 0,
+            z: 0
+        },
+        min: {
+            x: 0,
+            y: 0,
+            z: 0
+        }
+    }
+
+    componentDidMount() {
+        this.subscribe();
+    }
+
+    componentDidUpdate() {
+        const { bbox } = this.props;
+
+        const { max: max0, min: min0 } = this.bbox;
+        const { x: xMax0, y: yMax0, z: zMax0 } = max0;
+        const { x: xMin0, y: yMin0, z: zMin0 } = min0;
+
+        const { max: max1, min: min1 } = bbox;
+        const { x: xMax1, y: yMax1, z: zMax1 } = max1;
+        const { x: xMin1, y: yMin1, z: zMin1 } = min1;
+
+        if (xMax0 !== xMax1 || yMax0 !== yMax1 || zMax0 !== zMax1 ||
+            xMin0 !== xMin1 || yMin0 !== yMin1 || zMin0 !== zMin1) {
+            this.bbox = bbox;
+            this.updateSVG();
+        }
+    }
+
+    componentWillUnMount() {
+        this.unsubscribe();
+    }
+
+    subscribe() {
+        const tokens = [
+            pubsub.subscribe('file:load', (msg, data) => {
+                const { isSecondary, activeVisualizer } = this.props;
+
+                const isPrimaryVisualizer = !isSecondary && activeVisualizer === VISUALIZER_PRIMARY;
+                const isSecondaryVisualizer = isSecondary && activeVisualizer === VISUALIZER_SECONDARY;
+
+                if (isPrimaryVisualizer) {
+                    this.isSecondaryVisualizer = false;
+                    this.load(data);
+                    return;
+                }
+
+                if (isSecondaryVisualizer) {
+                    this.isSecondaryVisualizer = true;
+                    this.load(data);
+                    return;
+                }
+            }),
+        ];
+        this.pubsubTokens = this.pubsubTokens.concat(tokens);
+    }
+
+    unsubscribe() {
+        this.pubsubTokens.forEach((token) => {
+            this.pubsub.unsubscribe(token);
+        });
+        this.pubsubTokens = [];
+    }
+
+    rerenderGCode() {
+        const { state, content } = this.props;
+        const { gcode } = state;
+
+        if (gcode.content) {
+            this.load(gcode.content);
+        } else {
+            // reupload the file to update the colours
+            this.uploadGCodeFile(content);
+        }
+    }
+
+    async uploadGCodeFile (gcode) {
+        const serializedFile = new File([gcode], 'surfacing.gcode');
+        await api.file.upload(serializedFile, controller.port, VISUALIZER_SECONDARY);
+    }
+
+    updateSVG() {
+        let svg = document.getElementById(!this.isSecondaryVisualizer ? 'svg' : 'svg2');
+        const reduxBBox = this.props.bbox;
+        let bbox = JSON.parse(JSON.stringify(reduxBBox)); // make shallow copy
+        // convert from inches to mm
+        const { content } = this.props;
+        if (content.includes('G20')) {
+            bbox.max.x *= 25.4;
+            bbox.max.y *= 25.4;
+            bbox.min.x *= 25.4;
+            bbox.min.y *= 25.4;
+            bbox.delta.x *= 25.4;
+            bbox.delta.y *= 25.4;
+        }
+
+        // we are flipping the y values so the image isnt upside down,
+        // therefore the yMultiplier is * -1 what it normally would be
+        let xMultiplier = 1;
+        let yMultiplier = -1;
+        let xVal = bbox.min.x;
+        let yVal = bbox.min.y;
+        // top right
+        if (bbox.min.x >= 0 && bbox.min.y >= 0 && bbox.max.x > 0 && bbox.max.y > 0) {
+            xMultiplier = 1;
+            xVal = bbox.max.x;
+            yMultiplier = -1;
+            yVal = bbox.max.y;
+        } else if (bbox.min.x < 0 && bbox.min.y >= 0 && bbox.max.x <= 0 && bbox.max.y > 0) {
+            // top left
+            xMultiplier = 1;
+            xVal = bbox.min.x;
+            yMultiplier = -1;
+            yVal = bbox.max.y;
+        } else if (bbox.min.x >= 0 && bbox.min.y < 0 && bbox.max.x > 0 && bbox.max.y <= 0) {
+            // bottom right
+            xMultiplier = 1;
+            xVal = bbox.max.x;
+            yMultiplier = -1;
+            yVal = bbox.min.y;
+        } else if (bbox.min.x < 0 && bbox.min.y < 0 && bbox.max.x <= 0 && bbox.max.y <= 0) {
+            // bottom left
+            xMultiplier = 1;
+            xVal = bbox.min.x;
+            yMultiplier = -1;
+            yVal = bbox.min.y;
+        } else if (bbox.min.x < 0 && bbox.min.y < 0 && bbox.max.x > 0 && bbox.max.y > 0) {
+            // center
+            xMultiplier = 1;
+            xVal = 0;
+            yMultiplier = -1;
+            yVal = 0;
+        }
+        const middle = !this.isSecondaryVisualizer ? 250 : 235;
+        const xtrans = middle - (xVal * xMultiplier / 2);
+        const ytrans = middle - (yVal * yMultiplier / 2);
+
+        // center the svg
+        svg.setAttribute('transform', 'translate(' + xtrans + ',' + ytrans + ') scale(1,-1)');
+
+        reduxStore.dispatch({
+            type: fileActions.UPDATE_FILE_RENDER_STATE,
+            payload: {
+                state: RENDER_RENDERED
+            }
+        });
+    }
+
+    handleSVGRender(vizualization) {
+        const { vertices } = vizualization;
+        let svg = document.getElementById(!this.isSecondaryVisualizer ? 'svg' : 'svg2');
+        if (svg) {
+            vertices.map((vertice, i) => {
+                const node = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+                for (let prop in vertice.props) {
+                    if (Object.prototype.hasOwnProperty.call(vertice.props, prop)) {
+                        node.setAttribute(prop, vertice.props[prop]);
+                    }
+                }
+                return svg.appendChild(node);
+            });
+
+            this.updateSVG();
+        }
+    }
+
+    load(vizualization) {
+        const { disabled, disabledLite, liteMode } = this.props.state;
+        const shouldRenderVisualization = liteMode ? !disabledLite : !disabled;
+
+        this.unload();
+
+        if (shouldRenderVisualization) {
+            this.handleSVGRender(vizualization);
+        } else {
+            this.actions.setVisualizerReady();
+        }
+    }
+
+    unload() {
+        let svg = document.getElementById(!this.isSecondaryVisualizer ? 'svg' : 'svg2');
+        // remove svg
+        if (svg) {
+            while (svg.firstChild) {
+                svg.removeChild(svg.firstChild);
+            }
+        }
+    }
+
+    render() {
+        const id = !this.isSecondaryVisualizer ? 'svg' : 'svg2';
+        const viewBox = !this.isSecondaryVisualizer ? '0 0 500 500' : '0 0 470 470';
+        return (
+            <div
+                style={{
+                    visibility: this.props.show ? 'visible' : 'hidden'
+                }}
+                className={styles.visualizerContainer}
+            >
+                <svg
+                    height="100%"
+                    width="100%"
+                    viewBox={viewBox}
+                    className={styles.svgContainer}
+                >
+                    <g
+                        id={id}
+                    />
+                </svg>
+            </div>
+        );
+    }
+}
+
+SVGVisualizer.defaultProps = {
+    isSecondary: false,
+};
+
+export default connect((store) => {
+    const bbox = _get(store, 'file.bbox');
+    const content = _get(store, 'file.content');
+    const { activeVisualizer } = store.visualizer;
+    return {
+        bbox,
+        content,
+        activeVisualizer
+    };
+}, null, null, { forwardRef: true })(SVGVisualizer);

--- a/src/app/widgets/Visualizer/SVGVisualizer.jsx
+++ b/src/app/widgets/Visualizer/SVGVisualizer.jsx
@@ -233,16 +233,8 @@ class SVGVisualizer extends Component {
     }
 
     load(vizualization) {
-        const { disabled, disabledLite, liteMode } = this.props.state;
-        const shouldRenderVisualization = liteMode ? !disabledLite : !disabled;
-
         this.unload();
-
-        if (shouldRenderVisualization) {
-            this.handleSVGRender(vizualization);
-        } else {
-            this.actions.setVisualizerReady();
-        }
+        this.handleSVGRender(vizualization);
     }
 
     unload() {

--- a/src/app/widgets/Visualizer/SVGVisualizer.jsx
+++ b/src/app/widgets/Visualizer/SVGVisualizer.jsx
@@ -26,6 +26,7 @@ import api from 'app/api';
 import { connect } from 'react-redux';
 import * as fileActions from 'app/actions/fileInfoActions';
 import _get from 'lodash/get';
+import store from 'app/store';
 import pubsub from 'pubsub-js';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -61,6 +62,8 @@ class SVGVisualizer extends Component {
             z: 0
         }
     }
+
+    theme = store.get('widgets.visualizer');
 
     componentDidMount() {
         this.subscribe();
@@ -204,7 +207,9 @@ class SVGVisualizer extends Component {
     }
 
     handleSVGRender(vizualization) {
-        const { vertices } = vizualization;
+        const { vertices, colors } = vizualization;
+        const { currentTheme } = this.props.state;
+        const { G0Color, G1Color } = currentTheme;
         let svg = document.getElementById(!this.isSecondaryVisualizer ? 'svg' : 'svg2');
         if (svg) {
             vertices.map((vertice, i) => {
@@ -214,6 +219,12 @@ class SVGVisualizer extends Component {
                         node.setAttribute(prop, vertice.props[prop]);
                     }
                 }
+                // add stroke colour
+                const motion = colors[i][0];
+                const opacity = colors[i][1];
+                const stroke = motion === 'G0' ? G0Color + opacity : G1Color + opacity;
+                node.setAttribute('stroke', stroke);
+
                 return svg.appendChild(node);
             });
 
@@ -247,6 +258,8 @@ class SVGVisualizer extends Component {
     render() {
         const id = !this.isSecondaryVisualizer ? 'svg' : 'svg2';
         const viewBox = !this.isSecondaryVisualizer ? '0 0 500 500' : '0 0 470 470';
+        const { currentTheme } = this.props.state;
+        const { backgroundColor } = currentTheme;
         return (
             <div
                 style={{
@@ -259,6 +272,7 @@ class SVGVisualizer extends Component {
                     width="100%"
                     viewBox={viewBox}
                     className={styles.svgContainer}
+                    style={{ backgroundColor: backgroundColor }}
                 >
                     <g
                         id={id}

--- a/src/app/widgets/Visualizer/SecondaryVisualizer.jsx
+++ b/src/app/widgets/Visualizer/SecondaryVisualizer.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import * as WebGL from 'app/lib/three/WebGL';
@@ -9,7 +9,6 @@ import Loading from './Loading';
 import Rendering from './Rendering';
 
 const SecondaryVisualizer = ({ state, actions, surfacingData, showVisualizer, cameraPosition, visualizerRef, showLoading, showRendering }) => {
-    let visualizer = useRef();
     return (
         <div style={{ border: '1px solid black', height: '100%', width: '100%' }}>
             { showLoading && <Loading /> }
@@ -19,7 +18,7 @@ const SecondaryVisualizer = ({ state, actions, surfacingData, showVisualizer, ca
                 <VisualizerWrapper
                     show={showVisualizer}
                     cameraPosition={cameraPosition}
-                    ref={visualizer}
+                    ref={visualizerRef}
                     state={state}
                     actions={actions}
                     surfacingData={surfacingData}

--- a/src/app/widgets/Visualizer/SecondaryVisualizer.jsx
+++ b/src/app/widgets/Visualizer/SecondaryVisualizer.jsx
@@ -1,29 +1,30 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import * as WebGL from 'app/lib/three/WebGL';
 import { SURFACING_VISUALIZER_CONTAINER_ID } from 'app/constants';
 
-import Visualizer from './Visualizer';
+import VisualizerWrapper from './VisualizerWrapper';
 import Loading from './Loading';
 import Rendering from './Rendering';
 
 const SecondaryVisualizer = ({ state, actions, surfacingData, showVisualizer, cameraPosition, visualizerRef, showLoading, showRendering }) => {
+    let visualizer = useRef();
     return (
         <div style={{ border: '1px solid black', height: '100%', width: '100%' }}>
             { showLoading && <Loading /> }
             { showRendering && <Rendering /> }
 
             {WebGL.isWebGLAvailable() && (
-                <Visualizer
-                    isSecondary
+                <VisualizerWrapper
                     show={showVisualizer}
                     cameraPosition={cameraPosition}
-                    ref={visualizerRef}
+                    ref={visualizer}
                     state={state}
                     actions={actions}
                     surfacingData={surfacingData}
                     containerID={SURFACING_VISUALIZER_CONTAINER_ID}
+                    isSecondary={true}
                 />
             )}
         </div>

--- a/src/app/widgets/Visualizer/VisualizerWrapper.jsx
+++ b/src/app/widgets/Visualizer/VisualizerWrapper.jsx
@@ -23,7 +23,7 @@
 
 import React, { Component } from 'react';
 import pubsub from 'pubsub-js';
-import { isLiteMode } from '../../workers/Visualize.response';
+import { shouldVisualizeSVG } from '../../workers/Visualize.response';
 import SVGVisualizer from './SVGVisualizer';
 import Visualizer from './Visualizer';
 
@@ -57,6 +57,13 @@ class VisualizerWrapper extends Component {
                 };
             });
         });
+        pubsub.subscribe('visualizer:settings', () => {
+            this.setState(() => {
+                return {
+                    needRefresh: true
+                };
+            });
+        });
     }
 
     unsubscribe() {
@@ -65,11 +72,11 @@ class VisualizerWrapper extends Component {
 
     render() {
         const { state, show, cameraPosition, actions, containerID, isSecondary } = this.props;
-        let isLite = isLiteMode();
+        let renderSVG = shouldVisualizeSVG();
         return (
             <>
                 {
-                    !isLite &&
+                    !renderSVG &&
                         <Visualizer
                             show={show}
                             cameraPosition={cameraPosition}
@@ -83,7 +90,7 @@ class VisualizerWrapper extends Component {
                         />
                 }
                 {
-                    isLite &&
+                    renderSVG &&
                         <SVGVisualizer
                             show={show}
                             ref={(visualizerRef) => {

--- a/src/app/widgets/Visualizer/VisualizerWrapper.jsx
+++ b/src/app/widgets/Visualizer/VisualizerWrapper.jsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 Sienci Labs Inc.
+ *
+ * This file is part of gSender.
+ *
+ * gSender is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, under version 3 of the License.
+ *
+ * gSender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gSender.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact for information regarding this program and its license
+ * can be sent through gSender@sienci.com or mailed to the main office
+ * of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+ *
+ */
+
+import React, { Component } from 'react';
+import pubsub from 'pubsub-js';
+import { isLiteMode } from '../../workers/Visualize.response';
+import SVGVisualizer from './SVGVisualizer';
+import Visualizer from './Visualizer';
+
+class VisualizerWrapper extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { needRefresh: false };
+    }
+    visualizer = null;
+
+    componentDidMount() {
+        this.subscribe();
+    }
+
+    componentDidUpdate() {
+        if (this.state.needRefresh) {
+            this.visualizer.rerenderGCode();
+            this.setState(() => {
+                return {
+                    needRefresh: false
+                };
+            });
+        }
+    }
+
+    subscribe() {
+        pubsub.subscribe('litemode:change', () => {
+            this.setState(() => {
+                return {
+                    needRefresh: true
+                };
+            });
+        });
+    }
+
+    unsubscribe() {
+        pubsub.unsubscribe('litemode:change');
+    }
+
+    render() {
+        const { state, show, cameraPosition, actions, containerID, isSecondary } = this.props;
+        let isLite = isLiteMode();
+        return (
+            <>
+                {
+                    !isLite &&
+                        <Visualizer
+                            show={show}
+                            cameraPosition={cameraPosition}
+                            ref={(visualizerRef) => {
+                                this.visualizer = visualizerRef;
+                            }}
+                            state={state}
+                            actions={actions}
+                            containerID={containerID}
+                            isSecondary={isSecondary}
+                        />
+                }
+                {
+                    isLite &&
+                        <SVGVisualizer
+                            show={show}
+                            ref={(visualizerRef) => {
+                                this.visualizer = visualizerRef;
+                            }}
+                            state={state}
+                            actions={actions}
+                            containerID={containerID}
+                            isSecondary={isSecondary}
+                        />
+                }
+            </>
+        );
+    }
+}
+
+export default VisualizerWrapper;

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -65,6 +65,7 @@ import RecentFileButton from './RecentFileButton';
 import { addRecentFile, createRecentFile, createRecentFileFromRawPath } from './ClientRecentFiles';
 import { UPDATE_FILE_INFO } from '../../actions/fileInfoActions';
 import { outlineResponse } from '../../workers/Outline.response';
+import { shouldVisualizeSVG } from '../../workers/Visualize.response';
 
 
 class WorkflowControl extends PureComponent {
@@ -353,7 +354,7 @@ class WorkflowControl extends PureComponent {
         const workflowPaused = runHasStarted && (workflowState === WORKFLOW_STATE_PAUSED || senderInHold || activeHold);
 
         const { showModal, value } = this.state.startFromLine;
-        const { liteMode } = this.props;
+        const renderSVG = shouldVisualizeSVG();
 
         return (
             <div className={styles.workflowControl}>
@@ -569,7 +570,7 @@ class WorkflowControl extends PureComponent {
                     )
                 }
                 {
-                    !liteMode ?
+                    !renderSVG ?
                         <CameraDisplay
                             camera={camera}
                             cameraPosition={cameraPosition}

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -71,7 +71,8 @@ class WorkflowControl extends PureComponent {
     static propTypes = {
         state: PropTypes.object,
         actions: PropTypes.object,
-        invalidGcode: PropTypes.string
+        invalidGcode: PropTypes.string,
+        liteMode: PropTypes.bool
     };
 
     fileInputEl = null;
@@ -352,6 +353,7 @@ class WorkflowControl extends PureComponent {
         const workflowPaused = runHasStarted && (workflowState === WORKFLOW_STATE_PAUSED || senderInHold || activeHold);
 
         const { showModal, value } = this.state.startFromLine;
+        const { liteMode } = this.props;
 
         return (
             <div className={styles.workflowControl}>
@@ -566,11 +568,13 @@ class WorkflowControl extends PureComponent {
                         </Modal>
                     )
                 }
-
-                <CameraDisplay
-                    camera={camera}
-                    cameraPosition={cameraPosition}
-                />
+                {
+                    !liteMode ?
+                        <CameraDisplay
+                            camera={camera}
+                            cameraPosition={cameraPosition}
+                        /> : null
+                }
             </div>
         );
     }

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -557,15 +557,15 @@ class VisualizerWidget extends PureComponent {
             }
         },
         handleLiteModeToggle: () => {
-            const { liteMode, disabled, disabledLite } = this.state;
+            const { liteMode, gcode } = this.state;
             const newLiteModeValue = !liteMode;
-            const shouldRenderVisualization = newLiteModeValue ? !disabledLite : !disabled;
-            this.renderIfNecessary(shouldRenderVisualization);
 
             this.setState({
                 liteMode: newLiteModeValue,
                 minimizeRenders: newLiteModeValue
             });
+
+            pubsub.publish('litemode:change', gcode);
         },
         lineWarning: {
             onContinue: () => {
@@ -1128,6 +1128,7 @@ class VisualizerWidget extends PureComponent {
                     showVisualizer={showVisualizer}
                     visualizerRef={(ref) => {
                         this.visualizer = ref;
+                        console.log(ref);
                     }}
                     workflowRef={(ref) => {
                         this.workflowControl = ref;

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -1111,7 +1111,7 @@ class VisualizerWidget extends PureComponent {
                     showRendering={showRendering}
                     showVisualizer={showVisualizer}
                     visualizerRef={(ref) => {
-                        this.visualizer = ref;
+                        this.visualizer = ref?.visualizer;
                     }}
                     gcode={gcode}
                     surfacingData={surfacingData}
@@ -1127,8 +1127,7 @@ class VisualizerWidget extends PureComponent {
                     showRendering={showRendering}
                     showVisualizer={showVisualizer}
                     visualizerRef={(ref) => {
-                        this.visualizer = ref;
-                        console.log(ref);
+                        this.visualizer = ref?.visualizer;
                     }}
                     workflowRef={(ref) => {
                         this.workflowControl = ref;

--- a/src/app/widgets/Visualizer/index.styl
+++ b/src/app/widgets/Visualizer/index.styl
@@ -33,11 +33,17 @@
 }
 
 .visualizer-wrapper {
+    height: 100%;
     position: relative;
 }
 
 .visualizer-container {
     height: 100%;
+}
+
+.svg-container {
+    display: block;
+    margin: auto;
 }
 
 .no-margin {

--- a/src/app/workers/Visualize.response.js
+++ b/src/app/workers/Visualize.response.js
@@ -22,7 +22,8 @@ export const shouldVisualize = () => {
     return !isDisabled;
 };
 
-export const isLiteMode = () => {
+export const shouldVisualizeSVG = () => {
     const liteMode = store.get('widgets.visualizer.liteMode', false);
-    return liteMode;
+    const SVGEnabled = store.get('widgets.visualizer.SVGEnabled', false);
+    return liteMode && SVGEnabled;
 };

--- a/src/app/workers/Visualize.response.js
+++ b/src/app/workers/Visualize.response.js
@@ -21,3 +21,8 @@ export const shouldVisualize = () => {
     const isDisabled = (liteMode) ? store.get('widgets.visualizer.disabledLite') : store.get('widgets.visualizer.disabled');
     return !isDisabled;
 };
+
+export const isLiteMode = () => {
+    const liteMode = store.get('widgets.visualizer.liteMode', false);
+    return liteMode;
+};

--- a/src/app/workers/Visualize.worker.js
+++ b/src/app/workers/Visualize.worker.js
@@ -26,7 +26,7 @@ import Toolpath from 'gcode-toolpath';
 import * as THREE from 'three';
 
 onmessage = function({ data }) {
-    const { content, visualizer, isLaser = false, liteMode = false } = data;
+    const { content, visualizer, isLaser = false, shouldRenderSVG = false } = data;
     let vertices = [];
     const colors = [];
     const frames = [];
@@ -52,7 +52,7 @@ onmessage = function({ data }) {
         addLine: (modal, v1, v2) => {
             const { motion } = modal;
 
-            if (!liteMode) {
+            if (!shouldRenderSVG) {
                 const opacity = (motion === 'G0') ? 0.1 : 1;
                 const color = [motion, opacity];
                 colors.push(color, color);
@@ -98,7 +98,7 @@ onmessage = function({ data }) {
             const divisions = 30;
             const points = arcCurve.getPoints(divisions);
 
-            if (!liteMode) {
+            if (!shouldRenderSVG) {
                 const color = [motion, 1];
                 for (let i = 0; i < points.length; ++i) {
                     const point = points[i];

--- a/src/app/workers/Visualize.worker.js
+++ b/src/app/workers/Visualize.worker.js
@@ -51,20 +51,21 @@ onmessage = function({ data }) {
         // @param {object} v2 A 3D vector of the end point.
         addLine: (modal, v1, v2) => {
             const { motion } = modal;
-            const opacity = (motion === 'G0') ? 0.1 : 1;
-            const color = [motion, opacity];
-            colors.push(color, color);
-
-            const stroke = 'rgba(0,0,0,' + opacity + ')';
 
             if (!liteMode) {
+                const opacity = (motion === 'G0') ? 0.1 : 1;
+                const color = [motion, opacity];
+                colors.push(color, color);
                 vertices.push(
                     new THREE.Vector3(v1.x, v1.y, v1.z),
                     new THREE.Vector3(v2.x, v2.y, v2.z)
                 );
             } else {
+                const opacity = (motion === 'G0') ? '0F' : 'FF';
+                const color = [motion, opacity];
+                colors.push(color);
                 vertices.push(
-                    <line x1={v1.x} y1={v1.y} x2={v2.x} y2={v2.y} stroke={stroke} strokeWidth={10} fill="none"/>
+                    <line x1={v1.x} y1={v1.y} x2={v2.x} y2={v2.y} strokeWidth={10} fill="none"/>
                 );
             }
         },
@@ -96,9 +97,9 @@ onmessage = function({ data }) {
             );
             const divisions = 30;
             const points = arcCurve.getPoints(divisions);
-            const color = [motion, 1];
 
             if (!liteMode) {
+                const color = [motion, 1];
                 for (let i = 0; i < points.length; ++i) {
                     const point = points[i];
                     const z = ((v2.z - v1.z) / points.length) * i + v1.z;
@@ -113,6 +114,7 @@ onmessage = function({ data }) {
                     colors.push(color);
                 }
             } else {
+                const color = [motion, 'FF'];
                 for (let i = 1; i < points.length; ++i) {
                     const pointA = points[i - 1];
                     const pointB = points[i];
@@ -120,17 +122,18 @@ onmessage = function({ data }) {
 
                     if (plane === 'G17') { // XY-plane
                         vertices.push(
-                            <line x1={pointA.x} y1={pointA.y} x2={pointB.x} y2={pointB.y} stroke="black" strokeWidth={10} fill="none"/>
+                            <line x1={pointA.x} y1={pointA.y} x2={pointB.x} y2={pointB.y} strokeWidth={10} fill="none"/>
                         );
                     } else if (plane === 'G18') { // ZX-plane
                         vertices.push(
-                            <line x1={pointA.y} y1={z} x2={pointB.y} y2={z} stroke="black" strokeWidth={10} fill="none"/>
+                            <line x1={pointA.y} y1={z} x2={pointB.y} y2={z} strokeWidth={10} fill="none"/>
                         );
                     } else if (plane === 'G19') { // YZ-plane
                         vertices.push(
-                            <line x1={z} y1={pointA.x} x2={z} y2={pointB.x} stroke="black" strokeWidth={10} fill="none"/>
+                            <line x1={z} y1={pointA.x} x2={z} y2={pointB.x} strokeWidth={10} fill="none"/>
                         );
                     }
+                    colors.push(color);
                 }
             }
         }


### PR DESCRIPTION
**Summary of Changes:**
- lite mode's visualizer is now an svg
- this svg is:
	- a 2d image
	- rendered in top down view
	- centered in the visualizer area, with no grid
- this svg is also used in the surfacing tab when lite mode is enabled


**Current Issues:**
- the references are not fully working yet, so some actions like closing a file may not work as expected