### PR TITLE
Mi 834 dev find fix for auto update failing on linux builds

### DIFF
--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -85,6 +85,22 @@ const getLatestVersion = () => new Promise((resolve, reject) => {
 });
 
 //
+// Check if electron auto-update is supported for the
+// installation package-type/file-extension
+//
+const getShouldInstallUpdates = () => new Promise((resolve, reject) => {
+    authrequest
+        .get('/api/version/appUpdateSupport')
+        .end((err, res) => {
+            if (err) {
+                reject(res);
+            } else {
+                resolve(res);
+            }
+        });
+});
+
+//
 //Fetch latest app version for all OS from github
 //
 // const getLatestVersionAllOS = () => new Promise((resolve, reject) => {
@@ -738,8 +754,9 @@ log.printLog = (msg, file, lineNumber, level) => new Promise((resolve, reject) =
 });
 
 export default {
+    //OS
     getLatestVersion,
-    // getLatestVersionAllOS,
+    getShouldInstallUpdates,
 
     // State
     getState,

--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -319,10 +319,14 @@ class Header extends PureComponent {
             console.log(err);
         });
         window.ipcRenderer.on('update_available', (info) => {
-            this.setState({
-                updateAvailable: true
+            api.getShouldInstallUpdates().then((res) => {
+                if (res.body) {
+                    this.setState({
+                        updateAvailable: true
+                    });
+                    pubsub.publish('showUpdateToast', info);
+                }
             });
-            pubsub.publish('showUpdateToast', info);
         });
     }
 
@@ -339,10 +343,10 @@ class Header extends PureComponent {
             <>
                 <div className={styles.navBar}>
                     <div className={styles.primary}>
-                        <NavLogo updateAvailable={ updateAvailable } onClick={ () => this.toggleUpdateToast() }/>
+                        <NavLogo updateAvailable={updateAvailable} onClick={() => this.toggleUpdateToast()} />
                         <NavbarConnection
-                            state={ this.state }
-                            actions={ this.actions }
+                            state={this.state}
+                            actions={this.actions}
                             widgetId="connection"
                         />
                         {

--- a/src/electron-app/AutoUpdater.js
+++ b/src/electron-app/AutoUpdater.js
@@ -40,10 +40,10 @@ class AutoUpdater {
         if (process.platform !== 'darwin') {
             return;
         }
-
-        autoUpdater.addListener('update-available', (event) => {
-            log.debug('A new update is available');
-        });
+        //This does not work for windows.
+        // autoUpdater.addListener('update-available', (event) => {
+        //     log.debug('A new update is available');
+        // });
         // On Windows only `releaseName` is available.
         autoUpdater.addListener('update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateURL) => {
             const title = 'A new update is ready to install';

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,6 @@
 import '@babel/polyfill';
 import { app, ipcMain, dialog, powerSaveBlocker, powerMonitor, screen, session } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import os from 'os';
 import Store from 'electron-store';
 import chalk from 'chalk';
 import mkdirp from 'mkdirp';
@@ -150,9 +149,7 @@ const main = () => {
             });
 
             autoUpdater.on('update-available', (info) => {
-                if (!os.platform().toLocaleLowerCase().includes('linux')) {
-                    window.webContents.send('update_available', info);
-                }
+                window.webContents.send('update_available', info);
             });
 
             autoUpdater.on('error', (err) => {

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@
 import '@babel/polyfill';
 import { app, ipcMain, dialog, powerSaveBlocker, powerMonitor, screen, session } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import os from 'os';
 import Store from 'electron-store';
 import chalk from 'chalk';
 import mkdirp from 'mkdirp';
@@ -149,7 +150,9 @@ const main = () => {
             });
 
             autoUpdater.on('update-available', (info) => {
-                window.webContents.send('update_available', info);
+                if (!os.platform().toLocaleLowerCase().includes('linux')) {
+                    window.webContents.send('update_available', info);
+                }
             });
 
             autoUpdater.on('error', (err) => {

--- a/src/server/api/api.version.js
+++ b/src/server/api/api.version.js
@@ -25,6 +25,7 @@ import url from 'url';
 import registryUrl from 'registry-url';
 import registryAuthToken from 'registry-auth-token';
 import request from 'superagent';
+import os from 'os';
 import {
     ERR_INTERNAL_SERVER_ERROR
 } from '../constants';
@@ -69,4 +70,16 @@ export const getLatestVersion = (req, res) => {
 
             res.send({ time, name, version, description, homepage });
         });
+};
+
+export const getShouldInstallUpdates = (req, res) => {
+    let shouldUpdate = true;
+    //Check command line inputs for electron file extention
+    //Sample: C:\Program Files\gSender Edge\gSender Edge.exe
+    process.argv.forEach((consoleInput, index) => {
+        if (os.platform().toLocaleLowerCase().includes('linux') && !consoleInput.toLocaleLowerCase().includes('.appimage')) {
+            shouldUpdate = false;
+        }
+    });
+    res.send(shouldUpdate);
 };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -281,6 +281,7 @@ const appMain = () => {
     { // Register API routes with authorized access
         // Version
         app.get(urljoin(settings.route, 'api/version/latest'), api.version.getLatestVersion);
+        app.get(urljoin(settings.route, 'api/version/appUpdateSupport'), api.version.getShouldInstallUpdates);
 
         // State
         app.get(urljoin(settings.route, 'api/state'), api.state.get);


### PR DESCRIPTION
### New Changes:
Auto-update will work for only .AppImage file extension on Linux.

### Tests:
**Windows:**

1. Electron and web apps work fine.
2. Any errors or warnings? Nothing except the existing HTTP request setHeader error.

**Mac:**

1. No errors or warning on the web and electron app

**Ubuntu:**

1. Auto update pops up with no warnings/errors for .AppImage package.