### PR TITLE
Mi 813-dev-decimal places becomes inaccurate with larger decimal places in an inconsistent way with $13 enabled

### DIFF
--- a/src/app/widgets/Location/DisplayPanel.jsx
+++ b/src/app/widgets/Location/DisplayPanel.jsx
@@ -148,6 +148,16 @@ class DisplayPanel extends PureComponent {
         }));
     };
 
+    //Only rounds values with more than 3 decimal places which begin with 9
+    customMathRound(num) {
+        let radix = num % 1.0;
+        if ((radix > 0.899 && radix < 1.0) && (Number(num.split('.')[1].slice(0, 2)) > 97)) {
+            return Math.ceil(num).toFixed(Number(num.split('.')[1].length));
+        } else {
+            return num;
+        }
+    }
+
     renderAxis = (axis) => {
         const { canClick, machinePosition, workPosition, actions, safeRetractHeight, units, homingEnabled } = this.props;
         let mpos = machinePosition[axis] || '0.000';
@@ -207,8 +217,8 @@ class DisplayPanel extends PureComponent {
                     <AxisButton axis={axisLabel} onClick={handleAxisButtonClick} disabled={!canClick} />
                 </td>
                 <td className={styles.machinePosition}>
-                    <MachinePositionInput value={wpos} handleManualMovement={(value) => actions.handleManualMovement(value, axis)} />
-                    {!showPositionInput && <PositionLabel value={mpos} small />}
+                    <MachinePositionInput value={this.customMathRound(wpos)} handleManualMovement={(value) => actions.handleManualMovement(value, axis)} />
+                    {!showPositionInput && <PositionLabel value={this.customMathRound(mpos)} small />}
                 </td>
             </tr>
         );

--- a/src/app/widgets/Location/components/PositionLabel.jsx
+++ b/src/app/widgets/Location/components/PositionLabel.jsx
@@ -38,9 +38,7 @@ const PositionLabel = ({ value, small }) => {
                 fontWeight: small ? '400' : 'bold' }}
             className={styles.axesPositionLabel}
         >
-            <span>{value.split('.')[0]}</span>
-            <span>.</span>
-            <span>{value.split('.')[1]}</span>
+            <span>{value}</span>
         </div>
     );
 };

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gSender",
-  "version": "1.2.1-BETA",
+  "version": "1.2.1-EDGE",
   "productName": "gSender",
   "description": "CNC Milling Controller",
   "author": {


### PR DESCRIPTION
### Tests: 

1. With 1 decimal place:

    - input = G0X12.9, output = 12.9
    - input = G0X12.99, output = 13.0
    - input = G0X130, output = 130.0

2. With 2 decimal places:

    - input = G0X12.9, output = 12.90
    - input = G0X12.99, output = 13.00
    - input = G0X130, output = 130.00

3. 3 decimal places:
    - input G0X130Y130Z130, output x: 130.000, y: 130.000, z: 130.000

4. 4 and 5 decimal places:

    - input = G0X12.9, output = 12.9007 / 12.90066
    - input = G0X12.99, output = 13.0000 / 13.00000
    - input = G0X130, output = 130.0000 / 130.00000

5. Any known console/terminal error/working after the changes? **None**

6. Any style changes? **None**

**Logic** - round the decimal places only if the value of the first two decimal places > 97
for custom decimal places set to 1, do not round off