### PR TITLE
Mi 888 dev mobile responsiveness in css on phone

### DIFF
--- a/src/app/components/NavLogo/index.styl
+++ b/src/app/components/NavLogo/index.styl
@@ -58,3 +58,9 @@ animationTimingFunction: cubic-bezier(0.8, 0, 1, 1);
 animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);
 }
 }
+
+@media (max-width:599px) {
+  .NavLogo{
+    display: none;  
+  }
+}

--- a/src/app/components/Widget/index.styl
+++ b/src/app/components/Widget/index.styl
@@ -131,6 +131,9 @@ PRIMARY_COLOR = #3e85c7;
         padding: 15px;
         min-width: 330px;
         background-color: #e5e7eb;
+        @media (max-width: 599px) {
+            padding: 10px;
+        }
     }
 
     .widget-controls {

--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -321,7 +321,7 @@ class Header extends PureComponent {
     }
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width / window.visualViewport.height <= 0.5625;
+        const isMobile = window.visualViewport.width <= 599;
         this.setState({
             mobile: isMobile
         });

--- a/src/app/containers/NavSidebar/index.styl
+++ b/src/app/containers/NavSidebar/index.styl
@@ -85,7 +85,7 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 599px) {
   .Sidebar{
     display: none;
   }

--- a/src/app/containers/NavSidebar/index.styl
+++ b/src/app/containers/NavSidebar/index.styl
@@ -84,3 +84,10 @@
     color: #9CA3AF;
   }
 }
+
+@media (max-width: 600px) {
+  .Sidebar{
+    display: none;
+  }
+  
+}

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -301,12 +301,11 @@ class Workspace extends PureComponent {
     };
 
     updateScreenSize = () => {
-        const ratio = window.visualViewport.width / window.visualViewport.height;
-        const isMobile = ratio <= 0.5625; //9:16 ratio
+        const isMobile = window.visualViewport.width <= 599;
         this.setState({
             mobile: isMobile
         });
-        const isTablet = ratio <= 1 && ratio > 0.5625; //width smaller than height and wider than a phone
+        const isTablet = window.visualViewport.width > 599; //width smaller than height and wider than a phone
         this.setState({
             tablet: isTablet
         });

--- a/src/app/containers/Workspace/index.styl
+++ b/src/app/containers/Workspace/index.styl
@@ -44,6 +44,9 @@
     line-height: 1.5rem;
     background: none;
     position: relative;
+    @media (max-width: 599px) {
+    overflow-y: visible;
+    }
     &::-webkit-scrollbar {
         display: none;
     }
@@ -86,7 +89,7 @@
     }
 
     .workspace-table-mobile {
-        overflow-y: scroll;
+        overflow-y: auto;
         display: flex;
         flex-direction: column;
         flex-grow: 1;
@@ -95,6 +98,9 @@
         max-height: 100%;
         background-color: #d1d5db
         position: relative;
+         @media (max-width: 599px) {
+            height: 100%;
+        }
     }
 
     .workspace-table-row {
@@ -114,7 +120,7 @@
         flex-grow: 1;
         box-sizing border-box;
         padding: 10px 15px;
-        height: 100%;
+        min-height: fit-content;
         width: 100%;
         justify-content: center;
         align-content: center;
@@ -148,6 +154,10 @@
         min-width: 365px;
         max-width: 500px;
         overflow: hidden;
+        @media (max-width: 599px) {
+            min-width: auto;
+            max-width: auto;
+        }
         &.hidden {
             display: none;
         }

--- a/src/app/containers/Workspace/index.styl
+++ b/src/app/containers/Workspace/index.styl
@@ -173,3 +173,9 @@
         width: 66%;
     }
 }
+
+@media (max-width: 599px) {
+    .primary-container{
+        min-height: 650px;
+    }
+}

--- a/src/app/containers/Workspace/widgets.styl
+++ b/src/app/containers/Workspace/widgets.styl
@@ -52,7 +52,7 @@
     min-width: 360px;
     background-color: #d1d5db;
     width: auto;
