### PR TITLE
Wizard Improvements

### DIFF
--- a/src/app/components/Wizard/components/Actions.jsx
+++ b/src/app/components/Wizard/components/Actions.jsx
@@ -22,13 +22,26 @@
  */
 
 import React from 'react';
+import pubsub from 'pubsub-js';
+import { uniqueId } from 'lodash';
+import controller from 'app/lib/controller';
 import ToolModalButton from 'app/components/ToolModalButton/ToolModalButton';
-import { useWizardAPI } from 'app/components/Wizard/context';
+import { useWizardAPI, useWizardContext } from 'app/components/Wizard/context';
 import styles from '../index.styl';
 
 
 const Actions = ({ actions = [], stepIndex, substepIndex }) => {
-    const { markActionAsComplete, completeSubStep, scrollToActiveStep } = useWizardAPI();
+    const { markActionAsComplete, completeSubStep, scrollToActiveStep, setIsLoading } = useWizardAPI();
+    const { isLoading } = useWizardContext();
+    pubsub.subscribe('wizard:next', (msg, indexes) => {
+        const { stepIndex: stepIn, substepIndex: subStepIn } = indexes;
+        if (stepIn === stepIndex && subStepIn === substepIndex) {
+            markActionAsComplete(stepIndex, substepIndex);
+            const activeValues = completeSubStep(stepIndex, substepIndex);
+            scrollToActiveStep(activeValues);
+            setIsLoading(false);
+        }
+    });
     return (
         <>
             {
@@ -39,21 +52,29 @@ const Actions = ({ actions = [], stepIndex, substepIndex }) => {
                 {
                     actions.map((action, index) => {
                         const cbWithCompletion = () => {
-                            markActionAsComplete(stepIndex, substepIndex);
+                            setIsLoading(true);
+                            controller.command('wizard:step', stepIndex, substepIndex);
                             action.cb();
-                            completeSubStep();
-                            scrollToActiveStep();
                         };
                         return (
-                            <>
-                                {/* eslint-disable-next-line react/no-array-index-key */}
-                                <ToolModalButton key={`action-${index}`} onClick={cbWithCompletion} icon="fas fa-code">
-                                    {action.label}
-                                </ToolModalButton>
+                            <div key={`action-${uniqueId()}`}>
                                 {
-                                    (index !== actions.length - 1) && <span className={styles.orSpan}>OR</span>
+                                    isLoading
+                                        ? (
+                                            index === 0 &&
+                                                <span className={styles.loadingSpan}>Running</span>
+                                        ) : (
+                                            <>
+                                                <ToolModalButton onClick={cbWithCompletion} icon="fas fa-code" id="button-action">
+                                                    {action.label}
+                                                </ToolModalButton>
+                                                {
+                                                    (index !== actions.length - 1) && <span className={styles.orSpan}>OR</span>
+                                                }
+                                            </>
+                                        )
                                 }
-                            </>
+                            </div>
                         );
                     })
                 }

--- a/src/app/components/Wizard/components/Controls.jsx
+++ b/src/app/components/Wizard/components/Controls.jsx
@@ -30,14 +30,20 @@ const Controls = () => {
     const { completeSubStep, decrementStep, scrollToActiveStep, hasIncompleteActions } = useWizardAPI();
     return (
         <div className={styles.controls}>
-            <StepButton inverted onClick={decrementStep}>
+            <StepButton
+                inverted
+                onClick={() => {
+                    const activeValues = decrementStep();
+                    scrollToActiveStep(activeValues);
+                }}
+            >
                 <i className="fas fa-arrow-left" />
                 Back
             </StepButton>
             <StepButton
                 onClick={() => {
-                    completeSubStep();
-                    scrollToActiveStep();
+                    const activeValues = completeSubStep();
+                    scrollToActiveStep(activeValues);
                 }}
                 disabled={hasIncompleteActions()}
             >

--- a/src/app/components/Wizard/components/Instructions.jsx
+++ b/src/app/components/Wizard/components/Instructions.jsx
@@ -22,7 +22,8 @@
  */
 
 import React from 'react';
-import { /*useWizardAPI,*/ useWizardContext } from 'app/components/Wizard/context';
+import { uniqueId } from 'lodash';
+import { useWizardContext } from 'app/components/Wizard/context';
 import Substep from 'app/components/Wizard/components/Substep';
 import Controls from './Controls';
 import styles from '../index.styl';
@@ -44,7 +45,7 @@ const Instructions = () => {
                                     step.substeps.map((step, index) => (
                                         <Substep
                                             step={step}
-                                            key={`substep-${index}`}
+                                            key={`substep-${uniqueId()}`}
                                             index={index}
                                             stepIndex={stepIndex}
                                         />

--- a/src/app/components/Wizard/components/Step.jsx
+++ b/src/app/components/Wizard/components/Step.jsx
@@ -26,33 +26,33 @@ import styles from '../index.styl';
 
 const Step = ({ step, index = 1, active, complete }) => {
     const getTitleClass = () => {
-        if (active) {
-            return 'stepTitle-active';
-        }
         if (complete) {
             return 'stepTitle';
+        }
+        if (active) {
+            return 'stepTitle-active';
         }
 
         return 'stepTitle-future';
     };
     const getStepIndexClass = () => {
-        if (active) {
-            return 'stepIndex-active';
-        }
         if (complete) {
             return 'stepIndex-complete';
+        }
+        if (active) {
+            return 'stepIndex-active';
         }
         return 'stepIndex';
     };
 
     return (
-        <div className={active ? styles['step-active'] : styles.step}>
+        <div className={active && !complete ? styles['step-active'] : styles.step}>
             <div className={styles[getStepIndexClass()]}>
                 {complete ? <i className="fas fa-check" /> : (index + 1)}
             </div>
             <div className={styles.stepText}>
                 <span className={styles[getTitleClass()]}>Step {index + 1}</span>
-                <span className={active ? styles['stepperDescription-active'] : styles.stepperDescription}>{step.title}</span>
+                <span className={active && !complete ? styles['stepperDescription-active'] : styles.stepperDescription}>{step.title}</span>
             </div>
         </div>
     );

--- a/src/app/components/Wizard/components/Step.jsx
+++ b/src/app/components/Wizard/components/Step.jsx
@@ -26,33 +26,32 @@ import styles from '../index.styl';
 
 const Step = ({ step, index = 1, active, complete }) => {
     const getTitleClass = () => {
-        if (complete) {
-            return 'stepTitle';
-        }
         if (active) {
             return 'stepTitle-active';
         }
-
+        if (complete) {
+            return 'stepTitle';
+        }
         return 'stepTitle-future';
     };
     const getStepIndexClass = () => {
-        if (complete) {
-            return 'stepIndex-complete';
-        }
         if (active) {
             return 'stepIndex-active';
+        }
+        if (complete) {
+            return 'stepIndex-complete';
         }
         return 'stepIndex';
     };
 
     return (
-        <div className={active && !complete ? styles['step-active'] : styles.step}>
+        <div className={active ? styles['step-active'] : styles.step}>
             <div className={styles[getStepIndexClass()]}>
                 {complete ? <i className="fas fa-check" /> : (index + 1)}
             </div>
             <div className={styles.stepText}>
                 <span className={styles[getTitleClass()]}>Step {index + 1}</span>
-                <span className={active && !complete ? styles['stepperDescription-active'] : styles.stepperDescription}>{step.title}</span>
+                <span className={active ? styles['stepperDescription-active'] : styles.stepperDescription}>{step.title}</span>
             </div>
         </div>
     );

--- a/src/app/components/Wizard/components/Stepper.jsx
+++ b/src/app/components/Wizard/components/Stepper.jsx
@@ -16,7 +16,7 @@ const Stepper = () => {
                         key={uniqueId()}
                         index={index}
                         active={activeStep === index}
-                        complete={completedStep > index}
+                        complete={completedStep >= index}
                     />
                 ))
             }

--- a/src/app/components/Wizard/components/Stepper.jsx
+++ b/src/app/components/Wizard/components/Stepper.jsx
@@ -1,22 +1,22 @@
 import React from 'react';
+import { uniqueId } from 'lodash';
 import { useWizardContext } from 'app/components/Wizard/context';
 //import PropTypes from 'prop-types';
 import Step from './Step';
 import styles from '../index.styl';
 
 const Stepper = () => {
-    const { steps, activeStep } = useWizardContext();
+    const { steps, completedStep, activeStep } = useWizardContext();
     return (
         <div className={styles.stepperWrapper}>
             {
                 steps.map((step, index) => (
                     <Step
                         step={step}
-                        key={index}
+                        key={uniqueId()}
                         index={index}
                         active={activeStep === index}
-                        complete={activeStep > index}
-                        activeStep={activeStep}
+                        complete={completedStep > index}
                     />
                 ))
             }

--- a/src/app/components/Wizard/components/Substep.jsx
+++ b/src/app/components/Wizard/components/Substep.jsx
@@ -29,12 +29,17 @@ import Actions from './Actions';
 import styles from '../index.styl';
 
 const Substep = ({ step, index, stepIndex }) => {
-    const { activeSubstep, activeStep } = useWizardContext();
+    const { activeSubstep, activeStep, completedStep, completedSubStep } = useWizardContext();
 
-    // State calculation
-    const stepComplete = stepIndex < activeStep || ((activeStep === stepIndex) && activeSubstep > index);
-    const futureStep = stepIndex > activeStep || ((activeStep === stepIndex) && activeSubstep < index);
+    // // State calculation
+    /*
+        complete is:
+        - on or before the last completed step
+        - on the step after the completed one, but on a substep that is on or before a completed substep
+    */
+    const stepComplete = (stepIndex <= completedStep || (stepIndex === completedStep + 1 && index <= completedSubStep));
     const stepIsActive = stepIndex === activeStep && index === activeSubstep;
+    const futureStep = !stepIsActive && !stepComplete;
 
     return (
         <div className={cx(styles.substepWrapper,

--- a/src/app/components/Wizard/context.js
+++ b/src/app/components/Wizard/context.js
@@ -22,6 +22,7 @@
  */
 
 import React, { createContext, useContext, useState, useMemo } from 'react';
+import _ from 'lodash';
 
 const WizardContext = createContext({});
 const WizardAPI = createContext({});
@@ -33,6 +34,8 @@ const WizardAPI = createContext({});
  * @returns {JSX.Element}
  */
 export const WizardProvider = ({ children }) => {
+    const [completedStep, setCompletedStep] = useState(-1);
+    const [completedSubStep, setCompletedSubStep] = useState(-1);
     const [activeStep, setActiveStep] = useState(0);
     const [activeSubstep, setActiveSubstep] = useState(0);
     const [title, setTitle] = useState('Wizard');
@@ -40,6 +43,7 @@ export const WizardProvider = ({ children }) => {
     const [visible, setVisible] = useState(false);
     const [stepCount, setStepCount] = useState(0);
     const [minimized, setMinimized] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
 
     // Memoized API for context, can be fetched separate to data context
@@ -47,6 +51,7 @@ export const WizardProvider = ({ children }) => {
         setWizardSteps: (steps) => setSteps(steps),
         setTitle: (title) => setTitle(title),
         setVisible: (b) => setVisible(b),
+        setIsLoading: (state) => setIsLoading(state),
         getStepTitle: (index) => {
             const step = steps[index];
             if (!step) {
@@ -68,42 +73,110 @@ export const WizardProvider = ({ children }) => {
             }
         },
         decrementStep: () => {
+            // first check if we have substeps
+            if (activeSubstep > 0) {
+                const decrementedSubStep = activeSubstep - 1;
+                setActiveSubstep(decrementedSubStep);
+                return {
+                    activeStep: activeStep,
+                    activeSubstep: decrementedSubStep
+                };
+            }
+            // if not, go back to previous step
             const decrementedStep = activeStep - 1;
             if (decrementedStep >= 0) {
                 setActiveStep(decrementedStep);
+                // make sure we dont go to the very beginning of the step
+                // go to the last substep
+                const step = steps[decrementedStep];
+                const numberOfSubSteps = step.substeps.length;
+                const newSubstep = numberOfSubSteps - 1;
+                setActiveSubstep(newSubstep);
+                return {
+                    activeStep: decrementedStep,
+                    activeSubstep: newSubstep
+                };
             }
+            return {};
         },
         toggleMinimized: (state) => {
             setMinimized(!state);
         },
-        completeSubStep: () => {
+        completeSubStep: (stepIndex = activeStep, substepIndex = activeSubstep) => {
+            // check that more steps can be completed
             const maxStepIndex = stepCount - 1;
-            if (activeStep > maxStepIndex) {
-                return;
+            if (stepIndex > maxStepIndex) {
+                return {};
             }
-            const step = steps[activeStep];
+            let returnValues = {};
+
+            // ACTIVE****
+            const step = steps[stepIndex];
             const numberOfSubSteps = step.substeps.length;
-            const nextStep = activeSubstep + 1;
+            const nextStep = substepIndex + 1;
             // Completed all substeps, move to next step
             if (nextStep >= numberOfSubSteps) {
-                setActiveStep(activeStep + 1);
+                setActiveStep(stepIndex + 1);
                 setActiveSubstep(0);
-                if (activeStep >= maxStepIndex) {
+                returnValues = {
+                    activeStep: stepIndex + 1,
+                    activeSubstep: 0
+                };
+                if (stepIndex >= maxStepIndex) {
+                    // reset values
                     setVisible(false);
+                    setCompletedStep(-1);
+                    setCompletedSubStep(-1);
+                    setActiveStep(0);
+                    setActiveSubstep(0);
+                    setTitle('Wizard');
+                    setSteps([]);
+                    setStepCount(0);
+                    setMinimized(false);
+                    return {};
                 }
-                return;
+            } else {
+                // didnt complete substeps, so increment substep only
+                setActiveSubstep(nextStep);
+                returnValues = {
+                    activeStep: stepIndex,
+                    activeSubstep: nextStep
+                };
             }
-            setActiveSubstep(nextStep);
             // close window on everything done.
             if (activeStep >= maxStepIndex) {
+                // reset values
                 setVisible(false);
+                setCompletedStep(-1);
+                setCompletedSubStep(-1);
+                setActiveStep(0);
+                setActiveSubstep(0);
+                setTitle('Wizard');
+                setSteps([]);
+                setStepCount(0);
+                setMinimized(false);
+                return {};
             }
+
+            // check that the step we are completed has not already been completed
+            if ((completedStep >= stepIndex || (stepIndex === completedStep + 1 && completedSubStep >= substepIndex))) {
+                return returnValues;
+            }
+
+            // COMPLETED****
+            if (nextStep >= numberOfSubSteps) {
+                setCompletedStep(stepIndex);
+                setCompletedSubStep(-1);
+            } else {
+                setCompletedSubStep(substepIndex);
+            }
+            return returnValues;
         },
         isSubstepCompleted: (stepIndex, substepIndex) => {
-            if (activeStep > stepIndex) {
+            if (completedStep > stepIndex) {
                 return true;
             }
-            return activeSubstep > substepIndex && stepIndex === activeStep;
+            return completedSubStep > substepIndex && stepIndex === completedStep;
         },
         load: (instructions, title) => {
             if (!instructions || !instructions.steps) {
@@ -123,7 +196,15 @@ export const WizardProvider = ({ children }) => {
             setActiveStep(0);
             setVisible(true);
         },
-        scrollToActiveStep: () => {
+        // you must pass an object with activeStep and activeSubstep to this function.
+        // this is bc if you change those values before running this function, they won't update in time,
+        // and you will get the old values.
+        // completeSubStep and decrementStep both return the new values they set that can then be passed to this function
+        scrollToActiveStep: (activeValues) => {
+            if (_.isEmpty(activeValues)) {
+                return;
+            }
+            const { activeStep, activeSubstep } = activeValues;
             if (activeStep > steps.length) {
                 return;
             }
@@ -136,6 +217,8 @@ export const WizardProvider = ({ children }) => {
             const nextSteps = [...steps];
             nextSteps[stepIndex].substeps[substepIndex].actionTaken = true;
             setSteps(nextSteps);
+            setActiveStep(stepIndex);
+            setActiveSubstep(substepIndex);
         },
         hasIncompleteActions: () => {
             const step = steps[activeStep];
@@ -149,10 +232,24 @@ export const WizardProvider = ({ children }) => {
 
             return substep.actions.length > 0 && substep.actionTaken === false;
         }
-    }), [setActiveStep, setSteps, setTitle, setVisible, steps, stepCount, activeStep, activeSubstep, setMinimized, setActiveSubstep]);
+    }), [
+        setActiveStep,
+        setSteps,
+        setTitle,
+        setVisible,
+        steps,
+        stepCount,
+        activeStep,
+        activeSubstep,
+        completedStep,
+        completedSubStep,
+        isLoading,
+        setMinimized,
+        setActiveSubstep
+    ]);
 
     return (
-        <WizardContext.Provider value={{ steps, activeStep, activeSubstep, title, visible, stepCount, minimized }}>
+        <WizardContext.Provider value={{ steps, activeStep, activeSubstep, completedStep, completedSubStep, title, visible, stepCount, minimized, isLoading }}>
             <WizardAPI.Provider value={api}>
                 {children}
             </WizardAPI.Provider>

--- a/src/app/components/Wizard/index.styl
+++ b/src/app/components/Wizard/index.styl
@@ -333,6 +333,27 @@ button-mixin($color) {
 
 }
 
+.loadingSpan {
+  font-size: 2rem;
+  font-weight: bold;
+}
+.loadingSpan:after {
+    animation: dots 0.5s linear infinite;
+    content: '';
+  }
+
+  @keyframes dots {
+    0%, 20% {
+      content: '.';
+    }
+    40% {
+      content: '..';
+    }
+    60%, 100% {
+      content: '...';
+    }
+}
+
 .subHeading {
   padding: 0;
   margin: 0;

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -89,8 +89,7 @@ const renderPage = () => {
                     </Switch>
                 </Router>
             </GridSystemProvider>
-        </ReduxProvider>,
-        container
+        </ReduxProvider>
     );
 };
 

--- a/src/app/lib/controller.js
+++ b/src/app/lib/controller.js
@@ -98,7 +98,8 @@ class Controller {
         'homing:flag': [],
         'electronErrors:errorList': [],
         'grbl:iSready': [],
-        'sender:M0M1': []
+        'sender:M0M1': [],
+        'wizard:next': []
     };
 
     context = {

--- a/src/app/sagas/controllerSagas.js
+++ b/src/app/sagas/controllerSagas.js
@@ -525,6 +525,10 @@ export function* initialize() {
         }
     });
 
+    controller.addListener('wizard:next', (stepIndex, substepIndex) => {
+        pubsub.publish('wizard:next', { stepIndex, substepIndex });
+    });
+
     yield null;
 }
 

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1786,6 +1786,12 @@ class GrblController {
                 this.command('feeder:start');
                 this.runPostChangeHook();
             },
+            'wizard:step': () => {
+                const [stepIndex, substepIndex] = args;
+                this.feederCB = () => {
+                    this.emit('wizard:next', stepIndex, substepIndex);
+                };
+            }
         }[cmd];
 
         if (!handler) {


### PR DESCRIPTION
- prevent other actions from being taken until current running action is complete
	- feederCB used to run step finished code once gcode is finished running
	- when gcode is being run, buttons are replaced with dynamic "Running..." text to show user that something is being run on the backend
- fixed flow of wizard
	- `completeStep` and `completeSubStep` variables now added to keep track of completed steps
		- completed steps are whatever steps the user has finished running code for/have pressed continue on
		- if the user has finished a step, it will stay marked as completed, even if they press back
		- active step exists to show the current highlighted step. wizard auto scrolls to this step
	- back button decrements active step only
	- continue button marks the newly completed step and moves the active state up
- fixed some stylint errors