### PR TITLE
Mi 847 dev override toggle should use same component as other toggles in the UI

### DIFF
--- a/src/app/widgets/JobStatus/JobStatus.jsx
+++ b/src/app/widgets/JobStatus/JobStatus.jsx
@@ -117,6 +117,7 @@ class JobStatus extends PureComponent {
                                                     className={styles.litetoggle}
                                                     checked={this.state.isChecked}
                                                     size="md"
+                                                    style={{ 'min-width': '10rem' }}
                                                 />
                                             ) : <span />
                                         }


### PR DESCRIPTION
### Changes:

- Job override toggle now has a min-width of 10rem, so it does not squeeze under the right  block

### Tests:

- Any style changes to toggles anywhere else in the app? None
- The override toggle was hiding below 800px screen width. It doesn’t anymore.