-    @media only screen and (min-width: 390px) and (max-width: 768px) {
+    @media (max-width: 600px) {
         display: none;
     }
     @media (min-width: 1921px) {

--- a/src/app/containers/Workspace/widgets.styl
+++ b/src/app/containers/Workspace/widgets.styl
@@ -27,7 +27,9 @@
     grid-template-rows: minmax(0, 32fr) minmax(0, 38fr) minmax(0, 30fr);
     grid-gap: 0.5rem;
     width: 100%;
-    // margin-top: 1vh;
+    @media (max-width: 599px) {
+            grid-template: none;
+    }
     :global {
         // Class name for the chosen item
         .sortable-chosen {

--- a/src/app/containers/Workspace/widgets.styl
+++ b/src/app/containers/Workspace/widgets.styl
@@ -52,7 +52,7 @@
     min-width: 360px;
     background-color: #d1d5db;
     width: auto;
-    @media (max-width: 600px) {
+    @media (max-width: 599px) {
         display: none;
     }
     @media (min-width: 1921px) {

--- a/src/app/widgets/JogControl/index.styl
+++ b/src/app/widgets/JogControl/index.styl
@@ -111,6 +111,9 @@
     display: grid;
     grid-gap: 2rem;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    @media (max-width: 599px) {
+        grid-gap: 5px;
+    }
 }
 
 .controlGroupLabel {
@@ -211,6 +214,9 @@
     height: 100%;
     align-self: center;
     align-items: center;
+    @media (max-width: 599px) {
+        display: block;
+    }
 }
 
 .xy-keys {
@@ -221,6 +227,10 @@
 
     @media (max-height: 820px) {
         width: 43%;
+    }
+    @media (max-width: 599px) {
+        width: 91%;
+        grid-gap: 12px;
     }
 }
 
@@ -245,6 +255,14 @@
 
     button + button {
         margin-left: 0;
+    }
+    @media (max-width: 599px) {
+        display: flex;
+        width: 89%;
+        margin: 1rem;
+        button + button {
+            margin-left: 12px;
+        }
     }
 }
 

--- a/src/app/widgets/Location/DisplayPanel.jsx
+++ b/src/app/widgets/Location/DisplayPanel.jsx
@@ -281,56 +281,58 @@ class DisplayPanel extends PureComponent {
         return (
             <Panel className={styles.displayPanel}>
                 <div className={styles.locationWrapper}>
-                    <table className={styles.displaypanelTable}>
-                        <tbody>
-                            {hasAxisX && this.renderAxis(AXIS_X)}
-                            {hasAxisY && this.renderAxis(AXIS_Y)}
-                            {hasAxisZ && this.renderAxis(AXIS_Z)}
-                        </tbody>
-                    </table>
-                    <div className={styles.controlButtons}>
-                        <FunctionButton
-                            onClick={() => {
-                                const wcs = actions.getWorkCoordinateSystem();
-                                const p = {
-                                    'G54': 1,
-                                    'G55': 2,
-                                    'G56': 3,
-                                    'G57': 4,
-                                    'G58': 5,
-                                    'G59': 6
-                                }[wcs] || 0;
+                    <div className={styles.alwaysAvailable}>
+                        <table className={styles.displaypanelTable}>
+                            <tbody>
+                                {hasAxisX && this.renderAxis(AXIS_X)}
+                                {hasAxisY && this.renderAxis(AXIS_Y)}
+                                {hasAxisZ && this.renderAxis(AXIS_Z)}
+                            </tbody>
+                        </table>
+                        <div className={styles.controlButtons}>
+                            <FunctionButton
+                                onClick={() => {
+                                    const wcs = actions.getWorkCoordinateSystem();
+                                    const p = {
+                                        'G54': 1,
+                                        'G55': 2,
+                                        'G56': 3,
+                                        'G57': 4,
+                                        'G58': 5,
+                                        'G59': 6
+                                    }[wcs] || 0;
 
-                                controller.command('gcode', `G10 L20 P${p} X0 Y0 Z0`);
-                                pubsub.publish('softlimits:check', 0);
-                            }}
-                            disabled={!canClick}
-                        >
-                            <i className="fas fa-bullseye" />
-                            Zero All
-                        </FunctionButton>
-                        <FunctionButton
-                            onClick={() => {
-                                const modal = (units === METRIC_UNITS) ? 'G21' : 'G20';
-                                if (safeRetractHeight !== 0) {
-                                    if (homingEnabled) {
-                                        controller.command('gcode:safe', `G53 G0 Z${(Math.abs(safeRetractHeight) * -1)}`, modal);
-                                    } else {
-                                        controller.command('gcode', 'G91');
-                                        controller.command('gcode:safe', `G0 Z${safeRetractHeight}`, modal); // Retract Z when moving across workspace
+                                    controller.command('gcode', `G10 L20 P${p} X0 Y0 Z0`);
+                                    pubsub.publish('softlimits:check', 0);
+                                }}
+                                disabled={!canClick}
+                            >
+                                <i className="fas fa-bullseye" />
+                                Zero All
+                            </FunctionButton>
+                            <FunctionButton
+                                onClick={() => {
+                                    const modal = (units === METRIC_UNITS) ? 'G21' : 'G20';
+                                    if (safeRetractHeight !== 0) {
+                                        if (homingEnabled) {
+                                            controller.command('gcode:safe', `G53 G0 Z${(Math.abs(safeRetractHeight) * -1)}`, modal);
+                                        } else {
+                                            controller.command('gcode', 'G91');
+                                            controller.command('gcode:safe', `G0 Z${safeRetractHeight}`, modal); // Retract Z when moving across workspace
+                                        }
                                     }
-                                }
 
-                                controller.command('gcode', 'G90');
-                                controller.command('gcode', 'G0 X0 Y0'); //Move to Work Position Zero
-                            }}
-                            disabled={!canClick}
-                            className={styles.fontMonospace}
-                            primary
-                        >
-                            <i className="fas fa-chart-line" />
-                            Go XY0
-                        </FunctionButton>
+                                    controller.command('gcode', 'G90');
+                                    controller.command('gcode', 'G0 X0 Y0'); //Move to Work Position Zero
+                                }}
+                                disabled={!canClick}
+                                className={styles.fontMonospace}
+                                primary
+                            >
+                                <i className="fas fa-chart-line" />
+                                Go XY0
+                            </FunctionButton>
+                        </div>
                     </div>
 
                     {

--- a/src/app/widgets/Location/components/MachinePositionInput.styl
+++ b/src/app/widgets/Location/components/MachinePositionInput.styl
@@ -46,3 +46,10 @@
   -webkit-appearance: none;
   margin: 0;
 }
+
+@media (max-width: 599px) {
+  .position-input{
+    font-size: 1.1rem;  
+  }
+  
+}

--- a/src/app/widgets/Location/components/MachinePositionInput.styl
+++ b/src/app/widgets/Location/components/MachinePositionInput.styl
@@ -46,10 +46,3 @@
   -webkit-appearance: none;
   margin: 0;
 }
-
-@media (max-width: 599px) {
-  .position-input{
-    font-size: 1.1rem;  
-  }
-  
-}

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -298,3 +298,9 @@
     width: 90px;
     text-align: center;
 }
+
+@media (max-width: 599px) {
+    .axes-position-label{
+        font-size: 1.1rem;    
+    }
+}

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -35,6 +35,11 @@
     }
 }
 
+.alwaysAvailable{
+    display: flex;
+    width: 100%;
+}
+
 .hideHoming {
     display: none;
 }
@@ -49,7 +54,6 @@
 .col-space {
     margin-right: 5px;
 }
-
 .position-label {
     display: inline;
     border: 1px solid #9CA3AF;
@@ -93,6 +97,9 @@
     width: 100%;
     display: flex;
     justify-content: space-around;
+    @media (max-width: 599px) {
+        display: block;
+    }
 }
 .machine-position {
     width: 15ch;
@@ -104,6 +111,12 @@
     display: grid;
     grid-template-columns: repeat(3,minmax(0,1fr));
     height: max-content;
+    margin: auto;
+    @media (max-width: 599px) {
+        margin-top: 1rem;
+        width: 30%;
+        height: 40%
+    }
 }
 
 .quickPositionButton {
@@ -297,10 +310,4 @@
     font-size: 0.9rem;
     width: 90px;
     text-align: center;
-}
-
-@media (max-width: 599px) {
-    .axes-position-label{
-        font-size: 1.1rem;    
-    }
 }

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -114,7 +114,7 @@
     margin: auto;
     @media (max-width: 599px) {
         margin-top: 1rem;
-        width: 30%;
+        width: 50%;
         height: 40%
     }
 }
@@ -163,6 +163,11 @@
         transform: translateX(5%) rotate(45deg);
         width: 300%;
         text-align: left;
+        @media (max-width: 599px) {
+            width: 277%;
+            transform: translateX(9%) rotate(45deg);
+            font-size: 1.4rem !important;
+        }
     }
 }
 .QPBL {
@@ -180,6 +185,11 @@
          transform: translateX(-72%) rotate(-45deg);
         width: 300%;
         text-align: right;
+        @media (max-width: 599px) {
+            width: 271%;
+            transform: translateX(-73%) rotate(-45deg);
+            font-size: 1.4rem !important;
+        }
     }
 }
 .QPFR {
@@ -200,6 +210,11 @@
         position: relative;
         bottom: 8px;
 		display: block;
+        @media (max-width: 599px) {
+            width: 97%;
+            transform: translateX(1%) rotate(135deg);
+            font-size: 1.4rem !important;
+        }
     }
 }
 .QPFL {
@@ -221,6 +236,11 @@
         bottom: 8px;
 		display: block;
 		text-align: right;
+        @media (max-width: 599px) {
+            width: 99%;
+            transform: translate(3%) rotate(225deg)
+            font-size: 1.4rem !important;
+        }
 
     }
 }

