### PR TITLE
MI-957-Wizard tool responsiveness

### DIFF
--- a/src/app/components/Wizard/Wizard.jsx
+++ b/src/app/components/Wizard/Wizard.jsx
@@ -45,7 +45,7 @@ const Wizard = () => {
     );
 
     return (
-        <div className={cx(styles.wizardWrapper, { [styles.hidden]: !visible, [styles.minimizedWrapper]: minimized })}>
+        <div className={cx({ [styles.hidden]: !visible, [styles.minimizedWrapper]: minimized, [styles.wizardWrapper]: !minimized })}>
             <div className={styles.wizardTitle}>
                 <h1><i className="fas fa-hat-wizard" /> {title} - Step {activeStep + 1} of {steps.length}</h1>
                 <MinMaxButton />

--- a/src/app/components/Wizard/index.styl
+++ b/src/app/components/Wizard/index.styl
@@ -4,7 +4,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   background: white;
-  width: 80%;
+  min-width: 80%;
   height: 500px;
   border-radius: 5px;
   display: flex;
@@ -15,10 +15,11 @@
 
 .minimizedWrapper {
   position: absolute;
+  background: white;
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
-  width: 25%;
+  width: 40%;
   height: auto;
   border-radius: 5px;
   box-shadow: 0px 20px 20px -17px rgba(255, 159, 16, 0.73);
@@ -28,7 +29,6 @@
   display flex;
   flex-direction row;
   height: calc(100% - 40px);
-  gap: 1rem;
   justify-items stretch;
   align-items stretch;
   justify-content stretch
@@ -100,16 +100,18 @@
 .stepIndex {
   background: none;
   border: solid 1px #9ca3af;
-  border-radius 9999px;
   display flex;
+  color: #9ca3af;
+  font-weight: bold;
+  font-size: 1.1rem;
   align-items center;
   justify-content center;
   align-content center
   width: 2.5rem;
   height: 2.5rem;
-  color: #9ca3af;
-  font-weight: bold;
-  font-size: 1.1rem;
+  border-radius: 75px;
+  display: inline-flex;
+  flex: 0 0 auto;
 
   &-complete {
     @extends .stepIndex;
@@ -205,6 +207,7 @@
   align-content center
   justify-content space-around;
   gap: 2rem;
+  height: 7vh;
 }
 
 
@@ -216,7 +219,7 @@
   min-width: 12rem;
 
   i {
-    margin: 0 10px !important;
+    margin: 0 8px !important;
   }
 }
 
@@ -304,6 +307,7 @@ button-mixin($color) {
   opacity: 1;
   border-left: solid 3px #3e85c7;
   background: rgba(#3e85c7, 0.1);
+  overflow: hidden;
 }
 
 .substepPending {
@@ -320,6 +324,9 @@ button-mixin($color) {
   gap: 0.5rem;
   align-items center;
   width: 100%;
+  span{
+    margin-bottom: 1rem;
+  }
 }
 
 .orSpan {
@@ -334,3 +341,13 @@ button-mixin($color) {
   font-weight: bold;
   margin-top: 1rem;
 }
+
+@media (max-width: 1068px) {
+    .actionRow{
+      display: block !important;
+      text-align: center;
+      button{
+        margin-top: 1rem;
+      }
+    }
+  }


### PR DESCRIPTION
### Changes:

- Probe Tool (Step 3) buttons change to block element if the screen width is 1068px or narrower.
- Back and Complete buttons are a little narrower (vertically)

### Tests:

- No more content overflows on small screens.
- Tested on multiple resolutions from 700 X 600px till 3024 X 1964px.
- 500px modal size retained.

**Known Issue:** The modal size is fixed to 500px, so a part of it hides in a corner if you go too small on screen sizes.

**NOTE:** **Below screenshots are with screen size narrower than 1068px:**

<img width="674" alt="Screen Shot 2022-10-28 at 12 12 44 PM" src="https://user-images.githubusercontent.com/39333609/198685578-8e0688cd-3718-4bf8-bd3a-dcabd297409b.png">

<img width="674" alt="Screen Shot 2022-10-28 at 12 09 24 PM" src="https://user-images.githubusercontent.com/39333609/198685583-27b35959-4444-4e3b-8f75-42944398c03b.png">

<img width="674" alt="Screen Shot 2022-10-28 at 12 17 13 PM" src="https://user-images.githubusercontent.com/39333609/198685590-1877c390-c72c-4b6f-b6d8-9455a5f9089f.png">

### Screenshots with  screen size wider than 1068px:

<img width="1159" alt="Screen Shot 2022-10-28 at 12 28 43 PM" src="https://user-images.githubusercontent.com/39333609/198686716-8ae2140c-a4ce-4a66-ad49-34f8106bf0b8.png">

