### PR TITLE
Mi 916 dev reorder settings tab

### DIFF
--- a/src/app/containers/Preferences/General/Connection.js
+++ b/src/app/containers/Preferences/General/Connection.js
@@ -26,7 +26,7 @@ const Connection = ({ state, actions }) => {
             <div className={styles.reconnect}>
                 <Tooltip content="Reconnect to the last machine you used automatically" location="default">
                     <ToggleSwitch
-                        label="Re-connect automatically"
+                        label="Reconnect Automatically"
                         checked={autoReconnect}
                         onChange={() => actions.general.setAutoReconnect()}
                         size="small"

--- a/src/app/containers/Preferences/General/Workspace.js
+++ b/src/app/containers/Preferences/General/Workspace.js
@@ -34,7 +34,7 @@ const Workspace = ({ state, actions }) => {
             <div className={styles.addMargin}>
                 <Tooltip content="Flip the location of the Visualizer with Machine Controls" location="default">
                     <ToggleSwitch
-                        label="Reverse workspace layout"
+                        label="Visualizer on right Side"
                         checked={reverseWidgets}
                         onChange={() => actions.general.setReverseWidgets()}
                         size="small"

--- a/src/app/containers/Preferences/General/Workspace.js
+++ b/src/app/containers/Preferences/General/Workspace.js
@@ -29,7 +29,7 @@ const Workspace = ({ state, actions }) => {
                         <RadioButton className={styles.prefferedradio} label="Millimeters (G21)" value={METRIC_UNITS} />
                     </div>
                 </RadioGroup>
-                <small className={styles['item-info']}>Units to be displayed throughout the interface</small>
+                <small className={styles['item-info']}>What units would you like gSender to show you?</small>
             </div>
             <div className={styles.addMargin}>
                 <Tooltip content="Flip the location of the Visualizer with Machine Controls" location="default">

--- a/src/app/containers/Preferences/Preferences.jsx
+++ b/src/app/containers/Preferences/Preferences.jsx
@@ -93,14 +93,19 @@ class PreferencesPage extends PureComponent {
                     component: General
                 },
                 {
+                    id: 1,
+                    label: 'Safety',
+                    component: SafetySettings
+                },
+                {
                     id: 2,
                     label: 'Probe',
                     component: ProbeSettings
                 },
                 {
                     id: 3,
-                    label: 'Shortcuts',
-                    component: Shortcuts
+                    label: 'Spindle/Laser',
+                    component: SpindleLaser
                 },
                 {
                     id: 4,
@@ -108,32 +113,27 @@ class PreferencesPage extends PureComponent {
                     component: VisualizerSettings
                 },
                 {
-                    id: 1,
-                    label: 'Spindle/Laser',
-                    component: SpindleLaser
-                },
-                {
-                    id: 8,
-                    label: 'Safety',
-                    component: SafetySettings
-                },
-                {
                     id: 5,
-                    label: 'Tool Change',
-                    component: Events
+                    label: 'Shortcuts',
+                    component: Shortcuts
                 },
                 {
                     id: 6,
-                    label: 'Program Events',
-                    component: ProgramEvents,
-                },
-                {
-                    id: 9,
                     label: 'Stats',
                     component: StatsPage,
                 },
                 {
                     id: 7,
+                    label: 'Program Events',
+                    component: ProgramEvents,
+                },
+                {
+                    id: 8,
+                    label: 'Tool Change',
+                    component: Events
+                },
+                {
+                    id: 9,
                     label: 'About',
                     component: About,
                 }

--- a/src/app/containers/Preferences/Shortcuts/index.js
+++ b/src/app/containers/Preferences/Shortcuts/index.js
@@ -26,6 +26,12 @@ const tabs = [
     },
 ];
 
+const printButtonStyles = {
+    position: 'absolute',
+    top: '1.3em',
+    left: '26em',
+};
+
 const Shortcuts = ({ active }) => {
     const [tab, setTab] = useState(0);
     const componentRef = useRef();
@@ -34,7 +40,7 @@ const Shortcuts = ({ active }) => {
             <TabbedWidget>
                 <ReactToPrint
                     trigger={() => {
-                        return <Button>Print</Button>;
+                        return <Button style={printButtonStyles}>Print</Button>;
                     }}
                     content={() => componentRef.current}
                 />

--- a/src/app/containers/Preferences/Shortcuts/index.styl
+++ b/src/app/containers/Preferences/Shortcuts/index.styl
@@ -7,7 +7,7 @@ $primary = #3e85c7;
   max-height: 565px;
 }
 .table-wrapper {
-  height: 528px;
+  height: 570px;
   background-color: white;
   overflow-x: hidden;
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -150,6 +150,5 @@
     "Attempt Reconnect": "Attempt Reconnect",
     "Click \"Resume\" to continue execution.": "Click \"Resume\" to continue execution.",
     "Rendering": "Rendering",
-    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue.",
-    "Start from Line ": "Start from Line "
+    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue."
 }


### PR DESCRIPTION
### Changes:

1. Settings order changed to - General, Safety, Probe, Spindle/Laser, Visualizer, Shortcuts, Stats, Program Events, Tool Change, About.
2. Print shortcut button style changed
3. Preference copy renames
4. Workspace unit change message updated

### Tests:

1. Checked if the contents are correct for each setting after reordering them.
2. The Print button is now moved up so the shortcut table had to have more height to fill the space. Tested on multiple screen sizes to see if anything breaks.
3. Preference copy changes reflect as expected on the view.
4. Workspace unit change message reflects as expected on the app.
5. Any errors or warnings? None