### PR TITLE
Mi 779 add colour coded output for errors, alarms, and ok messages in the console

### DIFF
--- a/src/app/widgets/Console/Terminal.jsx
+++ b/src/app/widgets/Console/Terminal.jsx
@@ -223,9 +223,9 @@ class TerminalWrapper extends PureComponent {
 
     writeln(data) {
         this.term.write('\r');
-        if (data.toLowerCase().includes('error')) {
+        if (data.includes('error:')) {
             this.term.write(color.xterm(RED)(data));
-        } else if (data.toLowerCase().includes('alarm')) {
+        } else if (data.includes('ALARM:')) {
             this.term.write(color.xterm(ALARM_RED)(data));
         } else {
             this.term.write(data);

--- a/src/app/widgets/Console/Terminal.jsx
+++ b/src/app/widgets/Console/Terminal.jsx
@@ -37,6 +37,9 @@ import { MAX_TERMINAL_INPUT_ARRAY_SIZE } from 'app/lib/constants';
 import TooltipCustom from 'app/components/TooltipCustom/ToolTip';
 import { Toaster, TOASTER_INFO } from 'app/lib/toaster/ToasterLib';
 
+import color from 'cli-color';
+import { RED, ALARM_RED } from './variables';
+
 import History from './History';
 import styles from './index.styl';
 
@@ -220,7 +223,13 @@ class TerminalWrapper extends PureComponent {
 
     writeln(data) {
         this.term.write('\r');
-        this.term.write(data);
+        if (data.toLowerCase().includes('error')) {
+            this.term.write(color.xterm(RED)(data));
+        } else if (data.toLowerCase().includes('alarm')) {
+            this.term.write(color.xterm(ALARM_RED)(data));
+        } else {
+            this.term.write(data);
+        }
         this.term.prompt();
     }
 

--- a/src/app/widgets/Console/index.jsx
+++ b/src/app/widgets/Console/index.jsx
@@ -22,13 +22,14 @@
  */
 
 import cx from 'classnames';
-import color from 'cli-color';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import uuid from 'uuid';
 import Widget from 'app/components/Widget';
 import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
+import color from 'cli-color';
+import { GREY } from './variables';
 import WidgetConfig from '../WidgetConfig';
 import Console from './Console';
 import styles from './index.styl';
@@ -125,7 +126,7 @@ class ConsoleWidget extends PureComponent {
             });
 
             if (source) {
-                this.terminal.writeln(color.blackBright(source) + color.white(this.terminal.prompt + data));
+                this.terminal.writeln(color.blackBright(source) + color.xterm(GREY)(this.terminal.prompt + data));
             } else {
                 this.terminal.writeln(color.white(this.terminal.prompt + data));
             }
@@ -211,8 +212,7 @@ class ConsoleWidget extends PureComponent {
                         }
                         {i18n._('Console')}
                     </Widget.Title>
-                    <Widget.Controls>
-                    </Widget.Controls>
+                    <Widget.Controls />
                 </Widget.Header>
                 <Widget.Content
                     className={cx(

--- a/src/app/widgets/Console/variables.js
+++ b/src/app/widgets/Console/variables.js
@@ -1,0 +1,5 @@
+const GREY = 249;
+const RED = 196;
+const ALARM_RED = 167;
+
+export { GREY, RED, ALARM_RED };


### PR DESCRIPTION
### Changes:

1. error - **xterm(196)** (red)
2. response from the server/ OK Messages -  **default** (white)
3. User wrote something - **xterm(249)** (grey)
4. Alarms - **xterm( 167)** (variant of red)

To simulate alarm, add the following:

```
const testAlarm = 'ALARM: Probe fail';
            this.runner.parse(testAlarm);
```
at line 713 of GrblController.js (at the end of event ‘startup’).

<img width="552" alt="Screen Shot 2022-10-06 at 7 56 21 PM" src="https://user-images.githubusercontent.com/39333609/194562335-acd1a96e-dabe-4182-a44d-4154575652f9.png">


<img width="552" alt="Screen Shot 2022-10-06 at 7 57 50 PM" src="https://user-images.githubusercontent.com/39333609/194562384-82988864-4c01-44db-a916-753fc60b8a68.png">