--- a/src/app/widgets/NavbarConnection/Index.styl
+++ b/src/app/widgets/NavbarConnection/Index.styl
@@ -247,3 +247,9 @@
   width: 100%;
   min-height: 50px;
 }
+
+@media (max-width: 599px) {
+  .NavbarConnection{
+    margin: auto;  
+  }
+}

--- a/src/app/widgets/NavbarConnection/Index.styl
+++ b/src/app/widgets/NavbarConnection/Index.styl
@@ -32,7 +32,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.25rem 1rem;
-  min-width: 325px;
+  min-width: 312px;
   min-height: 50px;
 }
 

--- a/src/app/widgets/NavbarConnection/NavbarConnection.jsx
+++ b/src/app/widgets/NavbarConnection/NavbarConnection.jsx
@@ -66,7 +66,7 @@ class NavbarConnection extends PureComponent {
     }
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width / window.visualViewport.height <= 0.5625;
+        const isMobile = window.visualViewport.width <= 599;
         this.setState({
             mobile: isMobile
         });
@@ -124,7 +124,7 @@ class NavbarConnection extends PureComponent {
         const { connected, ports, connecting, baudrate, controllerType, alertMessage, port, unrecognizedPorts, showUnrecognized } = state;
         const { isActive } = this.state;
         const iconState = this.getIconState(connected, connecting, alertMessage);
-        const isMobile = window.visualViewport.width / window.visualViewport.height <= 0.5625;
+        const isMobile = window.visualViewport.width <= 599;
 
         return (
             <div

--- a/src/app/widgets/Probe/RunProbe.jsx
+++ b/src/app/widgets/Probe/RunProbe.jsx
@@ -23,7 +23,7 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import Modal from 'app/components/Modal';
+import Modal from '@trendmicro/react-modal';
 import i18n from 'app/lib/i18n';
 import combokeys from 'app/lib/combokeys';
 import gamepad, { runAction } from 'app/lib/gamepad';
@@ -187,7 +187,7 @@ class RunProbe extends PureComponent {
         const { connectionMade } = this.state;
 
         return (
-            <Modal disableOverlay onClose={actions.closeModal}>
+            <Modal disableOverlay onClose={actions.closeModal} className={styles.modalOverride}>
                 <Modal.Header className={styles.modalHeader}>
                     <Modal.Title>{i18n._(`Probe - ${probeCommand.id}`)}</Modal.Title>
                 </Modal.Header>

--- a/src/app/widgets/Probe/index.styl
+++ b/src/app/widgets/Probe/index.styl
@@ -91,6 +91,9 @@
     span {
         margin-top: 10px;
     }
+    @media (max-width: 599px) {
+        margin-top: 1rem;
+    }
 }
 .probeIndicator {
     width: 30px;
@@ -126,6 +129,18 @@
     min-height: 200px;
     display: flex;
     flex-direction: row;
+    @media (max-width: 599px) {
+        width: 100%;
+        display: flex; 
+        flex-direction: column;
+    }
+}
+
+.modalOverride{
+    @media (max-width: 599px) {
+        min-width: 20% !important;
+        max-width: 80% !important;
+    }
 }
 
 .left {
@@ -133,11 +148,19 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+     @media (max-width: 599px) {
+        width: 100%;
+        order: 2;
+    }
 }
 .right {
     width: 40%;
     display: flex;
     flex-direction: column;
+    @media (max-width: 599px) {
+        margin: auto;
+        margin-bottom: 1rem;
+    }
 }
 
 .probe-timer {
@@ -158,6 +181,9 @@
     > img {
         width: 15vh;
         margin: 0 auto;
+        @media (max-width: 599px) {
+            width: 80%;
+        }
     }
 }
 

--- a/src/app/widgets/Visualizer/index.styl
+++ b/src/app/widgets/Visualizer/index.styl
@@ -47,6 +47,7 @@
 
 .visualizer-container {
     height: 100%;
+    overflow: hidden;
 }
 
 .svg-container {


### PR DESCRIPTION
### Changes:

- Mobile styles kick in at 599px and smaller screens, this ensures we are safe for all mobile devices, and also tablets; the smallest tablet size that exists is 600px → Amazon Fire 7 (7-inch, 1024x600)
- Navbar links and visualizer are hidden for any screen size narrower than 600px.
- The widget has a fixed height of 650px to avoid Location and Jog Control buttons overflowing root divs.
- Any errors or new warnings? **None**
- **Location widget** - Rapid movement buttons zoomed in and moved below the already available buttons.
- **Jog Controls** - Movement-type buttons (Rapid, Normal, Precise) moved below job control buttons and changed to flex to save space. Jog controls are larger for better accessibility on phone screens
- Probe tool is responsive.

### Test: Tested on iPhone 13pro and Pixel 3xl; everything is responsive. Workspace can be scrolled to reveal extra content.
<img width="959" alt="Screenshot 2023-01-11 at 9 22 50 AM" src="https://user-images.githubusercontent.com/39333609/211836527-6919b282-f51f-498a-a290-4c7442a1cd5a.png">

<img width="450" alt="Screenshot" src="https://user-images.githubusercontent.com/39333609/211917208-34f65186-1ece-4f4d-b454-41332eb19e11.jpeg">

<img width="450" alt="Screenshot" src="https://user-images.githubusercontent.com/39333609/211837053-9528c665-dd9e-42fa-847e-46fbe7cf99c2.PNG">

<img width="450" alt="Screenshot" src="https://user-images.githubusercontent.com/39333609/211837126-f450419c-1c31-4ac9-b664-8960547adccd.PNG">

<img width="450" alt="Screenshot" src="https://user-images.githubusercontent.com/39333609/211916766-c5babf88-73c6-40da-998d-529038801f1a.PNG">