### PR TITLE
Mi 845 dev job override should toggle back on job stop to file attributes, and allow toggling back to attributes while job running

### DIFF
--- a/src/app/actions/visualizerActions.js
+++ b/src/app/actions/visualizerActions.js
@@ -3,10 +3,12 @@ import { createAction } from 'redux-action';
 
 export const {
     SET_CURRENT_VISUALIZER,
-    SET_LASER_MODE
+    SET_LASER_MODE,
+    UPDATE_JOB_OVERRIDES
 } = constants('connection', [
     'SET_CURRENT_VISUALIZER',
-    'SET_LASER_MODE'
+    'SET_LASER_MODE',
+    'UPDATE_JOB_OVERRIDES'
 ]);
 
 export const setCurrentVisualizer = createAction(SET_CURRENT_VISUALIZER);

--- a/src/app/reducers/visualizerReducers.js
+++ b/src/app/reducers/visualizerReducers.js
@@ -1,9 +1,10 @@
 import { createReducer } from 'redux-action';
-import { SET_CURRENT_VISUALIZER } from 'app/actions/visualizerActions';
+import { SET_CURRENT_VISUALIZER, UPDATE_JOB_OVERRIDES } from 'app/actions/visualizerActions';
 import { VISUALIZER_PRIMARY } from 'app/constants';
 
 const initialState = {
-    activeVisualizer: VISUALIZER_PRIMARY
+    activeVisualizer: VISUALIZER_PRIMARY,
+    jobOverrides: { isChecked: false, toggleStatus: 'jobStatus' }
 };
 
 const reducer = createReducer(initialState, {
@@ -11,6 +12,12 @@ const reducer = createReducer(initialState, {
         return {
             ...state,
             activeVisualizer: payload
+        };
+    },
+    [UPDATE_JOB_OVERRIDES]: (payload, state) => {
+        return {
+            ...state,
+            jobOverrides: payload,
         };
     },
 });

--- a/src/app/widgets/JobStatus/JobStatus.jsx
+++ b/src/app/widgets/JobStatus/JobStatus.jsx
@@ -25,6 +25,8 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import get from 'lodash/get';
+import reduxStore from 'app/store/redux';
+import { UPDATE_JOB_OVERRIDES } from 'app/actions/visualizerActions';
 import { connect } from 'react-redux';
 import TooltipCustom from 'app/components/TooltipCustom/ToolTip';
 import ToggleSwitch from 'app/components/ToggleSwitch';
@@ -57,11 +59,8 @@ class JobStatus extends PureComponent {
         return `${size} bytes`;
     };
 
-    state = {
-    }
-
     handleOverrideToggle = () => {
-        if (this.state.toggleStatus === 'jobStatus') {
+        if (get(reduxStore.getState(), 'visualizer.jobOverrides.toggleStatus') === 'jobStatus') {
             localStorage.setItem('jobOverrideToggle', JSON.stringify({
                 isChecked: true,
                 toggleStatus: 'overrides',
@@ -72,19 +71,13 @@ class JobStatus extends PureComponent {
                 toggleStatus: 'jobStatus',
             }));
         }
-        this.setState(JSON.parse(localStorage.getItem('jobOverrideToggle')));
+        reduxStore.dispatch({ type: UPDATE_JOB_OVERRIDES, payload: JSON.parse(localStorage.getItem('jobOverrideToggle')) });
     }
 
     componentDidUpdate() {
         if (!this.props.fileLoaded || !this.props.connection.isConnected) {
             localStorage.setItem('jobOverrideToggle', JSON.stringify({ isChecked: false,
                 toggleStatus: 'jobStatus', }));
-        }
-
-        if (this.props.activeState === 'Run') {
-            this.setState({ isChecked: true, toggleStatus: 'overrides' });
-        } else if (!this.props.fileLoaded) {
-            this.setState({ isChecked: false, toggleStatus: 'jobStatus' });
         }
     }
 
@@ -115,7 +108,7 @@ class JobStatus extends PureComponent {
                                                     label="Overrides"
                                                     onChange={() => this.handleOverrideToggle()}
                                                     className={styles.litetoggle}
-                                                    checked={this.state.isChecked}
+                                                    checked={get(reduxStore.getState(), 'visualizer.jobOverrides.isChecked')}
                                                     size="md"
                                                 />
                                             ) : <span />
@@ -135,7 +128,7 @@ class JobStatus extends PureComponent {
                             )
                             : (<div className={styles['file-name']}><span className={styles['file-text']}>No File Loaded</span></div>)}
                 </div>
-                {this.state.isChecked && state.senderStatus
+                {get(reduxStore.getState(), 'visualizer.jobOverrides.isChecked') && state.senderStatus
                     ? <Overrides state={state} />
                     : <IdleInfo state={state} />
                 }

--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -31,6 +31,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import isElectron from 'is-electron';
 import reduxStore from 'app/store/redux';
+import { UPDATE_JOB_OVERRIDES } from 'app/actions/visualizerActions';
 import controller from 'app/lib/controller';
 import api from 'app/api';
 import pubsub from 'pubsub-js';
@@ -209,6 +210,7 @@ class WorkflowControl extends PureComponent {
 
         const { received } = senderStatus;
         handleStop();
+        reduxStore.dispatch({ type: UPDATE_JOB_OVERRIDES, payload: { isChecked: false, toggleStatus: 'jobStatus' } });
         this.setState(prev => ({ runHasStarted: false, startFromLine: { ...prev.startFromLine, value: received } }));
         if (status.activeState === 'Check') {
             controller.command('gcode', '$C');
@@ -234,6 +236,7 @@ class WorkflowControl extends PureComponent {
         }
         this.setState({ fileLoaded: true });
         this.setState({ runHasStarted: true });
+        reduxStore.dispatch({ type: UPDATE_JOB_OVERRIDES, payload: { isChecked: true, toggleStatus: 'overrides' } });
         const { actions } = this.props;
         actions.onRunClick();
     }
@@ -574,11 +577,13 @@ class WorkflowControl extends PureComponent {
                     )
                 }
                 {
-                    !renderSVG ?
-                        <CameraDisplay
-                            camera={camera}
-                            cameraPosition={cameraPosition}
-                        /> : null
+                    !renderSVG
+                        ? (
+                            <CameraDisplay
+                                camera={camera}
+                                cameraPosition={cameraPosition}
+                            />
+                        ) : null
                 }
             </div>
         );


### PR DESCRIPTION
### Changes:

- Override toggle changes back to file attributes if the user stops the job

### Tests:

- No files loaded, toggle doesn’t appear
- Load a file, toggle appears
- Start a job with toggle off → turns on the override widget
- Start a job with override on → stays on (override on)
- Pause a job → No change to toggle status
- Stop a job with override on → Turns off override (Widget changes to File attribute)
- Stop a job with override off (with file attribute) → No change of widgets (Still on file attribute)
- User can change toggle status at any state without any problem

**Any errors or warnings?** **None**