### PR TITLE
Mi 883 dev find locations where redux variables are stored in widget state and refactor them to use redux

### DIFF
--- a/src/app/widgets/Location/index.jsx
+++ b/src/app/widgets/Location/index.jsx
@@ -629,9 +629,6 @@ class LocationWidget extends PureComponent {
             canClick: true, // Defaults to true
             units: store.get('workspace.units', METRIC_UNITS),
             safeRetractHeight: store.get('workspace.safeRetractHeight'),
-            workflow: {
-                state: controller.workflow.state
-            },
             modal: {
                 name: MODAL_NONE,
                 params: {}
@@ -746,6 +743,9 @@ class LocationWidget extends PureComponent {
         //const wcs = this.getWorkCoordinateSystem();
         const state = {
             ...this.state,
+            workflow: {
+                state: this.props.workflow.state
+            },
             // Determine if the motion button is clickable
             canClick: this.canClick(),
             // Output machine position with the display units

--- a/src/app/widgets/Probe/index.jsx
+++ b/src/app/widgets/Probe/index.jsx
@@ -351,10 +351,6 @@ class ProbeWidget extends PureComponent {
             toolChangeActive: false,
             port: controller.port,
             units,
-            controller: {
-                type: controller.type,
-                state: controller.state
-            },
             modal: {
                 name: MODAL_NONE,
                 params: {}
@@ -1063,7 +1059,11 @@ class ProbeWidget extends PureComponent {
     }
 
     generateProbeCommands() {
-        const state = { ...this.state };
+        const state = { ...this.state,
+            controller: {
+                type: controller.type,
+                state: controller.state
+            }, };
         const {
             useSafeProbeOption,
             retractionDistance,
@@ -1264,7 +1264,11 @@ class ProbeWidget extends PureComponent {
         const state = {
             ...this.state,
             canClick: this.canClick(),
-            connected: controller.port
+            connected: controller.port,
+            controller: {
+                type: controller.type,
+                state: controller.state
+            },
         };
         const actions = {
             ...this.actions

--- a/src/app/widgets/SecondaryFunctionality/index.jsx
+++ b/src/app/widgets/SecondaryFunctionality/index.jsx
@@ -152,10 +152,6 @@ class SecondaryFunctionality extends PureComponent {
             isFullscreen: false,
             disabled: this.config.get('disabled'),
             port: controller.port,
-            controller: {
-                type: controller.type,
-                state: controller.state
-            },
             selectedTab: 0,
             tabs: [
                 {

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -752,11 +752,6 @@ class VisualizerWidget extends PureComponent {
             units: store.get('workspace.units', METRIC_UNITS),
             theme: this.config.get('theme'),
             showSoftLimitsWarning: this.config.get('showSoftLimitsWarning', false),
-            controller: {
-                type: controller.type,
-                settings: controller.settings,
-                state: controller.state
-            },
             workflow: {
                 state: controller.workflow.state
             },
@@ -1331,6 +1326,11 @@ class VisualizerWidget extends PureComponent {
         const { renderState, isSecondary, gcode, surfacingData, activeVisualizer, activeState, alarmCode, workflow, isConnected } = this.props;
         const state = {
             ...this.state,
+            controller: {
+                type: controller.type,
+                settings: controller.settings,
+                state: controller.state
+            },
             alarmCode,
             activeState,
             workflow,


### PR DESCRIPTION
1. Folders and Files looked at for improper state usage (Total 72):
- Console(3 files)
- Coolant(3 files)
- JobStatus(6 files)
- JogControl(5 files)
- Location(14 files)
- Macro(5 files)
- NavbarConection(4 files)
- Probe(6 files)
- SecondaryFunctionality(1 file)
- Spindle(6 files)
- Visualizer(19 files)

2. There are a few work and machine positions that could be fetched from redux, but we are using default values in those state variables, so I have left them untouched. Ex: File - Visualizer/index.jsz

3. FIle: Location/index.jsx (moved out of state - workflow: {state: })
- Test: Loaded a gcode file and ran it to see if the location widget shows real time work position - YES
- Any console errors? NONE

4. File: Probe/index.jsx (moved out of state - controller: { type: controller.type,  state: controller.state})
- Any console errors? NONE
- Test: The only place this variable was used is inside canClick() and it fetches it from props. This state variable is unused in child components too, but I have kept it inside ‘const state’ just in case we need it in future.

5. File: SecondaryFunctionality/index.jsx (deleted from state - controller: { type: controller.type,  state: controller.state}))
- This variable was unused and does not affect child components
- Test: tested Probe, Macros, Console and Coolant tabs, everything works fine.

6. FIle: Visualizer/index.jsx (moved out of state - controller: { type: controller.type, settings: controller.settings, state: controller.state}))
- Test: Ran circle.gcode to see if the visualizer behaves differently - NO
- Any console errors? NO