### PR TITLE
Null Error Fixes

### DIFF
--- a/src/app/containers/Preferences/Stats/StatsList.js
+++ b/src/app/containers/Preferences/Stats/StatsList.js
@@ -32,10 +32,13 @@ const StatsList = ({ state, actions }) => {
 
     // solution found here: https://stackoverflow.com/a/25279340
     const convertMillisecondsToTimeStamp = (milliseconds) => {
-        let date = new Date(null);
-        date.setSeconds(milliseconds / 1000);
-        let result = date.toISOString().substring(11, 19);
-        return result;
+        if (milliseconds) {
+            let date = new Date(null);
+            date.setSeconds(milliseconds / 1000);
+            let result = date.toISOString().substring(11, 19);
+            return result;
+        }
+        return null;
     };
 
     const timeSpentRunning = convertMillisecondsToTimeStamp(store.get('workspace.timeSpentRunning'));

--- a/src/app/widgets/JobStatus/JobStatus.jsx
+++ b/src/app/widgets/JobStatus/JobStatus.jsx
@@ -135,7 +135,7 @@ class JobStatus extends PureComponent {
                             )
                             : (<div className={styles['file-name']}><span className={styles['file-text']}>No File Loaded</span></div>)}
                 </div>
-                {this.state.isChecked
+                {this.state.isChecked && state.senderStatus
                     ? <Overrides state={state} />
                     : <IdleInfo state={state} />
                 }


### PR DESCRIPTION
- when milliseconds are not given for time, it results in invalid time
- when program is refreshed while machine is running and the connection is re-established, the sender status is null, resulting in a program crash