### PR TITLE
Mi 786 updater should link to download on update available vs downloading for non windows p cs

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "acorn": "^6.4.2",
     "apexcharts": "^3.28.1",
     "avrgirl-arduino": "^5.0.1",
+    "axios": "^1.1.3",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "~1.18.3",
     "bootstrap": "~3.3.7",

--- a/package.json
+++ b/package.json
@@ -358,7 +358,7 @@
     "css-split-webpack-plugin": "~0.2.6",
     "dotenv": "~7.0.0",
     "electron": "10.4.1",
-    "electron-builder": "22.10.5",
+    "electron-builder": "^23.6.0",
     "electron-rebuild": "2.3.5",
     "eslint": "~5.16.0",
     "eslint-config-trendmicro": "~1.4.1",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "acorn": "^6.4.2",
     "apexcharts": "^3.28.1",
     "avrgirl-arduino": "^5.0.1",
-    "axios": "^1.1.3",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "~1.18.3",
     "bootstrap": "~3.3.7",

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -24,7 +24,7 @@
 import ensureArray from 'ensure-array';
 import superagent from 'superagent';
 import superagentUse from 'superagent-use';
-import axios from 'axios';
+// import axios from 'axios';
 import store from '../store';
 
 const bearer = (request) => {
@@ -87,14 +87,14 @@ const getLatestVersion = () => new Promise((resolve, reject) => {
 //
 //Fetch latest app version for all OS from github
 //
-const getLatestVersionAllOS = () => new Promise((resolve, reject) => {
-    axios.get('https://api.github.com/repos/Sienci-Labs/gsender/releases').then((res) => {
-        resolve(res.data[0].assets);
-    }).catch((error) => {
-        console.log(error);
-        return [];
-    });
-});
+// const getLatestVersionAllOS = () => new Promise((resolve, reject) => {
+//     axios.get('https://api.github.com/repos/Sienci-Labs/gsender/releases').then((res) => {
+//         resolve(res.data[0].assets);
+//     }).catch((error) => {
+//         console.log(error);
+//         return [];
+//     });
+// });
 
 //
 // State
@@ -718,7 +718,7 @@ file.upload = (file, port, visualizer) => new Promise((resolve, reject) => {
 
 export default {
     getLatestVersion,
-    getLatestVersionAllOS,
+    // getLatestVersionAllOS,
 
     // State
     getState,

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -24,6 +24,7 @@
 import ensureArray from 'ensure-array';
 import superagent from 'superagent';
 import superagentUse from 'superagent-use';
+import axios from 'axios';
 import store from '../store';
 
 const bearer = (request) => {
@@ -69,7 +70,7 @@ const signin = (options) => new Promise((resolve, reject) => {
 });
 
 //
-// Latest Version
+// Latest Version for windows
 //
 const getLatestVersion = () => new Promise((resolve, reject) => {
     authrequest
@@ -81,6 +82,18 @@ const getLatestVersion = () => new Promise((resolve, reject) => {
                 resolve(res);
             }
         });
+});
+
+//
+//Fetch latest app version for all OS from github
+//
+const getLatestVersionAllOS = () => new Promise((resolve, reject) => {
+    axios.get('https://api.github.com/repos/Sienci-Labs/gsender/releases').then((req, res) => {
+        console.log(res.body[0].assets);
+        return res.body[0].assets;
+    }).catch((error) => {
+        console.log(error);
+    });
 });
 
 //
@@ -705,6 +718,7 @@ file.upload = (file, port, visualizer) => new Promise((resolve, reject) => {
 
 export default {
     getLatestVersion,
+    getLatestVersionAllOS,
 
     // State
     getState,

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -88,11 +88,11 @@ const getLatestVersion = () => new Promise((resolve, reject) => {
 //Fetch latest app version for all OS from github
 //
 const getLatestVersionAllOS = () => new Promise((resolve, reject) => {
-    axios.get('https://api.github.com/repos/Sienci-Labs/gsender/releases').then((req, res) => {
-        console.log(res.body[0].assets);
-        return res.body[0].assets;
+    axios.get('https://api.github.com/repos/Sienci-Labs/gsender/releases').then((res) => {
+        resolve(res.data[0].assets);
     }).catch((error) => {
         console.log(error);
+        return [];
     });
 });
 

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -107,15 +107,6 @@ class UpdateAvailableAlert extends PureComponent {
             });
         }
 
-        const getUpdateForWindows = () => {
-            if (getOperatingSystem === 'MacOS') {
-                this.setState({
-                    buttonActive: false
-                });
-                restartHandler();
-            }
-        };
-
         return (
             <div className={cx(styles.updateWrapper, { [styles.hideModal]: !shown })}>
                 <div className={styles.updateIcon}>
@@ -127,7 +118,12 @@ class UpdateAvailableAlert extends PureComponent {
                     </div>
                     { currentOS === 'Windows OS' ? (
                         <button
-                            onClick={getUpdateForWindows}
+                            onClick={() => {
+                                this.setState({
+                                    buttonActive: false
+                                });
+                                restartHandler();
+                            }}
                             className={styles.restartButton}
                         >
                             {

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -39,25 +39,25 @@ class UpdateAvailableAlert extends PureComponent {
     actions = {
         hideModal: () => {
             this.setState({
-                shown: false
+                shown: false,
             });
         },
-    }
+    };
 
     pubsubTokens = [];
 
-    subscribe () {
+    subscribe() {
         const tokens = [
             pubsub.subscribe('showUpdateToast', (msg, info) => {
                 this.setState({
-                    shown: true
+                    shown: true,
                 });
             }),
         ];
         this.pubsubTokens = this.pubsubTokens.concat(tokens);
     }
 
-    unsubscribe () {
+    unsubscribe() {
         this.pubsubTokens.forEach((token) => {
             pubsub.unsubscribe(token);
         });
@@ -78,41 +78,51 @@ class UpdateAvailableAlert extends PureComponent {
         const actions = { ...this.actions };
         const currentOS = getOperatingSystem(window);
 
-        let updateLink = 'https://github.com/Sienci-Labs/gsender/releases/latest';
+        let updateLink =
+            'https://github.com/Sienci-Labs/gsender/releases/latest';
 
         return (
-            <div className={cx(styles.updateWrapper, { [styles.hideModal]: !shown })}>
+            <div
+                className={cx(styles.updateWrapper, {
+                    [styles.hideModal]: shown,
+                })}
+            >
                 <div className={styles.updateIcon}>
                     <i className="fas fa-download" />
                 </div>
                 <div className={styles.updateContent}>
                     <div>
-                        { currentOS === 'Windows OS' ? 'Update available to download. Download and restart now?' : 'A new version of gSender is available.'}
+                        {currentOS === 'Windows OS'
+                            ? 'Update available to download. Download and restart now?'
+                            : 'A new version of gSender is available.'}
                     </div>
-                    { currentOS === 'Windows OS' ? (
+                    {currentOS === 'Windows OS' ? (
                         <button
                             onClick={() => {
                                 this.setState({
-                                    buttonActive: false
+                                    buttonActive: false,
                                 });
                                 restartHandler();
                             }}
                             className={styles.restartButton}
                         >
-                            {
-                                buttonActive ? 'Download and install' : 'Downloading...'
-                            }
+                            {buttonActive
+                                ? 'Download and install'
+                                : 'Downloading...'}
                         </button>
                     ) : (
                         <button
-                            className={styles.restartButton}
                             onClick={() => {
                                 this.setState({
-                                    buttonActive: false
+                                    buttonActive: false,
                                 });
                                 window.open(updateLink, '_blank');
                             }}
-                        > Checkout the latest release
+                            className={styles.restartButton}
+                        >
+                            {buttonActive
+                                ? 'Checkout the latest release'
+                                : 'Redirecting...'}
                         </button>
                     )}
                 </div>
@@ -121,7 +131,6 @@ class UpdateAvailableAlert extends PureComponent {
                         <i className="fas fa-times" />
                     </button>
                 </div>
-
             </div>
         );
     }

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -98,7 +98,7 @@ class UpdateAvailableAlert extends PureComponent {
                 }
                 return '';
             });
-        } else if (getOperatingSystem === 'Linux OS') { //TODO - verify correct OS value for Raspberry Pi
+        } else if (currentOS === 'Linux OS') { //TODO - verify correct OS value for Raspberry Pi
             allOSUpdates.map((update) => {
                 if (update.name.includes('armv7l.AppImage')) {
                     updateLink = update.browser_download_url;

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -26,8 +26,6 @@ import cx from 'classnames';
 import pubsub from 'pubsub-js';
 import styles from './index.styl';
 import { getOperatingSystem } from '../util';
-import api from '../../../api';
-
 
 class UpdateAvailableAlert extends PureComponent {
     constructor(props) {
@@ -35,7 +33,6 @@ class UpdateAvailableAlert extends PureComponent {
         this.state = {
             shown: false,
             buttonActive: true,
-            allOSUpdates: [],
         };
     }
 
@@ -43,13 +40,6 @@ class UpdateAvailableAlert extends PureComponent {
         hideModal: () => {
             this.setState({
                 shown: false
-            });
-        },
-        getAllUpdates: () => {
-            Promise.all([api.getLatestVersionAllOS()]).then((data) => {
-                this.setState({
-                    allOSUpdates: data[0]
-                });
             });
         },
     }
@@ -76,7 +66,6 @@ class UpdateAvailableAlert extends PureComponent {
 
     componentDidMount() {
         this.subscribe();
-        this.actions.getAllUpdates();
     }
 
     componentWillUnmount() {
@@ -84,31 +73,15 @@ class UpdateAvailableAlert extends PureComponent {
     }
 
     render() {
-        const { shown, buttonActive, allOSUpdates } = this.state;
+        const { shown, buttonActive } = this.state;
         const { restartHandler } = this.props;
         const actions = { ...this.actions };
         const currentOS = getOperatingSystem(window);
 
-        let updateLink = '';
-
-        if (currentOS === 'MacOS') {
-            allOSUpdates.map((update) => {
-                if (update.name.includes('.dmg')) {
-                    updateLink = update.browser_download_url;
-                }
-                return '';
-            });
-        } else if (currentOS === 'Linux OS') { //TODO - verify correct OS value for Raspberry Pi
-            allOSUpdates.map((update) => {
-                if (update.name.includes('armv7l.AppImage')) {
-                    updateLink = update.browser_download_url;
-                }
-                return '';
-            });
-        }
+        let updateLink = 'https://github.com/Sienci-Labs/gsender/releases/latest';
 
         return (
-            <div className={cx(styles.updateWrapper, { [styles.hideModal]: !shown })}>
+            <div className={cx(styles.updateWrapper, { [styles.hideModal]: shown })}>
                 <div className={styles.updateIcon}>
                     <i className="fas fa-download" />
                 </div>
@@ -130,7 +103,18 @@ class UpdateAvailableAlert extends PureComponent {
                                 buttonActive ? 'Download and install' : 'Downloading...'
                             }
                         </button>
-                    ) : <a href={updateLink}> Click here to download </a>}
+                    ) : (
+                        <button
+                            className={styles.restartButton}
+                            onClick={() => {
+                                this.setState({
+                                    buttonActive: false
+                                });
+                                window.open(updateLink, '_blank');
+                            }}
+                        > Checkout the latest release
+                        </button>
+                    )}
                 </div>
                 <div className={styles.closeModal}>
                     <button onClick={actions.hideModal}>

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -39,25 +39,25 @@ class UpdateAvailableAlert extends PureComponent {
     actions = {
         hideModal: () => {
             this.setState({
-                shown: false,
+                shown: false
             });
         },
-    };
+    }
 
     pubsubTokens = [];
 
-    subscribe() {
+    subscribe () {
         const tokens = [
             pubsub.subscribe('showUpdateToast', (msg, info) => {
                 this.setState({
-                    shown: true,
+                    shown: true
                 });
             }),
         ];
         this.pubsubTokens = this.pubsubTokens.concat(tokens);
     }
 
-    unsubscribe() {
+    unsubscribe () {
         this.pubsubTokens.forEach((token) => {
             pubsub.unsubscribe(token);
         });
@@ -78,51 +78,43 @@ class UpdateAvailableAlert extends PureComponent {
         const actions = { ...this.actions };
         const currentOS = getOperatingSystem(window);
 
-        let updateLink =
-            'https://github.com/Sienci-Labs/gsender/releases/latest';
+        let updateLink = 'https://github.com/Sienci-Labs/gsender/releases/latest';
 
         return (
-            <div
-                className={cx(styles.updateWrapper, {
-                    [styles.hideModal]: shown,
-                })}
-            >
+            <div className={cx(styles.updateWrapper, { [styles.hideModal]: !shown })}>
                 <div className={styles.updateIcon}>
                     <i className="fas fa-download" />
                 </div>
                 <div className={styles.updateContent}>
                     <div>
-                        {currentOS === 'Windows OS'
-                            ? 'Update available to download. Download and restart now?'
-                            : 'A new version of gSender is available.'}
+                        { currentOS === 'Windows OS' ? 'Update available to download. Download and restart now?' : 'A new version of gSender is available.'}
                     </div>
-                    {currentOS === 'Windows OS' ? (
+                    { currentOS === 'Windows OS' ? (
                         <button
                             onClick={() => {
                                 this.setState({
-                                    buttonActive: false,
+                                    buttonActive: false
                                 });
                                 restartHandler();
                             }}
                             className={styles.restartButton}
                         >
-                            {buttonActive
-                                ? 'Download and install'
-                                : 'Downloading...'}
+                            {
+                                buttonActive ? 'Download and install' : 'Downloading...'
+                            }
                         </button>
                     ) : (
                         <button
                             onClick={() => {
                                 this.setState({
-                                    buttonActive: false,
+                                    buttonActive: false
                                 });
                                 window.open(updateLink, '_blank');
                             }}
                             className={styles.restartButton}
-                        >
-                            {buttonActive
-                                ? 'Checkout the latest release'
-                                : 'Redirecting...'}
+                        > {
+                                buttonActive ? 'Checkout the latest release' : 'Redirecting...'
+                            }
                         </button>
                     )}
                 </div>
@@ -131,6 +123,7 @@ class UpdateAvailableAlert extends PureComponent {
                         <i className="fas fa-times" />
                     </button>
                 </div>
+
             </div>
         );
     }

--- a/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
+++ b/src/app/containers/Workspace/UpdateAvailableAlert/UpdateAvailableAlert.jsx
@@ -81,7 +81,7 @@ class UpdateAvailableAlert extends PureComponent {
         let updateLink = 'https://github.com/Sienci-Labs/gsender/releases/latest';
 
         return (
-            <div className={cx(styles.updateWrapper, { [styles.hideModal]: shown })}>
+            <div className={cx(styles.updateWrapper, { [styles.hideModal]: !shown })}>
                 <div className={styles.updateIcon}>
                     <i className="fas fa-download" />
                 </div>

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -602,7 +602,6 @@ class Workspace extends PureComponent {
                         </div>
                     </Dropzone>
                 </div>
-                <UpdateAvailableAlert restartHandler={this.action.sendRestartCommand} />
             </ScreenAwake>
         );
     }

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -602,6 +602,7 @@ class Workspace extends PureComponent {
                         </div>
                     </Dropzone>
                 </div>
+                <UpdateAvailableAlert restartHandler={this.action.sendRestartCommand} />
             </ScreenAwake>
         );
     }

--- a/src/app/containers/Workspace/util.js
+++ b/src/app/containers/Workspace/util.js
@@ -1,4 +1,4 @@
-function getOperatingSystem(window) {
+const getOperatingSystem = (window) => {
     let operatingSystem = 'unknown';
 
     if (window.navigator.appVersion.indexOf('Win') !== -1) {
@@ -10,10 +10,7 @@ function getOperatingSystem(window) {
     } else if (window.navigator.appVersion.indexOf('Linux') !== -1) {
         operatingSystem = 'Linux OS';
     }
-
     return operatingSystem;
-}
-
-export const OS = (window) => {
-    return getOperatingSystem(window);
 };
+
+export { getOperatingSystem };

--- a/src/app/containers/Workspace/util.js
+++ b/src/app/containers/Workspace/util.js
@@ -1,0 +1,19 @@
+function getOperatingSystem(window) {
+    let operatingSystem = 'unknown';
+
+    if (window.navigator.appVersion.indexOf('Win') !== -1) {
+        operatingSystem = 'Windows OS';
+    } else if (window.navigator.appVersion.indexOf('Mac') !== -1) {
+        operatingSystem = 'MacOS';
+    } else if (window.navigator.appVersion.indexOf('X11') !== -1) {
+        operatingSystem = 'UNIX OS';
+    } else if (window.navigator.appVersion.indexOf('Linux') !== -1) {
+        operatingSystem = 'Linux OS';
+    }
+
+    return operatingSystem;
+}
+
+export const OS = (window) => {
+    return getOperatingSystem(window);
+};

--- a/src/app/containers/Workspace/util.js
+++ b/src/app/containers/Workspace/util.js
@@ -5,8 +5,6 @@ const getOperatingSystem = (window) => {
         operatingSystem = 'Windows OS';
     } else if (window.navigator.appVersion.indexOf('Mac') !== -1) {
         operatingSystem = 'MacOS';
-    } else if (window.navigator.appVersion.indexOf('X11') !== -1) {
-        operatingSystem = 'UNIX OS';
     } else if (window.navigator.appVersion.indexOf('Linux') !== -1) {
         operatingSystem = 'Linux OS';
     }


### PR DESCRIPTION
**How to fake an update and bring up the update popup:**

**Go to** - app → containers →  Workspace → UpdateAvailableAlert → UpdateAvailableAlert.jsx → line 84.
Change “!shown” to shown.

**Note:** Electron updater will throw an error if you hit ‘Download and install’ button on windows because a this branch already has the latest release.


**Things tested:** 

- No console or terminal errors in Windows and Mac on web app startup.
- No console error or error logs (main.log) in Windows and Mac on Electron startup.
- Electron on Windows says - ‘Update available to download. Download and restart now?’ and the button says ‘Download and install’, once the user clicks, the button text changes to ‘Downloading…’
- Electron on Mac says - ‘A new version of gSender is available.’ and the button says ‘Checkout the latest release’, once the user clicks, the button text changes to ‘Redirecting…’
- Both Windows and Mac open the link to the latest release page on GitHub.