### PR TITLE
Mi 896 dev ipc error in edge connecting from main connection widget but not firmware connection widget

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -272,7 +272,9 @@ const main = () => {
             ipcMain.on('reconnect-main', (event, options) => {
                 let shouldReconnect = false;
                 try {
-                    shouldReconnect = !event.sender.browserWindowOptions.parent && windowManager.childWindows.length > 0;
+                    if (event && event.sender && event.sender.browserWindowOptions) {
+                        shouldReconnect = !event.sender.browserWindowOptions.parent && windowManager.childWindows.length > 0;
+                    }
                 } catch (err) {
                     log.error(err);
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -270,7 +270,13 @@ const main = () => {
             });
 
             ipcMain.on('reconnect-main', (event, options) => {
-                if (!event.sender.browserWindowOptions.parent && windowManager.childWindows.length > 0) {
+                let shouldReconnect = false;
+                try {
+                    shouldReconnect = !event.sender.browserWindowOptions.parent && windowManager.childWindows.length > 0;
+                } catch (err) {
+                    log.error(err);
+                }
+                if (shouldReconnect) {
                     windowManager.childWindows.forEach(window => {
                         window.webContents.send('reconnect', options);
                     });


### PR DESCRIPTION
### Steps were taken to recreate the error:

1. Followed the exact steps the user has shared to recreate the error.
2. Connected via web app with homing on, killed terminal, started electron and connected. 
3. Connected through firmware modal.
4. Tested on Mac OS, Windows 11 and Linux.
5. Checked for server error logs on the web app and checked for app logs for electron.
6. Checked everything with both Homing on and off.
7. Results: Unable to recreate the error, the machine connects in every situation. No error logs on the server or logs files.

### Fixes:

1. The check for if the machine should reconnect is now a flag and is handled inside a try-catch block. The default behaviour is false.

### Final tests:

1. Does the workspace or main connection refresh when a new console is opened in a popup window? NO
2. Any console error when trying to connect with homing on and off? NO
3. Tried connecting from the Firmware modal and the main connection widget.