### PR TITLE
Mi 824 dev soft limit warning not dissapearing when zero set inside limit bounds

### DIFF
--- a/src/app/widgets/Visualizer/SoftLimitsWarningArea.js
+++ b/src/app/widgets/Visualizer/SoftLimitsWarningArea.js
@@ -86,7 +86,7 @@ class ControlArea extends Component {
                                 Warning: Cut will leave soft limits!
                             </div>
                         )
-                        : <div/>
+                        : <div />
                 }
             </div>
         );

--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -125,7 +125,9 @@ class Visualizer extends Component {
     node = null;
 
     fileLoaded = false;
+
     machineConnected = false;
+
     showSoftLimitsWarning = this.visualizerConfig.get('showSoftLimitsWarning');
 
     setRef = (node) => {
@@ -569,8 +571,8 @@ class Visualizer extends Component {
         const { currentTheme } = this.props.state;
         const { xAxisColor, yAxisColor, zAxisColor } = currentTheme;
 
-        const unitGroup = units === IMPERIAL_UNITS ?
-            this.group.getObjectByName('ImperialCoordinateSystem')
+        const unitGroup = units === IMPERIAL_UNITS
+            ? this.group.getObjectByName('ImperialCoordinateSystem')
             : this.group.getObjectByName('MetricCoordinateSystem');
 
         unitGroup.remove(unitGroup.getObjectByName('xAxis'));
@@ -629,8 +631,8 @@ class Visualizer extends Component {
         const { currentTheme } = this.props.state;
         const { xAxisColor, yAxisColor } = currentTheme;
 
-        const unitGroup = units === IMPERIAL_UNITS ?
-            this.group.getObjectByName('ImperialGridLineNumbers')
+        const unitGroup = units === IMPERIAL_UNITS
+            ? this.group.getObjectByName('ImperialGridLineNumbers')
             : this.group.getObjectByName('MetricGridLineNumbers');
 
         for (let i = -gridCount; i <= gridCount; ++i) {
@@ -1492,10 +1494,14 @@ class Visualizer extends Component {
             2 bottom right
             3 bottom left
         */
-        let xMultiplier = -1;
-        let yMultiplier = -1;
+        let xMultiplier = 1;
+        let yMultiplier = 1;
         if (homingFlag) {
             switch (machineCorner) {
+            case 0:
+                xMultiplier = -1;
+                yMultiplier = -1;
+                break;
             case 1:
                 xMultiplier = 1;
                 yMultiplier = -1;
@@ -1508,8 +1514,6 @@ class Visualizer extends Component {
                 xMultiplier = 1;
                 yMultiplier = 1;
                 break;
-            // case 0 and default are negative space, which is already assigned
-            case 0:
             default:
                 break;
             }
@@ -1533,30 +1537,29 @@ class Visualizer extends Component {
         let origin = {
             x: parseFloat(mpos.x) - parseFloat(wpos.x) * xMultiplier,
             y: parseFloat(mpos.y) - parseFloat(wpos.y) * yMultiplier,
-            z: parseFloat(mpos.z) - parseFloat(wpos.z)
+            z: parseFloat(mpos.z) - parseFloat(wpos.z) * -1,
         };
-
         let limitsMax = {
             x: softXMax * xMultiplier - origin.x,
             y: softYMax * yMultiplier - origin.y,
             z: softZMax - origin.z,
         };
 
-        let limitsMin = {
-            x: origin.x * -1,
-            y: origin.y * -1,
-            z: origin.z,
-        };
+        // let limitsMin = {
+        //     x: origin.x === 0 ? origin.x : origin.x * -1,
+        //     y: origin.y === 0 ? origin.y : origin.y * -1,
+        //     z: origin.z,
+        // };
 
         // get bbox
         let bbox = reduxStore.getState().file.bbox;
-        let bboxMin = bbox.min;
+        // let bboxMin = bbox.min;
         let bboxMax = bbox.max;
 
         // check if machine will leave soft limits
-        if (bboxMax.x > limitsMax.x || bboxMin.x < limitsMin.x ||
-            bboxMax.y > limitsMax.y || bboxMin.y < limitsMin.y ||
-            (bboxMax.z === null ? false : bboxMax.z > limitsMax.z) || (bboxMin.z === null ? false : bboxMin.z < limitsMin.z)) {
+        if (bboxMax.x > limitsMax.x ||
+            bboxMax.y > limitsMax.y ||
+            bboxMax.z > limitsMax.z) {
             pubsub.publish('softlimits:warning');
         } else {
             pubsub.publish('softlimits:ok');


### PR DESCRIPTION
### Bugs Fixed:

1. Default X and Y homing multipliers were set to -1, and Z was 1; This value affected the Origin and Max Cutting Area Limit calculation. So the check for if BBOX area lies inside the max and min available cutting area would fail with a soft limit warning. 
**Fix** - Changed the default values of X and Y to 1 (So the original values of Origin and Max Limit do not change in cases where the homing flag Is false)

2. We were checking if the BBOX lies within the max available cutting area and the min available cutting area(Min Limit). The cutting area calculation is dependent on soft limits, the min limit was always set to (-0, -0, -0). So, when the min DBOX had some negative min X, Y, and Z coordinates, the check failed, sending a soft limit warning. 
**Fix** - Removed minLimit vs minBbox limit check.

### Tests:

1. Check if the soft limit warning pops in the wrong places:

- Load circle-inch.gcode
- Set Homing Direction in bottom left ($23: X(off), Y(off), X(on))
- Set soft limits to(X,Y,Z Max Travel values / $130, $131, $132) X=25.5mm, Y=25.4mm, Z=6.3mm
- Jog to mpos 76X 81Y, -41 Z(G0 X76 Y81 Z-41 in console) → Pops a Soft Limit Alarm
- Unlock Alarm
- Click on ‘Zero All’ in the Location Widget
- No Soft Limit warnings

2. Play with soft limit values and see if the Soft Limit warning pops on the right scenario:

- Set X, Y, Z Max Travel values ($130, $131, $132) in Firmware to {x: 0.1, y: 0.1, z: 0.1}
- Load circle-inch.gcode (BBOX Max - {x: 0.5, y: 0.5, z: 0.25})
- Pops a soft limit warning
- Go back to the Firmware setting and change  X, Y, Z Max Travel values to {x: 25.5, y: 25.4, z: 6.3}
- Click ‘Zero All’ in the Location widget. (Or something to refresh the state)
- The soft limit warning disappears

### Any warnings/Errors?

App or Chrome Console - **None**
Server Terminal- **None**