### PR TITLE
Laser Custom Theme

### DIFF
--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -44,7 +44,7 @@ import styles from './index.styl';
 import { METRIC_UNITS, WORKFLOW_STATE_RUNNING } from '../../constants';
 import { convertToImperial, convertToMetric } from './calculate';
 import {
-    CUST_THEME, DARK_THEME_VALUES,
+    DARK_THEME_VALUES,
     BACKGROUND_PART, GRID_PART, XAXIS_PART, YAXIS_PART, ZAXIS_PART,
     LIMIT_PART, CUTTING_PART, JOGGING_PART, G0_PART, G1_PART
 } from '../../widgets/Visualizer/constants';
@@ -558,7 +558,7 @@ class PreferencesPage extends PureComponent {
                 });
                 pubsub.publish('theme:change', theme.value);
             },
-            handleCustThemeChange: (themeColours) => {
+            handleCustThemeChange: (themeColours, theme) => {
                 const { visualizer } = this.state;
                 const parts = [
                     BACKGROUND_PART,
@@ -577,15 +577,15 @@ class PreferencesPage extends PureComponent {
                     if (value === G1_PART) {
                         label = 'G1-3';
                     }
-                    return this.visualizerConfig.set(CUST_THEME + ' ' + label, themeColours.get(value));
+                    return this.visualizerConfig.set(theme + ' ' + label, themeColours.get(value));
                 });
                 this.setState({
                     visualizer: {
                         ...visualizer,
-                        theme: CUST_THEME,
+                        theme: theme,
                     }
                 });
-                pubsub.publish('theme:change', CUST_THEME);
+                pubsub.publish('theme:change', theme);
             },
             handleChangeComplete: (color, part) => {
                 const { visualizer } = this.state;
@@ -639,8 +639,8 @@ class PreferencesPage extends PureComponent {
                 }
                 return defaultColour;
             },
-            getCurrentColor: (part, defaultColour) => {
-                return this.visualizerConfig.get(CUST_THEME + ' ' + part, defaultColour);
+            getCurrentColor: (theme, part, defaultColour) => {
+                return this.visualizerConfig.get(theme + ' ' + part, defaultColour);
             },
             handleVisEnabledToggle: (liteMode = false) => {
                 const { visualizer } = this.state;

--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -44,9 +44,7 @@ import styles from './index.styl';
 import { METRIC_UNITS, WORKFLOW_STATE_RUNNING } from '../../constants';
 import { convertToImperial, convertToMetric } from './calculate';
 import {
-    DARK_THEME_VALUES,
-    BACKGROUND_PART, GRID_PART, XAXIS_PART, YAXIS_PART, ZAXIS_PART,
-    LIMIT_PART, CUTTING_PART, JOGGING_PART, G0_PART, G1_PART
+    DARK_THEME_VALUES, PARTS_LIST, G1_PART
 } from '../../widgets/Visualizer/constants';
 import StatsPage from './Stats';
 import SafetySettings from './Safety';
@@ -560,19 +558,7 @@ class PreferencesPage extends PureComponent {
             },
             handleCustThemeChange: (themeColours, theme) => {
                 const { visualizer } = this.state;
-                const parts = [
-                    BACKGROUND_PART,
-                    GRID_PART,
-                    XAXIS_PART,
-                    YAXIS_PART,
-                    ZAXIS_PART,
-                    LIMIT_PART,
-                    CUTTING_PART,
-                    JOGGING_PART,
-                    G0_PART,
-                    G1_PART
-                ];
-                parts.map((value) => {
+                PARTS_LIST.map((value) => {
                     let label = value;
                     if (value === G1_PART) {
                         label = 'G1-3';
@@ -595,49 +581,7 @@ class PreferencesPage extends PureComponent {
                 pubsub.publish('part:change');
             },
             getDefaultColour: (part) => {
-                let defaultColour;
-                let themeType = DARK_THEME_VALUES;
-                switch (part) {
-                case 'Background':
-                    defaultColour = themeType.backgroundColor;
-                    break;
-                case 'Grid':
-                    defaultColour = themeType.gridColor;
-                    break;
-                case 'X Axis':
-                    defaultColour = themeType.xAxisColor;
-                    break;
-                case 'Y Axis':
-                    defaultColour = themeType.yAxisColor;
-                    break;
-                case 'Z Axis':
-                    defaultColour = themeType.zAxisColor;
-                    break;
-                case 'Limit':
-                    defaultColour = themeType.limitColor;
-                    break;
-                case 'Cutting Coordinates Lines':
-                    defaultColour = themeType.cuttingCoordinateLines;
-                    break;
-                case 'Jogging Coordinates Lines':
-                    defaultColour = themeType.joggingCoordinateLines;
-                    break;
-                case 'G0':
-                    defaultColour = themeType.G0Color;
-                    break;
-                case 'G1':
-                    defaultColour = themeType.G1Color;
-                    break;
-                case 'G2':
-                    defaultColour = themeType.G1Color;
-                    break;
-                case 'G3':
-                    defaultColour = themeType.G1Color;
-                    break;
-                default:
-                    defaultColour = '#000000';
-                }
-                return defaultColour;
+                return DARK_THEME_VALUES.get(part) || '#000000';
             },
             getCurrentColor: (theme, part, defaultColour) => {
                 return this.visualizerConfig.get(theme + ' ' + part, defaultColour);

--- a/src/app/containers/Preferences/Shortcuts/ShortcutTable.js
+++ b/src/app/containers/Preferences/Shortcuts/ShortcutTable.js
@@ -25,10 +25,10 @@ function ShortcutTable({ forwardRef }) {
                         </tr>
                     </thead>
                     <tbody>
-                        {shortcuts.map((shortcut) => {
+                        {shortcuts.map((shortcut, i) => {
                             const { title, keys, category } = shortcut;
                             return keys ? (
-                                <tr key={title}>
+                                <tr key={`${title}-${i}`}>
                                     <td>{title || '-'}</td>
                                     <td>{keys || '-'}</td>
                                     <td>{category || '-'}</td>

--- a/src/app/containers/Preferences/Visualizer/Theme.js
+++ b/src/app/containers/Preferences/Visualizer/Theme.js
@@ -5,9 +5,8 @@ import { useSelector } from 'react-redux';
 
 import Tooltip from 'app/components/TooltipCustom/ToolTip';
 import {
-    CUSTOMIZABLE_THEMES, ALL_THEMES,
-    BACKGROUND_PART, GRID_PART, XAXIS_PART, YAXIS_PART, ZAXIS_PART,
-    LIMIT_PART, CUTTING_PART, JOGGING_PART, G0_PART, G1_PART
+    CUSTOMIZABLE_THEMES, ALL_THEMES, PARTS_LIST,
+    G1_PART, CUTTING_PART, JOGGING_PART
 }
 from 'app/widgets/Visualizer/constants';
 import pubsub from 'pubsub-js';
@@ -17,40 +16,16 @@ import ColorCircle from '../components/ColorCircle';
 
 import styles from '../index.styl';
 
-const parts = [
-    BACKGROUND_PART,
-    GRID_PART,
-    XAXIS_PART,
-    YAXIS_PART,
-    ZAXIS_PART,
-    LIMIT_PART,
-    CUTTING_PART,
-    JOGGING_PART,
-    G0_PART,
-    G1_PART
-];
-
 const Theme = ({ state, actions }) => {
     const { theme } = state.visualizer;
     const [isOpen, setIsOpen] = useState(false);
-    const [currentPart, setCurrentPart] = useState(BACKGROUND_PART);
+    const [currentPart, setCurrentPart] = useState(PARTS_LIST[0]);
     const fileLoaded = useSelector(store => store.file.fileLoaded);
 
     const getThemeColours = (theme) => {
-        return (
-            new Map([
-                [BACKGROUND_PART, actions.visualizer.getCurrentColor(theme, BACKGROUND_PART, actions.visualizer.getDefaultColour(BACKGROUND_PART))],
-                [GRID_PART, actions.visualizer.getCurrentColor(theme, GRID_PART, actions.visualizer.getDefaultColour(GRID_PART))],
-                [XAXIS_PART, actions.visualizer.getCurrentColor(theme, XAXIS_PART, actions.visualizer.getDefaultColour(XAXIS_PART))],
-                [YAXIS_PART, actions.visualizer.getCurrentColor(theme, YAXIS_PART, actions.visualizer.getDefaultColour(YAXIS_PART))],
-                [ZAXIS_PART, actions.visualizer.getCurrentColor(theme, ZAXIS_PART, actions.visualizer.getDefaultColour(ZAXIS_PART))],
-                [LIMIT_PART, actions.visualizer.getCurrentColor(theme, LIMIT_PART, actions.visualizer.getDefaultColour(LIMIT_PART))],
-                [CUTTING_PART, actions.visualizer.getCurrentColor(theme, CUTTING_PART, actions.visualizer.getDefaultColour(CUTTING_PART))],
-                [JOGGING_PART, actions.visualizer.getCurrentColor(theme, JOGGING_PART, actions.visualizer.getDefaultColour(JOGGING_PART))],
-                [G0_PART, actions.visualizer.getCurrentColor(theme, G0_PART, actions.visualizer.getDefaultColour(G0_PART))],
-                [G1_PART, actions.visualizer.getCurrentColor(theme, G1_PART, actions.visualizer.getDefaultColour(G1_PART))],
-            ])
-        );
+        let colourMap = new Map();
+        PARTS_LIST.map(part => colourMap.set(part, actions.visualizer.getCurrentColor(theme, part, actions.visualizer.getDefaultColour(part))));
+        return colourMap;
     };
 
     const [themeColours, setThemeColours] = useState(getThemeColours(theme));
@@ -132,7 +107,7 @@ const Theme = ({ state, actions }) => {
                         </Tooltip>
                         <Tooltip content="Click on the colour circles to change the colour for that component" location="default">
                             {
-                                parts.map((value, i) => {
+                                PARTS_LIST.map((value, i) => {
                                     let title = value;
                                     if (title === G1_PART) {
                                         title = 'G1-G3';

--- a/src/app/containers/Preferences/Visualizer/Theme.js
+++ b/src/app/containers/Preferences/Visualizer/Theme.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 
 import Tooltip from 'app/components/TooltipCustom/ToolTip';
 import {
-    DARK_THEME, LIGHT_THEME, CUST_THEME,
+    CUSTOMIZABLE_THEMES, ALL_THEMES,
     BACKGROUND_PART, GRID_PART, XAXIS_PART, YAXIS_PART, ZAXIS_PART,
     LIMIT_PART, CUTTING_PART, JOGGING_PART, G0_PART, G1_PART
 }
@@ -16,12 +16,6 @@ import ColorPicker from '../components/ColorPicker';
 import ColorCircle from '../components/ColorCircle';
 
 import styles from '../index.styl';
-
-const themes = [
-    DARK_THEME,
-    LIGHT_THEME,
-    CUST_THEME
-];
 
 const parts = [
     BACKGROUND_PART,
@@ -42,18 +36,24 @@ const Theme = ({ state, actions }) => {
     const [currentPart, setCurrentPart] = useState(BACKGROUND_PART);
     const fileLoaded = useSelector(store => store.file.fileLoaded);
 
-    const [themeColours, setThemeColours] = useState(new Map([
-        [BACKGROUND_PART, actions.visualizer.getCurrentColor(BACKGROUND_PART, actions.visualizer.getDefaultColour(BACKGROUND_PART))],
-        [GRID_PART, actions.visualizer.getCurrentColor(GRID_PART, actions.visualizer.getDefaultColour(GRID_PART))],
-        [XAXIS_PART, actions.visualizer.getCurrentColor(XAXIS_PART, actions.visualizer.getDefaultColour(XAXIS_PART))],
-        [YAXIS_PART, actions.visualizer.getCurrentColor(YAXIS_PART, actions.visualizer.getDefaultColour(YAXIS_PART))],
-        [ZAXIS_PART, actions.visualizer.getCurrentColor(ZAXIS_PART, actions.visualizer.getDefaultColour(ZAXIS_PART))],
-        [LIMIT_PART, actions.visualizer.getCurrentColor(LIMIT_PART, actions.visualizer.getDefaultColour(LIMIT_PART))],
-        [CUTTING_PART, actions.visualizer.getCurrentColor(CUTTING_PART, actions.visualizer.getDefaultColour(CUTTING_PART))],
-        [JOGGING_PART, actions.visualizer.getCurrentColor(JOGGING_PART, actions.visualizer.getDefaultColour(JOGGING_PART))],
-        [G0_PART, actions.visualizer.getCurrentColor(G0_PART, actions.visualizer.getDefaultColour(G0_PART))],
-        [G1_PART, actions.visualizer.getCurrentColor(G1_PART, actions.visualizer.getDefaultColour(G1_PART))],
-    ]));
+    const getThemeColours = (theme) => {
+        return (
+            new Map([
+                [BACKGROUND_PART, actions.visualizer.getCurrentColor(theme, BACKGROUND_PART, actions.visualizer.getDefaultColour(BACKGROUND_PART))],
+                [GRID_PART, actions.visualizer.getCurrentColor(theme, GRID_PART, actions.visualizer.getDefaultColour(GRID_PART))],
+                [XAXIS_PART, actions.visualizer.getCurrentColor(theme, XAXIS_PART, actions.visualizer.getDefaultColour(XAXIS_PART))],
+                [YAXIS_PART, actions.visualizer.getCurrentColor(theme, YAXIS_PART, actions.visualizer.getDefaultColour(YAXIS_PART))],
+                [ZAXIS_PART, actions.visualizer.getCurrentColor(theme, ZAXIS_PART, actions.visualizer.getDefaultColour(ZAXIS_PART))],
+                [LIMIT_PART, actions.visualizer.getCurrentColor(theme, LIMIT_PART, actions.visualizer.getDefaultColour(LIMIT_PART))],
+                [CUTTING_PART, actions.visualizer.getCurrentColor(theme, CUTTING_PART, actions.visualizer.getDefaultColour(CUTTING_PART))],
+                [JOGGING_PART, actions.visualizer.getCurrentColor(theme, JOGGING_PART, actions.visualizer.getDefaultColour(JOGGING_PART))],
+                [G0_PART, actions.visualizer.getCurrentColor(theme, G0_PART, actions.visualizer.getDefaultColour(G0_PART))],
+                [G1_PART, actions.visualizer.getCurrentColor(theme, G1_PART, actions.visualizer.getDefaultColour(G1_PART))],
+            ])
+        );
+    };
+
+    const [themeColours, setThemeColours] = useState(getThemeColours(theme));
 
     const themeRenderer = (option) => {
         const style = {
@@ -72,7 +72,7 @@ const Theme = ({ state, actions }) => {
         setIsOpen(true);
     };
 
-    const closeModal = (colour) => {
+    const closeModal = () => {
         setIsOpen(false);
     };
 
@@ -99,8 +99,11 @@ const Theme = ({ state, actions }) => {
                             clearable={false}
                             menuContainerStyle={{ zIndex: 5 }}
                             name="theme"
-                            onChange={actions.visualizer.handleThemeChange}
-                            options={map(themes, (value) => ({
+                            onChange={(value) => {
+                                actions.visualizer.handleThemeChange(value);
+                                setThemeColours(getThemeColours(value.value));
+                            }}
+                            options={map(ALL_THEMES, (value) => ({
                                 value: value,
                                 label: value
                             }))}
@@ -113,7 +116,7 @@ const Theme = ({ state, actions }) => {
                     </div>
                 </Tooltip>
             </Fieldset>
-            { theme === CUST_THEME && !fileLoaded &&
+            { CUSTOMIZABLE_THEMES.includes(theme) && !fileLoaded &&
                 <Fieldset legend="Colours">
                     <div className={styles.addMargin}>
                         <Tooltip content="Save your changes" location="default">
@@ -121,7 +124,7 @@ const Theme = ({ state, actions }) => {
                                 className={styles.saveColour}
                                 type="button"
                                 onClick={() => {
-                                    actions.visualizer.handleCustThemeChange(themeColours);
+                                    actions.visualizer.handleCustThemeChange(themeColours, theme);
                                 }}
                             >
                             Save
@@ -139,7 +142,7 @@ const Theme = ({ state, actions }) => {
                                         title = 'Jogging Coord Lines';
                                     }
                                     return (
-                                        <div key={i} className={styles.colorContainer}>
+                                        <div key={theme + i} className={styles.colorContainer}>
                                             <span className={styles.first}>{title}</span>
                                             <div className={styles.dotsV2}></div>
                                             <div role="button" className={styles.colorDisplay} onClick={() => openModal(value)} tabIndex={0}>
@@ -152,7 +155,7 @@ const Theme = ({ state, actions }) => {
                             }
                         </Tooltip>
                     </div>
-                    <ColorPicker actions={actions} part={currentPart} isOpen={isOpen} onClose={closeModal} chooseColour={chooseColour} />
+                    <ColorPicker actions={actions} theme={theme} part={currentPart} isOpen={isOpen} onClose={closeModal} chooseColour={chooseColour} />
                 </Fieldset>
             }
             {

--- a/src/app/containers/Preferences/components/ColorPicker.js
+++ b/src/app/containers/Preferences/components/ColorPicker.js
@@ -26,13 +26,13 @@ import Modal from 'app/components/Modal';
 import { SketchPicker } from 'react-color';
 import styles from '../index.styl';
 
-const ColorPicker = ({ actions, part, isOpen, onClose, chooseColour }) => {
-    const [color, setColor] = useState(actions.visualizer.getCurrentColor(part, actions.visualizer.getDefaultColour(part)));
+const ColorPicker = ({ actions, theme, part, isOpen, onClose, chooseColour }) => {
+    const [color, setColor] = useState(actions.visualizer.getCurrentColor(theme, part, actions.visualizer.getDefaultColour(part)));
     const [currentPart, setCurrentPart] = useState(part);
 
     const onOpen = () => {
-        if (color !== actions.visualizer.getCurrentColor(part, actions.visualizer.getDefaultColour(part)) && currentPart !== part) {
-            setColor(actions.visualizer.getCurrentColor(part, actions.visualizer.getDefaultColour(part)));
+        if (color !== actions.visualizer.getCurrentColor(theme, part, actions.visualizer.getDefaultColour(part)) && currentPart !== part) {
+            setColor(actions.visualizer.getCurrentColor(theme, part, actions.visualizer.getDefaultColour(part)));
             setCurrentPart(part);
         }
         return 1;

--- a/src/app/widgets/Visualizer/GCodeVisualizer.js
+++ b/src/app/widgets/Visualizer/GCodeVisualizer.js
@@ -24,6 +24,7 @@
 // import colornames from 'colornames';
 import * as THREE from 'three';
 import log from 'app/lib/log';
+import { BACKGROUND_PART, CUTTING_PART, G0_PART, G1_PART, G2_PART, G3_PART, LASER_PART } from './constants';
 
 class GCodeVisualizer {
     constructor(theme) {
@@ -42,9 +43,8 @@ class GCodeVisualizer {
     }
 
     updateLaserModeColors() {
-        const { /*G1Color, */backgroundColor } = this.theme;
-        const defaultColor = new THREE.Color(255, 0, 0);
-        const fillColor = new THREE.Color(backgroundColor);
+        const defaultColor = new THREE.Color(this.theme.get(LASER_PART));
+        const fillColor = new THREE.Color(this.theme.get(BACKGROUND_PART));
         const maxSpindleValue = Math.max(...[...this.spindleSpeeds]);
 
         const calculateOpacity = (speed) => ((maxSpindleValue === 0) ? 1 : (speed / maxSpindleValue));
@@ -64,20 +64,19 @@ class GCodeVisualizer {
     }
 
     render({ vertices, colors, frames, spindleSpeeds, isLaser = false, spindleChanges }) {
-        const { cuttingCoordinateLines, G0Color, G1Color } = this.theme;
         this.vertices = new THREE.Float32BufferAttribute(vertices, 3);
         this.frames = frames;
         this.spindleSpeeds = spindleSpeeds;
         this.isLaser = isLaser;
         this.spindleChanges = spindleChanges;
-        const defaultColor = new THREE.Color(cuttingCoordinateLines);
+        const defaultColor = new THREE.Color(this.theme.get(CUTTING_PART));
 
         // Get line colors for current theme
         const motionColor = {
-            'G0': new THREE.Color(G0Color),
-            'G1': new THREE.Color(G1Color),
-            'G2': new THREE.Color(G1Color),
-            'G3': new THREE.Color(G1Color),
+            'G0': new THREE.Color(this.theme.get(G0_PART)),
+            'G1': new THREE.Color(this.theme.get(G1_PART)),
+            'G2': new THREE.Color(this.theme.get(G2_PART)),
+            'G3': new THREE.Color(this.theme.get(G3_PART)),
             'default': defaultColor
         };
 
@@ -108,7 +107,6 @@ class GCodeVisualizer {
 
     /* Turns our array of Three colors into a float typed array we can set as a bufferAttribute */
     getColorTypedArray(colors, motionColor) {
-        console.log(colors);
         const colorArray = [];
         colors.forEach(colorTag => {
             const [motion, opacity] = colorTag;
@@ -129,8 +127,7 @@ class GCodeVisualizer {
         if (this.frames.length === 0) {
             return;
         }
-        const { cuttingCoordinateLine } = this.theme;
-        const defaultColor = new THREE.Color(cuttingCoordinateLine);
+        const defaultColor = new THREE.Color(this.theme.get(CUTTING_PART));
 
         frameIndex = Math.min(frameIndex, this.frames.length - 1);
         frameIndex = Math.max(frameIndex, 0);

--- a/src/app/widgets/Visualizer/constants.js
+++ b/src/app/widgets/Visualizer/constants.js
@@ -85,6 +85,18 @@ export const LIGHT_THEME_VALUES = {
 export const DARK_THEME = 'Dark';
 export const LIGHT_THEME = 'Light';
 export const CUST_THEME = 'Custom';
+export const LASER_THEME = 'Laser';
+
+export const ALL_THEMES = [
+    DARK_THEME,
+    LIGHT_THEME,
+    CUST_THEME,
+    LASER_THEME
+];
+export const CUSTOMIZABLE_THEMES = [
+    CUST_THEME,
+    LASER_THEME
+];
 
 export const BACKGROUND_PART = 'Background';
 export const GRID_PART = 'Grid';

--- a/src/app/widgets/Visualizer/constants.js
+++ b/src/app/widgets/Visualizer/constants.js
@@ -52,50 +52,17 @@ export const PRIMARY_COLOR = '#3E85C7'; // Light Blue
 export const BORDER_COLOR = '#9CA3AF';
 export const SECONDARY_COLOR = '#6F7376'; // Grey (for disabled look)
 
-export const DARK_THEME_VALUES = {
-    backgroundColor: '#111827', //Navy Blue
-    gridColor: '#77a9d7', // Turqoise / Light Blue
-    xAxisColor: '#df3b3b', //Indian Red
-    yAxisColor: '#06b881', //Light Green
-    zAxisColor: '#295d8d', //Light Green
-    limitColor: '#5191cc', //Indian Red
-    cuttingCoordinateLines: '#fff', //White
-    joggingCoordinateLines: '#0ef6ae', // Light Green
-    G0Color: '#0ef6ae', // Light Green
-    G1Color: '#3e85c7', // Light Blue
-    G2Color: '#3e85c7', // Light Blue
-    G3Color: '#3e85c7', // Light Blue
-};
-
-export const LIGHT_THEME_VALUES = {
-    backgroundColor: '#e5e7eb', //Navy Blue
-    gridColor: '#000000', // Turqoise / Light Blue
-    xAxisColor: '#df3b3b', //Indian Red
-    yAxisColor: '#06b881', //Light Green
-    zAxisColor: '#295d8d', //Light Green
-    limitColor: '#5191cc', //Indian Red
-    cuttingCoordinateLines: '#000000',
-    joggingCoordinateLines: '#0ef6ae', // Light Green
-    G0Color: '#0ef6ae', // Light Green
-    G1Color: '#111827', // Dark Blue
-    G2Color: '#111827', // Dark Blue
-    G3Color: '#111827', // Dark Blue
-};
-
 export const DARK_THEME = 'Dark';
 export const LIGHT_THEME = 'Light';
 export const CUST_THEME = 'Custom';
-export const LASER_THEME = 'Laser';
 
 export const ALL_THEMES = [
     DARK_THEME,
     LIGHT_THEME,
     CUST_THEME,
-    LASER_THEME
 ];
 export const CUSTOMIZABLE_THEMES = [
     CUST_THEME,
-    LASER_THEME
 ];
 
 export const BACKGROUND_PART = 'Background';
@@ -110,3 +77,50 @@ export const G0_PART = 'G0';
 export const G1_PART = 'G1';
 export const G2_PART = 'G2';
 export const G3_PART = 'G3';
+export const LASER_PART = 'Laser';
+
+export const PARTS_LIST = [
+    BACKGROUND_PART,
+    GRID_PART,
+    XAXIS_PART,
+    YAXIS_PART,
+    ZAXIS_PART,
+    LIMIT_PART,
+    CUTTING_PART,
+    JOGGING_PART,
+    G0_PART,
+    G1_PART,
+    LASER_PART
+];
+
+export const DARK_THEME_VALUES = new Map([
+    [BACKGROUND_PART, '#111827'], //Navy Blue
+    [GRID_PART, '#77a9d7'], // Turqoise / Light Blue
+    [XAXIS_PART, '#df3b3b'], //Indian Red
+    [YAXIS_PART, '#06b881'], //Light Green
+    [ZAXIS_PART, '#295d8d'], //Light Green
+    [LIMIT_PART, '#5191cc'], //Indian Red
+    [CUTTING_PART, '#fff'], //White
+    [JOGGING_PART, '#0ef6ae'], // Light Green
+    [G0_PART, '#0ef6ae'], // Light Green
+    [G1_PART, '#3e85c7'], // Light Blue
+    [G2_PART, '#3e85c7'], // Light Blue
+    [G3_PART, '#3e85c7'], // Light Blue
+    [LASER_PART, '#FF0000'], // Red
+]);
+
+export const LIGHT_THEME_VALUES = new Map([
+    [BACKGROUND_PART, '#e5e7eb'], //Navy Blue
+    [GRID_PART, '#000000'], // Turqoise / Light Blue
+    [XAXIS_PART, '#df3b3b'], //Indian Red
+    [YAXIS_PART, '#06b881'], //Light Green
+    [ZAXIS_PART, '#295d8d'], //Light Green
+    [LIMIT_PART, '#5191cc'], //Indian Red
+    [CUTTING_PART, '#000000'],
+    [JOGGING_PART, '#0ef6ae'], // Light Green
+    [G0_PART, '#0ef6ae'], // Light Green
+    [G1_PART, '#111827'], // Dark Blue
+    [G2_PART, '#111827'], // Dark Blue
+    [G3_PART, '#111827'], // Dark Blue
+    [LASER_PART, '#FF0000'] // Red
+]);

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -83,7 +83,7 @@ import {
     LIGHT_THEME_VALUES,
     DARK_THEME,
     DARK_THEME_VALUES,
-    CUST_THEME
+    CUSTOMIZABLE_THEMES
 } from './constants';
 import SecondaryVisualizer from './SecondaryVisualizer';
 import useKeybinding from '../../lib/useKeybinding';
@@ -1229,24 +1229,22 @@ class VisualizerWidget extends PureComponent {
         const { theme } = store.get('widgets.visualizer');
         if (theme === LIGHT_THEME) {
             return LIGHT_THEME_VALUES;
-        }
-        if (theme === DARK_THEME) {
+        } else if (theme === DARK_THEME) {
             return DARK_THEME_VALUES;
-        }
-        if (theme === CUST_THEME) {
+        } else if (CUSTOMIZABLE_THEMES.includes(theme)) {
             return {
-                backgroundColor: this.config.get('Custom Background', DARK_THEME_VALUES.backgroundColor),
-                gridColor: this.config.get('Custom Grid', DARK_THEME_VALUES.gridColor),
-                xAxisColor: this.config.get('Custom X Axis', DARK_THEME_VALUES.xAxisColor),
-                yAxisColor: this.config.get('Custom Y Axis', DARK_THEME_VALUES.yAxisColor),
-                zAxisColor: this.config.get('Custom Z Axis', DARK_THEME_VALUES.zAxisColor),
-                limitColor: this.config.get('Custom Limit', DARK_THEME_VALUES.limitColor),
-                cuttingCoordinateLines: this.config.get('Custom Cutting Coordinate Lines', DARK_THEME_VALUES.cuttingCoordinateLines),
-                joggingCoordinateLines: this.config.get('Custom Jogging Coordinate Lines', DARK_THEME_VALUES.joggingCoordinateLines),
-                G0Color: this.config.get('Custom G0', DARK_THEME_VALUES.G0Color),
-                G1Color: this.config.get('Custom G1-3', DARK_THEME_VALUES.G1Color),
-                G2Color: this.config.get('Custom G1-3', DARK_THEME_VALUES.G2Color),
-                G3Color: this.config.get('Custom G1-3', DARK_THEME_VALUES.G3Color),
+                backgroundColor: this.config.get(theme + ' Background', DARK_THEME_VALUES.backgroundColor),
+                gridColor: this.config.get(theme + ' Grid', DARK_THEME_VALUES.gridColor),
+                xAxisColor: this.config.get(theme + ' X Axis', DARK_THEME_VALUES.xAxisColor),
+                yAxisColor: this.config.get(theme + ' Y Axis', DARK_THEME_VALUES.yAxisColor),
+                zAxisColor: this.config.get(theme + ' Z Axis', DARK_THEME_VALUES.zAxisColor),
+                limitColor: this.config.get(theme + ' Limit', DARK_THEME_VALUES.limitColor),
+                cuttingCoordinateLines: this.config.get(theme + ' Cutting Coordinate Lines', DARK_THEME_VALUES.cuttingCoordinateLines),
+                joggingCoordinateLines: this.config.get(theme + ' Jogging Coordinate Lines', DARK_THEME_VALUES.joggingCoordinateLines),
+                G0Color: this.config.get(theme + ' G0', DARK_THEME_VALUES.G0Color),
+                G1Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G1Color),
+                G2Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G2Color),
+                G3Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G3Color),
             };
         }
         return DARK_THEME_VALUES;

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -83,7 +83,8 @@ import {
     LIGHT_THEME_VALUES,
     DARK_THEME,
     DARK_THEME_VALUES,
-    CUSTOMIZABLE_THEMES
+    CUSTOMIZABLE_THEMES,
+    PARTS_LIST
 } from './constants';
 import SecondaryVisualizer from './SecondaryVisualizer';
 import useKeybinding from '../../lib/useKeybinding';
@@ -1232,20 +1233,9 @@ class VisualizerWidget extends PureComponent {
         } else if (theme === DARK_THEME) {
             return DARK_THEME_VALUES;
         } else if (CUSTOMIZABLE_THEMES.includes(theme)) {
-            return {
-                backgroundColor: this.config.get(theme + ' Background', DARK_THEME_VALUES.backgroundColor),
-                gridColor: this.config.get(theme + ' Grid', DARK_THEME_VALUES.gridColor),
-                xAxisColor: this.config.get(theme + ' X Axis', DARK_THEME_VALUES.xAxisColor),
-                yAxisColor: this.config.get(theme + ' Y Axis', DARK_THEME_VALUES.yAxisColor),
-                zAxisColor: this.config.get(theme + ' Z Axis', DARK_THEME_VALUES.zAxisColor),
-                limitColor: this.config.get(theme + ' Limit', DARK_THEME_VALUES.limitColor),
-                cuttingCoordinateLines: this.config.get(theme + ' Cutting Coordinate Lines', DARK_THEME_VALUES.cuttingCoordinateLines),
-                joggingCoordinateLines: this.config.get(theme + ' Jogging Coordinate Lines', DARK_THEME_VALUES.joggingCoordinateLines),
-                G0Color: this.config.get(theme + ' G0', DARK_THEME_VALUES.G0Color),
-                G1Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G1Color),
-                G2Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G2Color),
-                G3Color: this.config.get(theme + ' G1-3', DARK_THEME_VALUES.G3Color),
-            };
+            let colourMap = new Map();
+            PARTS_LIST.map(part => colourMap.set(part, this.config.get(theme + ' ' + part, DARK_THEME_VALUES.get(part))));
+            return colourMap;
         }
         return DARK_THEME_VALUES;
     }


### PR DESCRIPTION
- added laser colour
- added support for more custom themes, making it easier to add new ones in the future 
     - in `constants.js`, create the constant for the new theme and add it to two constant arrays, `ALL_THEMES` and `CUSTOMIZABLE_THEMES`
     - that's all!
- changed the way the theme colours are stored, making it easier to add new ones in the future
     - in constants.js, create a new part constant and add it to `PARTS_LIST` and `DARK_THEME_VALUES`/`LIGHT_THEME_VALUES`
- now recreates cutting pointer on theme change so that its colour updates
- fixed "duplicate key" errors when opening settings