### PR TITLE
Fix For Keybindings ID Duplication

### DIFF
--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -91,6 +91,7 @@ class Header extends PureComponent {
 
     shuttleControlEvents = {
         CONTROLLER_COMMAND_UNLOCK: {
+            id: 61,
             title: 'Unlock',
             keys: '$',
             cmd: 'CONTROLLER_COMMAND_UNLOCK',
@@ -103,6 +104,7 @@ class Header extends PureComponent {
             callback: this.shuttleControlFunctions.CONTROLLER_COMMAND
         },
         CONTROLLER_COMMAND_RESET: {
+            id: 62,
             title: 'Soft Reset',
             keys: '%',
             cmd: 'CONTROLLER_COMMAND_RESET',
@@ -115,6 +117,7 @@ class Header extends PureComponent {
             callback: this.shuttleControlFunctions.CONTROLLER_COMMAND
         },
         CONTROLLER_COMMAND_HOMING: {
+            id: 31,
             title: 'Homing',
             keys: ['ctrl', 'alt', 'command', 'h'].join('+'),
             cmd: 'CONTROLLER_COMMAND_HOMING',

--- a/src/app/containers/NavSidebar/index.jsx
+++ b/src/app/containers/NavSidebar/index.jsx
@@ -87,6 +87,7 @@ class NavSidebar extends PureComponent {
 
     shuttleControlEvents = {
         OPEN_TOOLBAR_CONN: {
+            id: 64,
             title: 'Connect',
             keys: 'f1',
             cmd: 'OPEN_TOOLBAR_CONN',
@@ -97,6 +98,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_SURF: {
+            id: 65,
             title: 'Surfacing',
             keys: 'f2',
             cmd: 'OPEN_TOOLBAR_SURF',
@@ -107,6 +109,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_MAP: {
+            id: 66,
             title: 'Heightmap',
             keys: 'f3',
             cmd: 'OPEN_TOOLBAR_MAP',
@@ -117,6 +120,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_CALI: {
+            id: 67,
             title: 'Calibrate',
             keys: 'f4',
             cmd: 'OPEN_TOOLBAR_CALI',
@@ -127,6 +131,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_FIRM: {
+            id: 68,
             title: 'Firmware',
             keys: 'f5',
             cmd: 'OPEN_TOOLBAR_FIRM',
@@ -137,6 +142,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_HELP: {
+            id: 69,
             title: 'Help',
             keys: 'f6',
             cmd: 'OPEN_TOOLBAR_HELP',
@@ -147,6 +153,7 @@ class NavSidebar extends PureComponent {
             callback: this.shuttleControlFunctions.OPEN_TOOLBAR
         },
         OPEN_TOOLBAR_SETT: {
+            id: 70,
             title: 'Settings',
             keys: 'f7',
             cmd: 'OPEN_TOOLBAR_SETT',

--- a/src/app/widgets/Coolant/CoolantControls.jsx
+++ b/src/app/widgets/Coolant/CoolantControls.jsx
@@ -72,6 +72,7 @@ const shuttleControlFunctions = {
 };
 const shuttleControlEvents = {
     MIST_COOLANT: {
+        id: 71,
         title: 'Mist Coolant',
         keys: '',
         cmd: 'MIST_COOLANT',
@@ -81,6 +82,7 @@ const shuttleControlEvents = {
         callback: shuttleControlFunctions.MIST_COOLANT
     },
     FLOOD_COOLANT: {
+        id: 72,
         title: 'Flood Coolant',
         keys: '',
         cmd: 'FLOOD_COOLANT',
@@ -90,6 +92,7 @@ const shuttleControlEvents = {
         callback: shuttleControlFunctions.FLOOD_COOLANT
     },
     STOP_COOLANT: {
+        id: 73,
         title: 'Stop Coolant',
         keys: '',
         cmd: 'STOP_COOLANT',

--- a/src/app/widgets/JogControl/index.jsx
+++ b/src/app/widgets/JogControl/index.jsx
@@ -573,6 +573,7 @@ class AxesWidget extends PureComponent {
 
     shuttleControlEvents = {
         JOG_X_P: {
+            id: 32,
             title: 'Jog: X+',
             keys: 'shift+right',
             cmd: 'JOG_X_P',
@@ -587,6 +588,7 @@ class AxesWidget extends PureComponent {
             }
         },
         JOG_X_M: {
+            id: 33,
             title: 'Jog: X-',
             keys: 'shift+left',
             cmd: 'JOG_X_M',
@@ -599,6 +601,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_Y_P: {
+            id: 34,
             title: 'Jog: Y+',
             keys: 'shift+up',
             cmd: 'JOG_Y_P',
@@ -611,6 +614,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_Y_M: {
+            id: 35,
             title: 'Jog: Y-',
             keys: 'shift+down',
             cmd: 'JOG_Y_M',
@@ -623,6 +627,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_Z_P: {
+            id: 36,
             title: 'Jog: Z+',
             keys: 'shift+pageup',
             cmd: 'JOG_Z_P',
@@ -635,6 +640,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_Z_M: {
+            id: 37,
             title: 'Jog: Z-',
             keys: 'shift+pagedown',
             cmd: 'JOG_Z_M',
@@ -647,6 +653,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_X_P_Y_M: {
+            id: 38,
             title: 'Jog: X+ Y-',
             keys: '',
             cmd: 'JOG_X_P_Y_M',
@@ -659,6 +666,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_X_M_Y_P: {
+            id: 39,
             title: 'Jog: X- Y+',
             keys: '',
             cmd: 'JOG_X_M_Y_P',
@@ -671,6 +679,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_X_Y_P: {
+            id: 40,
             title: 'Jog: X+ Y+',
             keys: '',
             cmd: 'JOG_X_Y_P',
@@ -683,6 +692,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         JOG_X_Y_M: {
+            id: 41,
             title: 'Jog: X- Y-',
             keys: '',
             cmd: 'JOG_X_Y_M',
@@ -695,6 +705,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG,
         },
         STOP_JOG: {
+            id: 42,
             title: 'Stop Jog',
             keys: '',
             cmd: 'STOP_JOG',
@@ -711,6 +722,7 @@ class AxesWidget extends PureComponent {
             },
         },
         SET_R_JOG_PRESET: {
+            id: 45,
             title: 'Select Rapid Jog Preset',
             keys: ['shift', 'v'].join('+'),
             cmd: 'SET_R_JOG_PRESET',
@@ -723,6 +735,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SET_JOG_PRESET,
         },
         SET_N_JOG_PRESET: {
+            id: 46,
             title: 'Select Normal Jog Preset',
             keys: ['shift', 'c'].join('+'),
             cmd: 'SET_N_JOG_PRESET',
@@ -735,6 +748,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SET_JOG_PRESET,
         },
         SET_P_JOG_PRESET: {
+            id: 47,
             title: 'Select Precise Jog Preset',
             keys: ['shift', 'x'].join('+'),
             cmd: 'SET_P_JOG_PRESET',
@@ -747,6 +761,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SET_JOG_PRESET,
         },
         CYCLE_JOG_PRESETS: {
+            id: 48,
             title: 'Cycle Through Jog Presets',
             keys: ['shift', 'z'].join('+'),
             cmd: 'CYCLE_JOG_PRESETS',
@@ -765,6 +780,7 @@ class AxesWidget extends PureComponent {
             },
         },
         JOG_SPEED_I: {
+            id: 43,
             title: 'Increase Jog Speed',
             keys: '=',
             cmd: 'JOG_SPEED_I',
@@ -777,6 +793,7 @@ class AxesWidget extends PureComponent {
             callback: this.shuttleControlFunctions.JOG_SPEED
         },
         JOG_SPEED_D: {
+            id: 44,
             title: 'Decrease Jog Speed',
             keys: '-',
             cmd: 'JOG_SPEED_D',

--- a/src/app/widgets/Location/index.jsx
+++ b/src/app/widgets/Location/index.jsx
@@ -63,7 +63,6 @@ import {
     WORKFLOW_STATE_RUNNING,
     WORKFLOW_STATE_IDLE,
     LOCATION_CATEGORY,
-    JOGGING_CATEGORY,
     AXIS_X,
     AXIS_Y,
     AXIS_Z,
@@ -480,31 +479,8 @@ class LocationWidget extends PureComponent {
     }
 
     shuttleControlEvents = {
-        JOG_SPEED_I: {
-            title: 'Increase Jog Speed',
-            keys: '=',
-            cmd: 'JOG_SPEED_I',
-            payload: {
-                speed: 'increase'
-            },
-            preventDefault: false,
-            isActive: true,
-            category: JOGGING_CATEGORY,
-            callback: this.shuttleControlFunctions.JOG_SPEED
-        },
-        JOG_SPEED_D: {
-            title: 'Decrease Jog Speed',
-            keys: '-',
-            cmd: 'JOG_SPEED_D',
-            payload: {
-                speed: 'decrease'
-            },
-            preventDefault: false,
-            isActive: true,
-            category: JOGGING_CATEGORY,
-            callback: this.shuttleControlFunctions.JOG_SPEED
-        },
         ZERO_X_AXIS: {
+            id: 23,
             title: 'Zero X Axis',
             keys: ['shift', 'w'].join('+'),
             cmd: 'ZERO_X_AXIS',
@@ -515,6 +491,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.ZERO_AXIS
         },
         ZERO_Y_AXIS: {
+            id: 24,
             title: 'Zero Y Axis',
             keys: ['shift', 'e'].join('+'),
             cmd: 'ZERO_Y_AXIS',
@@ -525,6 +502,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.ZERO_AXIS
         },
         ZERO_Z_AXIS: {
+            id: 25,
             title: 'Zero Z Axis',
             keys: ['shift', 'r'].join('+'),
             cmd: 'ZERO_Z_AXIS',
@@ -535,6 +513,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.ZERO_AXIS
         },
         ZERO_ALL_AXIS: {
+            id: 26,
             title: 'Zero All',
             keys: ['shift', 'q'].join('+'),
             cmd: 'ZERO_ALL_AXIS',
@@ -545,6 +524,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.ZERO_AXIS
         },
         GO_TO_X_AXIS_ZERO: {
+            id: 27,
             title: 'Go to X Zero',
             keys: ['shift', 's'].join('+'),
             cmd: 'GO_TO_X_AXIS_ZERO',
@@ -555,6 +535,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.GO_TO_AXIS_ZERO
         },
         GO_TO_Y_AXIS_ZERO: {
+            id: 28,
             title: 'Go to Y Zero',
             keys: ['shift', 'd'].join('+'),
             cmd: 'GO_TO_Y_AXIS_ZERO',
@@ -565,6 +546,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.GO_TO_AXIS_ZERO
         },
         GO_TO_Z_AXIS_ZERO: {
+            id: 29,
             title: 'Go to Z Zero',
             keys: ['shift', 'f'].join('+'),
             cmd: 'GO_TO_Z_AXIS_ZERO',
@@ -575,6 +557,7 @@ class LocationWidget extends PureComponent {
             callback: this.shuttleControlFunctions.GO_TO_AXIS_ZERO
         },
         GO_TO_XY_AXIS_ZERO: {
+            id: 30,
             title: 'Go to XY Zero',
             keys: ['shift', 'a'].join('+'),
             cmd: 'GO_TO_XY_AXIS_ZERO',

--- a/src/app/widgets/Probe/Probe.jsx
+++ b/src/app/widgets/Probe/Probe.jsx
@@ -46,6 +46,7 @@ class Probe extends PureComponent {
 
     shuttleControlEvents = {
         OPEN_PROBE: {
+            id: 74,
             title: 'Open Probe',
             keys: '',
             cmd: 'OPEN_PROBE',
@@ -57,6 +58,7 @@ class Probe extends PureComponent {
             },
         },
         PROBE_ROUTINE_SCROLL_RIGHT: {
+            id: 75,
             title: 'Probe Routine Scroll Right',
             keys: '',
             cmd: 'PROBE_ROUTINE_SCROLL_RIGHT',
@@ -75,6 +77,7 @@ class Probe extends PureComponent {
             },
         },
         PROBE_ROUTINE_SCROLL_LEFT: {
+            id: 76,
             title: 'Probe Routine Scroll Left',
             keys: '',
             cmd: 'PROBE_ROUTINE_SCROLL_LEFT',
@@ -93,6 +96,7 @@ class Probe extends PureComponent {
             },
         },
         PROBE_DIAMETER_SCROLL_UP: {
+            id: 77,
             title: 'Probe Diameter Scroll Up',
             keys: '',
             cmd: 'PROBE_DIAMETER_SCROLL_UP',
@@ -113,6 +117,7 @@ class Probe extends PureComponent {
             },
         },
         PROBE_DIAMETER_SCROLL_DOWN: {
+            id: 78,
             title: 'Probe Diameter Scroll Down',
             keys: '',
             cmd: 'PROBE_DIAMETER_SCROLL_DOWN',

--- a/src/app/widgets/Probe/RunProbe.jsx
+++ b/src/app/widgets/Probe/RunProbe.jsx
@@ -48,6 +48,7 @@ class RunProbe extends PureComponent {
 
     shuttleControlEvents = {
         START_PROBE: {
+            id: 50,
             title: 'Start Probing',
             keys: '',
             cmd: 'START_PROBE',
@@ -59,6 +60,7 @@ class RunProbe extends PureComponent {
             },
         },
         CONFIRM_PROBE: {
+            id: 49,
             title: 'Confirm Probe',
             keys: '',
             cmd: 'CONFIRM_PROBE',

--- a/src/app/widgets/Spindle/index.jsx
+++ b/src/app/widgets/Spindle/index.jsx
@@ -63,6 +63,7 @@ class SpindleWidget extends PureComponent {
 
     shuttleControlEvents = {
         TOGGLE_SPINDLE_LASER_MODE: {
+            id: 51,
             title: 'Toggle Mode',
             keys: '',
             cmd: 'TOGGLE_SPINDLE_LASER_MODE',
@@ -74,6 +75,7 @@ class SpindleWidget extends PureComponent {
             }
         },
         CW_LASER_ON: {
+            id: 52,
             title: 'CW / Laser On',
             keys: '',
             cmd: 'CW_LASER_ON',
@@ -87,6 +89,7 @@ class SpindleWidget extends PureComponent {
             }
         },
         CCW_LASER_TEST: {
+            id: 53,
             title: 'CCW / Laser Test',
             keys: '',
             cmd: 'CCW_LASER_TEST',
@@ -100,6 +103,7 @@ class SpindleWidget extends PureComponent {
             }
         },
         STOP_LASER_OFF: {
+            id: 54,
             title: 'Stop / Laser Off',
             keys: '',
             cmd: 'STOP_LASER_OFF',

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -885,6 +885,7 @@ class VisualizerWidget extends PureComponent {
 
     shuttleControlEvents = {
         LOAD_FILE: {
+            id: 0,
             title: 'Load File',
             keys: ['shift', 'l'].join('+'),
             cmd: 'LOAD_FILE',
@@ -898,6 +899,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         UNLOAD_FILE: {
+            id: 1,
             title: 'Unload File',
             keys: ['shift', 'k'].join('+'),
             cmd: 'UNLOAD_FILE',
@@ -911,6 +913,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         TEST_RUN: {
+            id: 2,
             title: 'Test Run',
             keys: '#',
             cmd: 'TEST_RUN',
@@ -922,6 +925,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         START_JOB: {
+            id: 3,
             title: 'Start Job',
             keys: '~',
             cmd: 'START_JOB',
@@ -935,6 +939,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         PAUSE_JOB: {
+            id: 4,
             title: 'Pause Job',
             keys: '!',
             cmd: 'PAUSE_JOB',
@@ -946,6 +951,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         STOP_JOB: {
+            id: 5,
             title: 'Stop Job',
             keys: '@',
             cmd: 'STOP_JOB',
@@ -959,6 +965,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         FEEDRATE_OVERRIDE_P: {
+            id: 6,
             title: 'Feed +',
             keys: '',
             cmd: 'FEEDRATE_OVERRIDE_P',
@@ -969,6 +976,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.FEEDRATE_OVERRIDE,
         },
         FEEDRATE_OVERRIDE_PP: {
+            id: 7,
             title: 'Feed ++',
             keys: '',
             cmd: 'FEEDRATE_OVERRIDE_PP',
@@ -979,6 +987,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.FEEDRATE_OVERRIDE,
         },
         FEEDRATE_OVERRIDE_M: {
+            id: 8,
             title: 'Feed -',
             keys: '',
             cmd: 'FEEDRATE_OVERRIDE_M',
@@ -989,6 +998,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.FEEDRATE_OVERRIDE,
         },
         FEEDRATE_OVERRIDE_MM: {
+            id: 9,
             title: 'Feed --',
             keys: '',
             cmd: 'FEEDRATE_OVERRIDE_MM',
@@ -999,6 +1009,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.FEEDRATE_OVERRIDE,
         },
         FEEDRATE_OVERRIDE_RESET: {
+            id: 10,
             title: 'Feed Reset',
             keys: '',
             cmd: 'FEEDRATE_OVERRIDE_RESET',
@@ -1009,6 +1020,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.FEEDRATE_OVERRIDE,
         },
         SPINDLE_OVERRIDE_P: {
+            id: 11,
             title: 'Spindle/Laser +',
             keys: '',
             cmd: 'SPINDLE_OVERRIDE_P',
@@ -1019,6 +1031,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SPINDLE_OVERRIDE
         },
         SPINDLE_OVERRIDE_PP: {
+            id: 12,
             title: 'Spindle/Laser ++',
             keys: '',
             cmd: 'SPINDLE_OVERRIDE_PP',
@@ -1029,6 +1042,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SPINDLE_OVERRIDE
         },
         SPINDLE_OVERRIDE_M: {
+            id: 13,
             title: 'Spindle/Laser -',
             keys: '',
             cmd: 'SPINDLE_OVERRIDE_M',
@@ -1039,6 +1053,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SPINDLE_OVERRIDE
         },
         SPINDLE_OVERRIDE_MM: {
+            id: 14,
             title: 'Spindle/Laser --',
             keys: '',
             cmd: 'SPINDLE_OVERRIDE_MM',
@@ -1049,6 +1064,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SPINDLE_OVERRIDE
         },
         SPINDLE_OVERRIDE_RESET: {
+            id: 15,
             title: 'Spindle/Laser Reset',
             keys: '',
             cmd: 'SPINDLE_OVERRIDE_RESET',
@@ -1059,6 +1075,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.SPINDLE_OVERRIDE
         },
         VISUALIZER_VIEW_3D: {
+            id: 16,
             title: '3D / Isometric',
             keys: '',
             cmd: 'VISUALIZER_VIEW_3D',
@@ -1069,6 +1086,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         VISUALIZER_VIEW_TOP: {
+            id: 17,
             title: 'Top',
             keys: '',
             cmd: 'VISUALIZER_VIEW_TOP',
@@ -1079,6 +1097,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         VISUALIZER_VIEW_FRONT: {
+            id: 18,
             title: 'Front',
             keys: '',
             cmd: 'VISUALIZER_VIEW_FRONT',
@@ -1089,6 +1108,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         VISUALIZER_VIEW_RIGHT: {
+            id: 19,
             title: 'Right',
             keys: '',
             cmd: 'VISUALIZER_VIEW_RIGHT',
@@ -1099,6 +1119,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         VISUALIZER_VIEW_LEFT: {
+            id: 20,
             title: 'Left',
             keys: '',
             cmd: 'VISUALIZER_VIEW_LEFT',
@@ -1109,6 +1130,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         VISUALIZER_VIEW_RESET: {
+            id: 21,
             title: 'Reset View',
             keys: ['shift', 'n'].join('+'),
             cmd: 'VISUALIZER_VIEW_RESET',
@@ -1119,6 +1141,7 @@ class VisualizerWidget extends PureComponent {
             callback: this.shuttleControlFunctions.VISUALIZER_VIEW
         },
         LIGHTWEIGHT_MODE: {
+            id: 22,
             title: 'Lightweight Mode',
             keys: ['shift', 'm'].join('+'),
             cmd: 'LIGHTWEIGHT_MODE',
@@ -1128,6 +1151,7 @@ class VisualizerWidget extends PureComponent {
             callback: () => this.actions.handleLiteModeToggle(),
         },
         CUT: {
+            id: 55,
             title: 'Cut',
             keys: ['ctrl', 'x'].join('+'),
             cmd: 'CUT',
@@ -1139,6 +1163,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         COPY: {
+            id: 56,
             title: 'Copy',
             keys: ['ctrl', 'c'].join('+'),
             cmd: 'COPY',
@@ -1150,6 +1175,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         PASTE: {
+            id: 57,
             title: 'Paste',
             keys: ['ctrl', 'v'].join('+'),
             cmd: 'PASTE',
@@ -1161,6 +1187,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         UNDO: {
+            id: 58,
             title: 'Undo',
             keys: ['ctrl', 'z'].join('+'),
             cmd: 'UNDO',
@@ -1172,6 +1199,7 @@ class VisualizerWidget extends PureComponent {
             },
         },
         TOGGLE_SHORTCUTS: {
+            id: 63,
             title: 'Toggle Shortcuts',
             keys: '^',
             cmd: 'TOGGLE_SHORTCUTS',


### PR DESCRIPTION
- fixed duplicating ids problem: added default id for each shortcut in shuttleEvents instead of generating them in the keybindings hook
- created small migration to make sure ids return to their default ones