### PR TITLE
Visualizer Regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
     "recompose": "~0.30.0",
     "redux": "~4.0.1",
     "redux-action": "^1.2.2",
+    "redux-batched-subscribe": "^0.1.6",
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.1.3",
     "redux-thunk": "^2.3.0",

--- a/src/app/reducers/controllerReducers.js
+++ b/src/app/reducers/controllerReducers.js
@@ -24,6 +24,7 @@ import { createReducer } from 'redux-action';
 import { ensurePositiveNumber } from 'ensure-type';
 import _get from 'lodash/get';
 import _mapValues from 'lodash/mapValues';
+import { MAX_TERMINAL_INPUT_ARRAY_SIZE } from 'app/lib/constants';
 import {
     TOOL_CHANGE,
     UPDATE_CONTROLLER_SETTINGS,
@@ -221,8 +222,12 @@ const reducer = createReducer(initialState, {
         };
     },
     [UPDATE_TERMINAL_HISTORY]: (payload, reducerState) => {
+        const newHistory = [...reducerState.terminalHistory, payload];
+        if (reducerState.terminalHistory === MAX_TERMINAL_INPUT_ARRAY_SIZE) {
+            newHistory.shift();
+        }
         return {
-            terminalHistory: payload
+            terminalHistory: newHistory
         };
     }
 });

--- a/src/app/store/redux/index.js
+++ b/src/app/store/redux/index.js
@@ -22,6 +22,8 @@
  */
 
 import { createStore, applyMiddleware, compose } from 'redux';
+import { batchedSubscribe } from 'redux-batched-subscribe';
+import debounce from 'lodash/debounce';
 import { END } from 'redux-saga';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
@@ -41,8 +43,9 @@ const configureStore = (preloadedState) => {
             applyMiddleware(thunk, sagaMiddleware, createLogger({ collapsed: true })),
         );
     }
+    const debounceNotify = debounce(notify => notify());
 
-    const store = createStore(mainReducer, preloadedState, enhancer);
+    const store = createStore(mainReducer, preloadedState, compose(enhancer, batchedSubscribe(debounceNotify)));
     store.close = () => store.dispatch(END);
     store.runSaga = sagaMiddleware.run;
     return store;

--- a/src/app/widgets/Console/Terminal.jsx
+++ b/src/app/widgets/Console/Terminal.jsx
@@ -68,7 +68,7 @@ class TerminalWrapper extends PureComponent {
     };
 
     state = {
-        terminalInputHistory: store.get('workspace.terminal.inputHistory', []), // to store user commands in the terminal
+        terminalInputHistory: store.get('workspace.terminal.inputHistory', []), // to store user input from the terminal
         terminalInputIndex: store.get('workspace.terminal.inputHistory')?.length
     }
 

--- a/src/app/widgets/Console/index.jsx
+++ b/src/app/widgets/Console/index.jsx
@@ -150,7 +150,6 @@ class ConsoleWidget extends PureComponent {
             }
 
             this.terminal.writeln(data);
-            this.terminal.updateTerminalHistory(data);
         }
     };
 

--- a/src/app/widgets/Console/index.jsx
+++ b/src/app/widgets/Console/index.jsx
@@ -150,6 +150,7 @@ class ConsoleWidget extends PureComponent {
             }
 
             this.terminal.writeln(data);
+            this.terminal.updateTerminalHistory(data);
         }
     };
 

--- a/src/app/widgets/JobStatus/JobStatus.jsx
+++ b/src/app/widgets/JobStatus/JobStatus.jsx
@@ -110,7 +110,7 @@ class JobStatus extends PureComponent {
                                                     className={styles.litetoggle}
                                                     checked={get(reduxStore.getState(), 'visualizer.jobOverrides.isChecked')}
                                                     size="md"
-                                                    style={{ 'min-width': '10rem' }}
+                                                    style={{ minWidth: '10rem' }}
                                                 />
                                             ) : <span />
                                         }


### PR DESCRIPTION
- added batched subscribe to redux enhancers to get rid of visualizer lag
- in redux dispatch, now sends the new terminal line only instead of the whole array
- terminalInputHistory in Terminal.jsx state only stores the user inputs now (just like it did before the terminal history overhaul)
- fixed styling error in JobStatus widget"