### PR TITLE
Mi 910 dev gamepad shortcuts bugs

### DIFF
--- a/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
@@ -37,6 +37,7 @@ const Profile = ({ data, onUpdateProfiles }) => {
     };
 
     const handleDelete = (currShortcut) => {
+        console.log('Current Shortcut to delete :', currShortcut);
         const updatedShortcuts = shortcuts.map((shortcut) => (shortcut.id === currShortcut.id
             ? { ...shortcut, keys: '', keysName: '', isActive: false }
             : shortcut
@@ -44,8 +45,11 @@ const Profile = ({ data, onUpdateProfiles }) => {
 
         const profiles = store.get('workspace.gamepad.profiles', []);
 
+        //CHecks if parent array has all the child array elements
+        const arrayComparator = (parentArr, childArr) => childArr.every(element => parentArr.includes(element));
+
         const updatedProfiles =
-            profiles.map(profile => (profile.id.includes(data.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
+            profiles.map(profile => (arrayComparator(profile.id, data.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
 
         onUpdateProfiles(updatedProfiles);
 

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
@@ -37,7 +37,6 @@ const Profile = ({ data, onUpdateProfiles }) => {
     };
 
     const handleDelete = (currShortcut) => {
-        console.log('Current Shortcut to delete :', currShortcut);
         const updatedShortcuts = shortcuts.map((shortcut) => (shortcut.id === currShortcut.id
             ? { ...shortcut, keys: '', keysName: '', isActive: false }
             : shortcut
@@ -65,8 +64,11 @@ const Profile = ({ data, onUpdateProfiles }) => {
 
         const profiles = store.get('workspace.gamepad.profiles', []);
 
+        //CHecks if parent array has all the child array elements
+        const arrayComparator = (parentArr, childArr) => childArr.every(element => parentArr.includes(element));
+
         const updatedProfiles =
-            profiles.map(profile => (profile.id.includes(data.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
+            profiles.map(profile => (arrayComparator(profile.id, data.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
 
         onUpdateProfiles(updatedProfiles);
     };

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileItem.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileItem.js
@@ -7,13 +7,13 @@ import { Confirm } from 'app/components/ConfirmationDialog/ConfirmationDialogLib
 import styles from '../index.styl';
 
 const ProfileItem = ({ title, icon, id, onClick, onDelete }) => {
-    const handleDelete = (e) => {
+    const handleDelete = (e, ommitId) => {
         e.stopPropagation(); //Prevents bubbling that will fire the parent div's onclick first
 
         Confirm({
             content: 'Are you sure you want to delete this gamepad profile?',
             title: 'Delete Gamepad Profile',
-            onConfirm: () => onDelete(id)
+            onConfirm: () => onDelete(ommitId)
         });
     };
 
@@ -31,7 +31,7 @@ const ProfileItem = ({ title, icon, id, onClick, onDelete }) => {
             <i
                 tabIndex={-1}
                 role="button"
-                onClick={handleDelete}
+                onClick={(event) => handleDelete(event, id)}
                 onKeyDown={null}
                 className={classnames('fas fa-times', styles.profileItemDelete)}
             />
@@ -41,7 +41,7 @@ const ProfileItem = ({ title, icon, id, onClick, onDelete }) => {
 ProfileItem.propTypes = {
     title: PropTypes.string,
     icon: PropTypes.string,
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    id: PropTypes.array,
     onClick: PropTypes.func,
     onDelete: PropTypes.func,
 };

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileShortcutModal.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileShortcutModal.js
@@ -82,10 +82,7 @@ const ProfileShortcutModal = ({ profile, shortcut, onClose, onUpdateProfiles, fi
                     isActive: currentShortcut.id === shortcut.id ? true : currentShortcut.isActive,
                 }));
 
-         //TODO
-         //Commented on merge conflict
-         //No such variables declared/imported anywhere on this file
-        //filter(filterCategory, newShortcutsArr);
+        filter(filterCategory, newShortcutsArr);
 
         const profiles = store.get('workspace.gamepad.profiles', []);
 

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileShortcutModal.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/ProfileShortcutModal.js
@@ -82,10 +82,14 @@ const ProfileShortcutModal = ({ profile, shortcut, onClose, onUpdateProfiles }) 
                     isActive: currentShortcut.id === shortcut.id ? true : currentShortcut.isActive,
                 }));
 
+
         const profiles = store.get('workspace.gamepad.profiles', []);
 
+        //CHecks if parent array has all the child array elements
+        const arrayComparator = (parentArr, childArr) => childArr.every(element => parentArr.includes(element));
+
         const cleanedProfiles =
-            profiles.map(currentProfile => (currentProfile.id.includes(profile.id) ? ({ ...profile, shortcuts: newShortcutsArr }) : currentProfile));
+            profiles.map(currentProfile => (arrayComparator(currentProfile.id, profile.id) ? ({ ...profile, shortcuts: newShortcutsArr }) : currentProfile));
 
         onUpdateProfiles(cleanedProfiles);
 

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 
 import store from 'app/store';
 import { Toaster, TOASTER_SUCCESS, TOASTER_SHORT } from 'app/lib/toaster/ToasterLib';
@@ -46,8 +46,11 @@ const Gamepad = () => {
 
         const profiles = store.get('workspace.gamepad.profiles', []);
 
+        //CHecks if parent array has all the child array elements
+        const arrayComparator = (parentArr, childArr) => childArr.every(element => parentArr.includes(element));
+
         const updatedProfiles =
-            profiles.map(profile => (profile.id.includes(currentProfile.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
+            profiles.map(profile => (arrayComparator(profile.id, currentProfile.id) ? ({ ...profile, shortcuts: updatedShortcuts }) : profile));
 
         handleUpdateProfiles(updatedProfiles);
     };
@@ -56,6 +59,10 @@ const Gamepad = () => {
 
     const allShortcutsEnabled = currentProfile?.shortcuts?.every(shortcut => shortcut.isActive);
     const allShortcutsDisabled = currentProfile?.shortcuts?.every(shortcut => !shortcut.isActive);
+
+    useEffect(() => {
+        console.log(' gamepad profiles updated');
+    }, [profiles]);
 
     return (
         <div className={styles.container}>

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
@@ -20,7 +20,9 @@ const Gamepad = () => {
     };
 
     const handleProfileDelete = (id) => {
-        const filteredProfiles = profiles.filter(profile => !profile.id.includes(id));
+        let filteredProfiles = profiles.filter((profile) => {
+            return JSON.stringify(profile.id) !== JSON.stringify(id);
+        });
 
         setProfiles(filteredProfiles);
         setCurrentProfileID(null);

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
@@ -15,8 +15,8 @@ const Gamepad = () => {
     const [currentProfileID, setCurrentProfileID] = useState(null);
     const [showAddProfile, setShowAddProfile] = useState(false);
 
-    const handleProfileClick = (id) => {
-        setCurrentProfileID(id[0]); //Can just grab one of the ids in the array for computing the profile information below
+    const handleProfileClick = (ids) => {
+        setCurrentProfileID(ids[0]); //Can just grab one of the ids in the array for computing the profile information below
     };
 
     const handleProfileDelete = (id) => {

--- a/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 
 import store from 'app/store';
 import { Toaster, TOASTER_SUCCESS, TOASTER_SHORT } from 'app/lib/toaster/ToasterLib';
@@ -59,10 +59,6 @@ const Gamepad = () => {
 
     const allShortcutsEnabled = currentProfile?.shortcuts?.every(shortcut => shortcut.isActive);
     const allShortcutsDisabled = currentProfile?.shortcuts?.every(shortcut => !shortcut.isActive);
-
-    useEffect(() => {
-        console.log(' gamepad profiles updated');
-    }, [profiles]);
 
     return (
         <div className={styles.container}>

--- a/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
@@ -156,7 +156,7 @@ const Keyboard = () => {
 
     const allShortcutsEnabled = useMemo(() => shortcutsList.every(shortcut => shortcut.isActive), [shortcutsList]);
     const allShortcutsDisabled = useMemo(() => shortcutsList.every(shortcut => !shortcut.isActive), [shortcutsList]);
-
+    console.log('Keyboard: ', shortcutsList);
     return (
         <div>
             <div className={styles['table-wrapper']}>

--- a/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
@@ -156,7 +156,6 @@ const Keyboard = () => {
 
     const allShortcutsEnabled = useMemo(() => shortcutsList.every(shortcut => shortcut.isActive), [shortcutsList]);
     const allShortcutsDisabled = useMemo(() => shortcutsList.every(shortcut => !shortcut.isActive), [shortcutsList]);
-    console.log('Keyboard: ', shortcutsList);
     return (
         <div>
             <div className={styles['table-wrapper']}>

--- a/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
+++ b/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
@@ -54,7 +54,7 @@ const ShortcutsTable = ({ onEdit, onDelete, onShortcutToggle, dataSet }) => {
         renderShortcutCell: (_, row) => {
             const { keys, isActive, keysName } = row;
             const shortcut = [...keys][0] === '+' ? ['+'] : keys.split('+');
-
+            console.log('Render Cell Shortcut :', shortcut);
             const hasShortcut = !!shortcut[0];
 
             let cleanedShortcut = null;
@@ -72,7 +72,7 @@ const ShortcutsTable = ({ onEdit, onDelete, onShortcutToggle, dataSet }) => {
             return (
                 <div className={styles.shortcutComboColumn}>
                     {
-                        hasShortcut || keysName
+                        hasShortcut || ''
                             ? (
                                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', alignItems: 'center' }}>
                                     {keysName ? <kbd>{keysName}</kbd> : output}

--- a/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
+++ b/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
@@ -54,7 +54,6 @@ const ShortcutsTable = ({ onEdit, onDelete, onShortcutToggle, dataSet }) => {
         renderShortcutCell: (_, row) => {
             const { keys, isActive, keysName } = row;
             const shortcut = [...keys][0] === '+' ? ['+'] : keys.split('+');
-            console.log('Render Cell Shortcut :', shortcut);
             const hasShortcut = !!shortcut[0];
 
             let cleanedShortcut = null;

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -150,6 +150,5 @@
     "Attempt Reconnect": "Attempt Reconnect",
     "Click \"Resume\" to continue execution.": "Click \"Resume\" to continue execution.",
     "Rendering": "Rendering",
-    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue.",
-    "Start from Line ": "Start from Line "
+    "Please turn your device to landscape for the best experience, or click to continue.": "Please turn your device to landscape for the best experience, or click to continue."
 }

--- a/src/app/lib/useKeybinding.js
+++ b/src/app/lib/useKeybinding.js
@@ -115,7 +115,6 @@ export function removeOldKeybindings() {
             updatedCommandKeys.splice(updatedCommandKeys.findIndex(el => el === keyToRemove), 1);
         }
     });
-    console.log(updatedCommandKeys);
     store.replace('commandKeys', updatedCommandKeys);
 
     // do the same for gamepad shortcuts
@@ -132,7 +131,6 @@ export function removeOldKeybindings() {
         });
         return { ...profile, shortcuts: updatedProfileShortcuts };
     });
-    console.log(updatedGamepadProfiles);
     store.replace('workspace.gamepad.profiles', updatedGamepadProfiles);
 
     combokeys.reload();


### PR DESCRIPTION
### Fixes:

1. Gamepad ID is an array, changed prop types to match that.
2. The gamepad profile delete operation is fixed.
3. Add a gamepad shortcut workflow is fixed.
4. Delete a gamepad shortcut workflow is fixed.
5. Toggle a shortcut active/inactive made to work.
6. Edit a gamepad shortcut workflow is fixed and works.
7. Delete a shortcut workflow fixed.
8. Conditional rendering of add/edit/delete a shortcut fixed, it used to show a '+' even for already assigned shortcuts.
9. Enable and Disable all gamepad shortcuts made to work.

### Tests:

1. Add a new controller works.
2. Delete an existing controller works
3. Add/delete/update a shortcut works
4. Enable/disable a shortcut works
5. All assigned shortcuts works - tried loading a file and running a job from the controller. Everything works as expected



Any errors or warnings? **None**