### PR TITLE
Mi 885 dev about section doesn't fill space in preferences for release notes

### DIFF
--- a/src/app/containers/Preferences/About/MainArea.js
+++ b/src/app/containers/Preferences/About/MainArea.js
@@ -8,7 +8,7 @@ import releases from './releases.json';
 
 const MainArea = () => {
     return (
-        <div style={{ height: "80%" }}>
+        <div style={{ height: "540px" }}>
             <div className={styles.section} style={{ height: "10%" }}>
                 <p style={{ marginTop: '1rem' }}>
                     gSender is a a free GRBL CNC control software that is


### PR DESCRIPTION
### Changes:

The Release Notes div now has a fixed size of 540px so it doesn’t scale when the screen size changes and it also covers the entire space it was supposed to.
<img width="950" alt="image" src="https://user-images.githubusercontent.com/39333609/207963381-03a2d843-5f42-4ad5-9af2-6e9205fd8866.png">

### Tests:

- Checked on different screen sizes on the dev tool. The size doesn’t change.
- Tested for style leaks - the changes do not affect any other components.