### PR TITLE
Mi 892 dev remote mode configuration   use our themed confirm dialog, use our themed buttons, remove bootstrap buttons/confirm, general modal styling

### DIFF
--- a/src/app/components/ConfirmationDialog/ConfirmationDialog.jsx
+++ b/src/app/components/ConfirmationDialog/ConfirmationDialog.jsx
@@ -53,7 +53,7 @@ const ConfirmationDialog = () => {
             setOnConfirm(() => options.onConfirm);
             setConfirmLabel(options.confirmLabel);
             setCancelLabel(options.cancelLabel);
-            setShow(true);
+            setShow(options.show);
         });
     });
 

--- a/src/app/components/ConfirmationDialog/ConfirmationDialogLib.js
+++ b/src/app/components/ConfirmationDialog/ConfirmationDialogLib.js
@@ -35,7 +35,8 @@ export const Confirm = (options = {}) => {
         onClose = null,
         onConfirm = null,
         confirmLabel = 'Confirm',
-        cancelLabel = 'Cancel'
+        cancelLabel = 'Cancel',
+        show = true,
     } = options;
     pubsub.publish('dialog:new', {
         title: title,
@@ -44,6 +45,7 @@ export const Confirm = (options = {}) => {
         onClose: onClose,
         onConfirm: onConfirm,
         confirmLabel: confirmLabel,
-        cancelLabel: cancelLabel
+        cancelLabel: cancelLabel,
+        show: show
     });
 };

--- a/src/app/components/HeadlessIndicator/index.jsx
+++ b/src/app/components/HeadlessIndicator/index.jsx
@@ -24,7 +24,7 @@
 import React, { useState, useEffect } from 'react';
 import reduxStore from 'app/store/redux';
 import Switch from '@mui/material/Switch';
-import Button from '@mui/material/Button';
+import Button from 'app/components/FunctionButton/FunctionButton';
 import Creatable from 'react-select/creatable';
 import _ from 'lodash';
 import { Toaster, TOASTER_INFO } from 'app/lib/toaster/ToasterLib';
@@ -312,7 +312,7 @@ const HeadlessIndicator = ({ address, port }) => {
                     </div>
                     <div className={styles.footer}>
                         <div className={styles.buttonWrapper}>
-                            <Button variant="contained" style={{ backgroundColor: '#3e85c7' }} onClick={updateRemotePreferences}>OK</Button>
+                            <Button primary onClick={updateRemotePreferences}>OK</Button>
                         </div>
                     </div>
                 </div>

--- a/src/app/components/HeadlessIndicator/index.jsx
+++ b/src/app/components/HeadlessIndicator/index.jsx
@@ -28,6 +28,7 @@ import Button from '@mui/material/Button';
 import Creatable from 'react-select/creatable';
 import _ from 'lodash';
 import { Toaster, TOASTER_INFO } from 'app/lib/toaster/ToasterLib';
+import { Confirm } from 'app/components/ConfirmationDialog/ConfirmationDialogLib';
 import actions from './apiActions';
 import Tooltip from '../TooltipCustom/ToolTip';
 import DialogBox from './DialogBox';
@@ -317,25 +318,15 @@ const HeadlessIndicator = ({ address, port }) => {
                 </div>
             </DialogBox>
             {/* Restart confirmation dialog */}
-            <DialogBox
-                show={showConfirmation}
+            <Confirm
                 title="Restart app?"
-                onClose={() => {
-                    setShowConfirmation(false);
-                }}
-            >
-                <div className={styles.confirmationWrapper}>
-                    <div className={styles.warning}>
-                        <b>Note:</b> You are about to restart the app with new settings. Please make sure you save all the changes before you proceed.
-                    </div>
-                    <div className={styles.footer}>
-                        <div className={styles.buttonWrapper}>
-                            <Button variant="contained" style={{ backgroundColor: '#f9a13b' }} onClick={() => handleAppRestart('cancel')}>Restart later</Button>
-                            <Button variant="contained" style={{ backgroundColor: '#3e85c7' }} onClick={() => handleAppRestart('ok')}>Restart now</Button>
-                        </div>
-                    </div>
-                </div>
-            </DialogBox>
+                content="Note: You are about to restart the app with new settings. Please make sure you save all the changes before you proceed."
+                onClose={() => handleAppRestart('cancel')}
+                onConfirm={() => handleAppRestart('ok')}
+                confirmLabel="Restart now"
+                cancelLabel="Restart later"
+                show={showConfirmation}
+            />
         </div>
     );
 };

--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -340,7 +340,7 @@ class Header extends PureComponent {
                             widgetId="connection"
                         />
                         {
-                            !isElectron() && <HeadlessIndicator {...hostInformation} />
+                            isElectron() && <HeadlessIndicator {...hostInformation} />
                         }
                     </div>
                     { !mobile && <NavSidebar /> }

--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -340,7 +340,7 @@ class Header extends PureComponent {
                             widgetId="connection"
                         />
                         {
-                            isElectron() && <HeadlessIndicator {...hostInformation} />
+                            !isElectron() && <HeadlessIndicator {...hostInformation} />
                         }
                     </div>
                     { !mobile && <NavSidebar /> }


### PR DESCRIPTION
### Changes:
- Changed the remote restart confirm dialog to the app default confirm component
- Modified/ added a show flag to the existing Confirm component to control it from the parent
- Changed buttons to app default

### Tests:
- Frontend or server console errors/warnings? **NO**
- Is the extra flag in Confirm Component affecting the app anywhere else? For ex - restoring app settings, etc. **NO**