### PR TITLE
MI-917-DEV-Errors-and-Alarms-styling

### DIFF
--- a/src/app/containers/Preferences/About/index.styl
+++ b/src/app/containers/Preferences/About/index.styl
@@ -53,20 +53,21 @@
     max-height: 17rem;
     background-color: white;
     overflow-y: auto;
+    overflow-x: hidden;
     padding: 2px 16px;
     box-shadow: 0 2px 4px 0 rgba(0,0,0,0.2);
     justify-content: space-between;
-    &::-webkit-scrollbar {
-    width: 7px;
-    }
-    &::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 6px #13283c; 
-    border-radius: 10px;
-    }
-    &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5); 
-    }
+    // &::-webkit-scrollbar {
+    // width: 7px;
+    // }
+    // &::-webkit-scrollbar-track {
+    // -webkit-box-shadow: inset 0 0 6px #13283c; 
+    // border-radius: 10px;
+    // }
+    // &::-webkit-scrollbar-thumb {
+    // border-radius: 10px;
+    // -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5); 
+    // }
 }
     .content{
         h2 {

--- a/src/app/containers/Preferences/Safety/ErrorLogs/ErrorLog.js
+++ b/src/app/containers/Preferences/Safety/ErrorLogs/ErrorLog.js
@@ -48,7 +48,7 @@ const ErrorLog = () => {
                                             >
                                                 <span className={styles.errorTag}>Alarm</span>
                                                 <span className={styles.errorDate}>
-                                                    Occured on {log.split('[error] GRBL_ALARM:')[0].slice(1, 20).replace(' ', ' at ') || ''}
+                                                    On {log.split('[error] GRBL_ALARM:')[0].slice(1, 20).replace(' ', ' at ') || ''}
                                                 </span>
                                                 <p className={styles.errorReason}>
                                                     {log.split('[error] GRBL_ALARM:')[1]}
@@ -67,7 +67,7 @@ const ErrorLog = () => {
                                             >
                                                 <span className={styles.errorTag}>Error{log.split('[error] GRBL_ERROR:')[1].split('Origin')[1]}</span>
                                                 <span className={styles.errorDate}>
-                                                    Occured on {log.split('[error] GRBL_ERROR:')[0].slice(1, 20).replace(' ', ' at ') || ''}
+                                                    On {log.split('[error] GRBL_ERROR:')[0].slice(1, 20).replace(' ', ' at ') || ''}
                                                 </span>
                                                 <p className={styles.errorReason}>
                                                     {log.split('[error] GRBL_ERROR:')[1].split('Line')[0]} <br />

--- a/src/app/containers/Preferences/index.styl
+++ b/src/app/containers/Preferences/index.styl
@@ -598,6 +598,7 @@
     min-height: 387px;
     height: 387px !important;
     overflow-y: auto;
+    overflow-x: hidden;
 
     .verticalTimeline{
       height: auto !important;
@@ -641,17 +642,17 @@
         line-height: 25rem;
       }
 
-    &::-webkit-scrollbar {
-    width: 7px;
-    }
-    &::-webkit-scrollbar-track {
-    -webkit-box-shadow: inset 0 0 7px #ffffff; 
-    border-radius: 10px;
-    }
-    &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    -webkit-box-shadow: inset 0 0 6px #1f2937; 
-    }
+    // &::-webkit-scrollbar {
+    // width: 7px;
+    // }
+    // &::-webkit-scrollbar-track {
+    // -webkit-box-shadow: inset 0 0 7px #ffffff; 
+    // border-radius: 10px;
+    // }
+    // &::-webkit-scrollbar-thumb {
+    // border-radius: 10px;
+    // -webkit-box-shadow: inset 0 0 6px #1f2937; 
+    // }
     }
   }
 

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -150,6 +150,5 @@
     "Attempt Reconnect": "Attempt Reconnect",
     "Click \"Resume\" to continue execution.": "Click \"Resume\" to continue execution.",
     "Rendering": "Rendering",
-    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue.",
-    "Start from Line ": "Start from Line "
+    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue."
 }


### PR DESCRIPTION
### Changes:

1. No more horizontal scrolls on the About, or Errors and Alarms section.
2. Error timeline says ‘On {date}’ instead of 'Occured on {date}'
3. Forced scrollbar styles were removed for both the About and, Errors and Alarms sections.

### Tests:

1. App dragged to multiple screen sizes on the dev tool to see if the horizontal scrollbar appears on both the electron and the web. It does not appear anymore.
2. Scrollbars compared with other places on the app to verify consistency.
<img width="778" alt="Screenshot 2023-01-25 133601" src="https://user-images.githubusercontent.com/39333609/214657433-1f0cc3dc-860d-4b8c-8bb9-e1c716e5cb88.png">
<img width="797" alt="Screenshot 2023-01-25 134743" src="https://user-images.githubusercontent.com/39333609/214657436-f359a2b9-c677-45a8-8796-1bda0d3a164a.png">

