### PR TITLE
Fix Electron App not full exiting on MacOS

### DIFF
--- a/src/electron-app/WindowManager.js
+++ b/src/electron-app/WindowManager.js
@@ -76,7 +76,6 @@ class WindowManager {
                     this.width = width;
                     this.height = height;
                 }
-                return;
             }
 
             app.quit();


### PR DESCRIPTION
- app now completely exits when pressing exit button on macOS (equivalent to cmd+Q)