### PR TITLE
Jogging Changes

### DIFF
--- a/src/app/containers/Preferences/General/JoggingPresets.js
+++ b/src/app/containers/Preferences/General/JoggingPresets.js
@@ -72,29 +72,35 @@ export default class JoggingPresets extends Component {
     }
 
     handleXYChange = (e) => {
+        // if empty input, do nothing
+        if (e.target.value === '') {
+            return;
+        }
+
         let value = Number(e.target.value);
         const { units, selectedPreset, jogSpeeds } = this.state;
 
         const currentPreset = jogSpeeds[selectedPreset];
 
-        if (!value) {
-            return;
-        }
+        const maxMM = 9000;
+        const minMM = 0.01;
+        const maxIN = 354;
+        const minIN = 0.001;
 
         if (units === 'mm') {
-            if (value > 1000) {
-                value = 1000;
+            if (value >= maxMM) {
+                value = maxMM;
+            } else if (value <= minMM) {
+                value = minMM;
             }
         }
 
         if (units === 'in') {
-            if (value > 40) {
-                value = 40;
+            if (value >= maxIN) {
+                value = maxIN;
+            } else if (value <= minIN) {
+                value = minIN;
             }
-        }
-
-        if (value <= 0) {
-            value = 1;
         }
 
         const metricValue = units === 'mm' ? value : convertToMetric(value);
@@ -121,25 +127,34 @@ export default class JoggingPresets extends Component {
     }
 
     handleZChange = (e) => {
+        if (e.target.value === '') {
+            return;
+        }
+
         let value = Number(e.target.value);
         const { units, selectedPreset, jogSpeeds } = this.state;
 
         const currentPreset = jogSpeeds[selectedPreset];
 
+        const maxMM = 9000;
+        const minMM = 0.01;
+        const maxIN = 354;
+        const minIN = 0.001;
+
         if (units === 'mm') {
-            if (value > 100) {
-                value = 100;
+            if (value >= maxMM) {
+                value = maxMM;
+            } else if (value <= minMM) {
+                value = minMM;
             }
         }
 
         if (units === 'in') {
-            if (value > 4) {
-                value = 4;
+            if (value >= maxIN) {
+                value = maxIN;
+            } else if (value <= minIN) {
+                value = minIN;
             }
-        }
-
-        if (value <= 0) {
-            value = 1;
         }
 
         const metricValue = units === 'mm' ? value : convertToMetric(value);
@@ -166,24 +181,33 @@ export default class JoggingPresets extends Component {
     }
 
     handleSpeedChange = (e) => {
+        if (e.target.value === '') {
+            return;
+        }
+
         let value = Number(e.target.value);
         const { units, selectedPreset, jogSpeeds } = this.state;
         const currentPreset = jogSpeeds[selectedPreset];
 
+        const maxMM = 90000;
+        const minMM = 50;
+        const maxIN = 3543;
+        const minIN = 2;
+
         if (units === 'mm') {
-            if (value >= 50000.1) {
-                return;
+            if (value >= maxMM) {
+                value = maxMM;
+            } else if (value <= minMM) {
+                value = minMM;
             }
         }
 
         if (units === 'in') {
-            if (value >= 2000.1) {
-                return;
+            if (value >= maxIN) {
+                value = maxIN;
+            } else if (value <= minIN) {
+                value = minIN;
             }
-        }
-
-        if (value <= 0) {
-            return;
         }
 
         const metricValue = units === 'mm' ? value : convertToMetric(value);

--- a/src/app/widgets/JogControl/NumberInput.jsx
+++ b/src/app/widgets/JogControl/NumberInput.jsx
@@ -120,13 +120,19 @@ class NumberInput extends PureComponent {
                     therefore, we force update the display.
             */
             changeHandler(value);
-            let oldValue = value;
-            this.setState({
-                value: 1
-            });
-            this.setState({
-                value: oldValue
-            });
+            if (this.state.value === value) {
+                this.setState({
+                    value: '',
+                }, () => {
+                    this.setState({
+                        value: value,
+                    });
+                });
+            } else {
+                this.setState({
+                    value: value,
+                });
+            }
         }
     }
 

--- a/src/app/widgets/JogControl/SpeedControls.jsx
+++ b/src/app/widgets/JogControl/SpeedControls.jsx
@@ -33,10 +33,10 @@ const SpeedControl = ({ state, actions }) => {
 
     const xyMin = (units === METRIC_UNITS) ? 0.01 : 0.001;
     const zMin = (units === METRIC_UNITS) ? 0.01 : 0.001;
-    const xyMax = (units === METRIC_UNITS) ? 1000 : 20;
-    const zMax = (units === METRIC_UNITS) ? 60 : 5;
+    const xyMax = (units === METRIC_UNITS) ? 9000 : 354;
+    const zMax = (units === METRIC_UNITS) ? 9000 : 354;
     const speedMin = (units === METRIC_UNITS) ? 50 : 2;
-    const speedMax = (units === METRIC_UNITS) ? 50000 : 2000;
+    const speedMax = (units === METRIC_UNITS) ? 90000 : 3543;
     const decimals = (units === METRIC_UNITS) ? 2 : 3;
 
     return (

--- a/src/app/widgets/JogControl/index.jsx
+++ b/src/app/widgets/JogControl/index.jsx
@@ -405,9 +405,7 @@ class AxesWidget extends PureComponent {
         },
         handleXYStepChange: (value) => {
             const { jog } = this.state;
-            if (Number.isNaN(value)) {
-                value = this.props.value;
-            }
+            // any input that gets to this point is valid, so set it
             this.setState({
                 jog: {
                     ...jog,
@@ -419,9 +417,7 @@ class AxesWidget extends PureComponent {
         },
         handleZStepChange: (value) => {
             const { jog } = this.state;
-            if (Number.isNaN(value)) {
-                value = this.props.value;
-            }
+            // any input that gets to this point is valid, so set it
             this.setState({
                 jog: {
                     ...jog,
@@ -433,9 +429,7 @@ class AxesWidget extends PureComponent {
         },
         handleFeedrateChange: (value) => {
             const { jog } = this.state;
-            if (Number.isNaN(value)) {
-                value = this.props.value;
-            }
+            // any input that gets to this point is valid, so set it
             this.setState({
                 jog: {
                     ...jog,


### PR DESCRIPTION
### Min/Max:
- changed min/max values for jogging inputs and made them consistent across preferences and the widget UI
### Jogging UI:
- when input is blank, wait for input instead of automatically setting it to 0.01
- force update so when the input results in the same value, the display will be updated with the correct value.
    - ex. if max=9000, inputting 9000.01 will set value->9000. if the user types in 9500 next, the value will once again be set to 9000. Since that's the same as before, the display will not update, and the input field will still show 9500. this change forces an update to happen.