### PR TITLE
Stop Modal From Closing on Overlay Click

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@trendmicro/react-iframe": "~0.3.1",
     "@trendmicro/react-interpolate": "~0.5.5",
     "@trendmicro/react-loader": "~0.6.1",
-    "@trendmicro/react-modal": "~2.2.2",
+    "@trendmicro/react-modal": "~3.1.0",
     "@trendmicro/react-navs": "~0.11.6",
     "@trendmicro/react-notifications": "~1.0.1",
     "@trendmicro/react-paginations": "~0.6.1",

--- a/src/app/components/ToolModal/ToolModal.jsx
+++ b/src/app/components/ToolModal/ToolModal.jsx
@@ -30,7 +30,7 @@ import styles from './index.styl';
 import { LARGE, MEDIUM, SMALL } from './sizings';
 
 
-const ToolModal = ({ onClose, title, style, className, size, children }) => {
+const ToolModal = ({ onClose, title, style, className, size, children, disableOverlayClick = false }) => {
     let sizingStyles;
 
     switch (size?.toLowerCase()) {
@@ -61,6 +61,7 @@ const ToolModal = ({ onClose, title, style, className, size, children }) => {
             style={{ ...style, ...sizingStyles }}
             className={className}
             size={size}
+            disableOverlayClick={disableOverlayClick}
         >
             <div className={styles.toolModal}>
                 <div className={styles.header}>

--- a/src/app/widgets/Macro/AddMacro.jsx
+++ b/src/app/widgets/Macro/AddMacro.jsx
@@ -75,6 +75,7 @@ class AddMacro extends PureComponent {
                 onClose={actions.closeModal}
                 title="Add New Macro"
                 disableOverlay
+                disableOverlayClick
             >
                 <div style={modalContainerStyle}>
                     <div style={modalBodyStyle}>


### PR DESCRIPTION
- updated modal package: new prop disableOverlayClick stops the modal from being closed when clicking outside of it
- added this prop to the AddMacro modal