### PR TITLE
Probe Distance Setting

### DIFF
--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -145,7 +145,8 @@ class PreferencesPage extends PureComponent {
                 normalFeedrate: this.probeConfig.get('probeFeedrate', {}),
                 fastFeedrate: this.probeConfig.get('probeFastFeedrate', {}),
                 probeCommand: this.probeConfig.get('probeCommand', 'G38.2'),
-                connectivityTest: this.probeConfig.get('connectivityTest', true)
+                connectivityTest: this.probeConfig.get('connectivityTest', true),
+                zProbeDistance: this.probeConfig.get('zProbeDistance', {})
             },
             laser: {
                 ...this.spindleConfig.get('laser')
@@ -444,6 +445,25 @@ class PreferencesPage extends PureComponent {
                     }
                 });
                 pubsub.publish('probe:test', value);
+            },
+            changeZProbeDistance: (e) => {
+                const probeSettings = { ...this.state.probeSettings };
+                const value = Math.abs(Number(e.target.value).toFixed(3) * 1);
+
+                const { units } = this.state;
+
+                const metricValue = units === 'mm' ? value : Math.abs(convertToMetric(value));
+                const imperialValue = units === 'in' ? value : Math.abs(convertToImperial(value));
+
+                this.setState({
+                    probeSettings: {
+                        ...probeSettings,
+                        zProbeDistance: {
+                            mm: metricValue,
+                            in: imperialValue,
+                        }
+                    }
+                });
             }
         },
         laser: {
@@ -800,6 +820,7 @@ class PreferencesPage extends PureComponent {
         this.probeConfig.set('probeFeedrate', probeSettings.normalFeedrate);
         this.probeConfig.set('probeFastFeedrate', probeSettings.fastFeedrate);
         this.probeConfig.set('connectivityTest', probeSettings.connectivityTest);
+        this.probeConfig.set('zProbeDistance', probeSettings.zProbeDistance);
 
         controller.command('settings:updated', this.state);
 

--- a/src/app/containers/Preferences/Probe/ProbeSettings.js
+++ b/src/app/containers/Preferences/Probe/ProbeSettings.js
@@ -69,6 +69,15 @@ const ProbeSettings = ({ state, probeActions, values, type }) => {
                                 units={`${units}`}
                             />
                         </Tooltip>
+                        <Tooltip content="Maximum distance for Z probe" location="default">
+                            <Input
+                                label="Z Probe Distance"
+                                value={values.zProbeDistance}
+                                onChange={probeActions.changeZProbeDistance}
+                                additionalProps={{ type: 'number', id: 'zProbeDistance' }}
+                                units={`${units}`}
+                            />
+                        </Tooltip>
                     </>
                 )
             }

--- a/src/app/containers/Preferences/Probe/index.jsx
+++ b/src/app/containers/Preferences/Probe/index.jsx
@@ -47,6 +47,7 @@ const Probe = ({ active, state, actions }) => {
         fastFeedrate: units === 'mm' ? probeSettings.fastFeedrate.mm : probeSettings.fastFeedrate.in,
         normalFeedrate: units === 'mm' ? probeSettings.normalFeedrate.mm : probeSettings.normalFeedrate.in,
         retractionDistance: units === 'mm' ? probeSettings.retractionDistance.mm : probeSettings.retractionDistance.in,
+        zProbeDistance: units === 'mm' ? probeSettings.zProbeDistance.mm : probeSettings.zProbeDistance.in,
     };
 
     const handleTouchplateTypeChange = (option) => {

--- a/src/app/store/defaultState.js
+++ b/src/app/store/defaultState.js
@@ -303,6 +303,10 @@ const defaultState = {
                 mm: 4,
                 in: 0.15
             },
+            zProbeDistance: {
+                mm: 30,
+                in: 1.5
+            },
             touchPlateHeight: 10,
             probeType: 'Auto',
         },

--- a/src/app/widgets/Probe/index.jsx
+++ b/src/app/widgets/Probe/index.jsx
@@ -79,13 +79,13 @@ class ProbeWidget extends PureComponent {
     PROBE_DISTANCE_METRIC = {
         X: 50,
         Y: 50,
-        Z: 30
+        Z: this.state.zProbeDistance ? this.state.zProbeDistance.mm : 30
     };
 
     PROBE_DISTANCE_IMPERIAL = {
         X: 2,
         Y: 2,
-        Z: 1.2
+        Z: this.state.zProbeDistance ? this.state.zProbeDistance.in : 1.2
     };
 
 
@@ -364,6 +364,7 @@ class ProbeWidget extends PureComponent {
             probeFastFeedrate: this.config.get('probeFastFeedrate') || {},
             touchPlateHeight: this.config.get('touchPlateHeight') || {},
             retractionDistance: this.config.get('retractionDistance') || {},
+            zProbeDistance: this.config.get('zProbeDistance') || {},
             touchplate: store.get('workspace[probeProfile]', {}),
             availableTools,
             toolDiameter,
@@ -1164,6 +1165,25 @@ class ProbeWidget extends PureComponent {
                 this.actions.handleProbeCommandChange(0);
             }
         }
+
+        this.setState({
+            probeAxis: this.config.get('probeAxis', 'Z'),
+            probeCommand: this.config.get('probeCommand', 'G38.2'),
+            useTLO: this.config.get('useTLO'),
+            probeDepth: this.config.get('probeDepth') || {},
+            probeFeedrate: this.config.get('probeFeedrate') || {},
+            probeFastFeedrate: this.config.get('probeFastFeedrate') || {},
+            touchPlateHeight: this.config.get('touchPlateHeight') || {},
+            retractionDistance: this.config.get('retractionDistance') || {},
+            zProbeDistance: this.config.get('zProbeDistance') || {},
+            connectivityTest: this.config.get('connectivityTest'),
+        }, () => {
+            const { zProbeDistance } = this.state;
+            if (zProbeDistance) {
+                this.PROBE_DISTANCE_METRIC.Z = zProbeDistance.mm;
+                this.PROBE_DISTANCE_IMPERIAL.Z = zProbeDistance.in;
+            }
+        });
     }
 
     subscribe() {


### PR DESCRIPTION
- added z probe distance
    - determines the maximum Z distance travelled during probe
    - modifiable in settings
- fixed bug where config values were not updated in the Probe widget when changed in settings