### PR TITLE
Remove Unnecessary Keybinding Info From Store

### DIFF
--- a/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
+++ b/src/app/containers/Preferences/Shortcuts/Gamepad/Profile.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import store from 'app/store';
 import { Toaster, TOASTER_SUCCESS } from 'app/lib/toaster/ToasterLib';
 import Button from 'app/components/FunctionButton/FunctionButton';
+import shuttleEvents from 'app/lib/shuttleEvents';
 import { generateList } from '../utils';
 
 import styles from '../index.styl';
@@ -25,9 +26,16 @@ const Profile = ({ data, onUpdateProfiles, setCurrentProfileID }) => {
     const [dataSet, setDataSet] = useState(shortcuts);
     const [filterCategory, setFilterCategory] = useState(ALL_CATEGORY);
 
+    const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
+
     const filter = (category, shortcutsList) => {
         const allShortcuts = shortcutsList || shortcuts;
-        const filteredData = category === ALL_CATEGORY ? allShortcuts : Object.fromEntries(Object.entries(allShortcuts).filter(([key, entry]) => entry.category === category));
+        const filteredData = category === ALL_CATEGORY ? allShortcuts : Object.fromEntries(Object.entries(allShortcuts).filter(([key, entry]) => {
+            if (allShuttleControlEvents[key]) {
+                return allShuttleControlEvents[key].category === category;
+            }
+            return entry.category === category;
+        }));
         setDataSet(filteredData);
         setFilterCategory(category);
     };

--- a/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
+++ b/src/app/containers/Preferences/Shortcuts/Keyboard/index.js
@@ -35,6 +35,7 @@ import Modal from 'app/components/Modal';
 import FunctionButton from 'app/components/FunctionButton/FunctionButton';
 // import { updateShortcutsList, holdShortcutsListener, unholdShortcutsListener } from 'app/actions/preferencesActions';
 import { Toaster, TOASTER_SUCCESS } from 'app/lib/toaster/ToasterLib';
+import shuttleEvents from 'app/lib/shuttleEvents';
 
 import CategoryFilter from '../CategoryFilter';
 import ShortcutsTable from '../ShortcutsTable';
@@ -51,10 +52,16 @@ const Keyboard = () => {
     const [shortcutsList, setShortcutsList] = useState(store.get('commandKeys', {}));
     const [dataSet, setDataSet] = useState(shortcutsList);
     const [filterCategory, setFilterCategory] = useState(ALL_CATEGORY);
+    const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
 
     const filter = (category, shortcuts) => {
         const allShortcuts = shortcuts || shortcutsList;
-        const filteredData = category === ALL_CATEGORY ? allShortcuts : Object.fromEntries(Object.entries(allShortcuts).filter(([key, entry]) => entry.category === category));
+        const filteredData = category === ALL_CATEGORY ? allShortcuts : Object.fromEntries(Object.entries(allShortcuts).filter(([key, entry]) => {
+            if (allShuttleControlEvents[key]) {
+                return allShuttleControlEvents[key].category === category;
+            }
+            return entry.category === category;
+        }));
         setDataSet(filteredData);
         setFilterCategory(category);
     };

--- a/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
+++ b/src/app/containers/Preferences/Shortcuts/ShortcutsTable.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Table from 'app/components/Table';
 import ToggleSwitch from 'app/components/ToggleSwitch';
+import shuttleEvents from 'app/lib/shuttleEvents';
 
 import {
     CARVING_CATEGORY,
@@ -43,6 +44,8 @@ import {
 
 import { formatShortcut } from './helpers';
 import styles from './edit-area.styl';
+
+const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
 
 /**
  * Shortcuts Table Component
@@ -127,16 +130,23 @@ const ShortcutsTable = ({ onEdit, onDelete, onShortcutToggle, dataSet }) => {
                 [COOLANT_CATEGORY]: 'categoryDarkRed'
             };
 
-            const category = categories[row.category];
+            const rowCategory = allShuttleControlEvents[row.cmd] ? allShuttleControlEvents[row.cmd].category : row.category;
+            const category = categories[rowCategory];
 
             return (
-                <div className={styles[category]}>{row.category}</div>
+                <div className={styles[category]}>{rowCategory}</div>
+            );
+        },
+        renderTitleCell: (_, row) => {
+            const rowTitle = allShuttleControlEvents[row.cmd] ? allShuttleControlEvents[row.cmd].title : row.title;
+            return (
+                <div>{rowTitle}</div>
             );
         }
     };
 
     const columns = [
-        { dataKey: 'title', title: 'Action', sortable: true, width: '25%' },
+        { dataKey: 'title', title: 'Action', sortable: true, width: '25%', render: renders.renderTitleCell },
         { dataKey: 'keys', title: 'Shortcut', sortable: true, width: '45%', render: renders.renderShortcutCell },
         { dataKey: 'category', title: 'Category', sortable: true, width: '20%', render: renders.renderCategoryCell },
         { dataKey: 'isActive', title: 'Active', width: '10%', render: renders.renderToggleCell }

--- a/src/app/containers/Preferences/Shortcuts/utils.js
+++ b/src/app/containers/Preferences/Shortcuts/utils.js
@@ -1,3 +1,8 @@
+import shuttleEvents from 'app/lib/shuttleEvents';
+import { MACRO_CATEGORY } from 'app/constants';
+
+const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
+
 export const AVAILABILITY_TYPES = {
     DEFAULT: 'DEFAULT',
     AVAILABLE: 'AVAILABLE',
@@ -14,7 +19,15 @@ export const generateList = (shortcuts) => {
         shortcutsList.push(shortcuts[key]);
     });
     shortcutsList.sort((a, b) => {
-        return a.category.localeCompare(b.category);
+        let categoryA = MACRO_CATEGORY;
+        let categoryB = MACRO_CATEGORY;
+        if (allShuttleControlEvents[a.cmd]) {
+            categoryA = allShuttleControlEvents[a.cmd].category;
+        }
+        if (allShuttleControlEvents[b.cmd]) {
+            categoryB = allShuttleControlEvents[b.cmd].category;
+        }
+        return categoryA.localeCompare(categoryB);
     });
     return shortcutsList;
 };

--- a/src/app/lib/combokeys.js
+++ b/src/app/lib/combokeys.js
@@ -76,8 +76,9 @@ class Combokeys extends events.EventEmitter {
         }
         const commandKeys = await this.getCommandKeys();
 
-        Object.entries(commandKeys).filter(([key, keybinding]) => keybinding.isActive).forEach(([key, o]) => {
-            const { keys, cmd, payload = null, isActive, category } = o;
+        Object.entries(commandKeys).forEach(([key, o]) => {
+            const { keys, isActive } = o;
+            const { cmd, payload = null, category, preventDefault: preventDefaultBool } = shuttleEvents.allShuttleControlEvents[key] ?? o; // if macro, won't have shuttleEvents to pull defaults from
 
             //Do not add any keybindings if the shortcut is disabled or there is no shortcut at all
             if (!isActive || !keys) {
@@ -86,7 +87,7 @@ class Combokeys extends events.EventEmitter {
 
             const callback = (event) => {
                 log.debug(`combokeys: keys=${keys} cmd=${cmd} payload=${JSON.stringify(payload)}`);
-                if (!!o.preventDefault) {
+                if (!!preventDefaultBool) {
                     preventDefault(event);
                 }
                 if (category === MACRO_CATEGORY) {
@@ -112,14 +113,14 @@ class Combokeys extends events.EventEmitter {
             if (jogCmds.includes(cmd)) {
                 const callback = (event) => {
                     log.debug(`combokeys: keys=${keys} cmd=${STOP_CMD} payload=${JSON.stringify(payload)}`);
-                    if (!!o.preventDefault) {
+                    if (!!preventDefaultBool) {
                         preventDefault(event);
                     }
                     this.emit(STOP_CMD, event, payload);
                 };
 
                 const modiferKeyCB = (e) => {
-                    if (!!o.preventDefault) {
+                    if (!!preventDefaultBool) {
                         preventDefault(e);
                     }
 

--- a/src/app/lib/useKeybinding.js
+++ b/src/app/lib/useKeybinding.js
@@ -38,27 +38,9 @@ function useKeybinding(shuttleControlEvents) {
                 // add to store
                 let updatedCommandKeys = currentCommandKeys;
                 updatedCommandKeys[defaultCommand.cmd] = {
-                    title: defaultCommand.title,
                     cmd: defaultCommand.cmd,
                     keys: defaultCommand.keys,
-                    payload: defaultCommand.payload,
-                    preventDefault: defaultCommand.preventDefault,
                     isActive: defaultCommand.isActive,
-                    category: defaultCommand.category,
-                    callback: defaultCommand.callback
-                };
-                store.replace('commandKeys', updatedCommandKeys);
-            } else if (currentCommandKeys[defaultCommand.cmd].resetFlag) { // if reset flag is set, set everything but keys and isActive to default values
-                let updatedCommandKeys = currentCommandKeys;
-                updatedCommandKeys[defaultCommand.cmd] = {
-                    title: defaultCommand.title,
-                    cmd: defaultCommand.cmd,
-                    keys: currentCommandKeys[defaultCommand.cmd].keys,
-                    payload: defaultCommand.payload,
-                    preventDefault: defaultCommand.preventDefault,
-                    isActive: currentCommandKeys[defaultCommand.cmd].isActive,
-                    category: defaultCommand.category,
-                    callback: defaultCommand.callback
                 };
                 store.replace('commandKeys', updatedCommandKeys);
             }
@@ -71,15 +53,10 @@ function useKeybinding(shuttleControlEvents) {
                 if (_.isEmpty(shortcuts) || !shortcuts[defaultCommand.cmd]) {
                     // no default keys for gamepad
                     updatedProfileShortcuts[defaultCommand.cmd] = {
-                        title: defaultCommand.title,
+                        cmd: defaultCommand.cmd,
                         keys: defaultCommand.gamepadKeys || '',
                         keysName: defaultCommand.keysName || '',
-                        cmd: defaultCommand.cmd,
-                        payload: defaultCommand.payload,
-                        preventDefault: defaultCommand.preventDefault,
                         isActive: defaultCommand.isActive,
-                        category: defaultCommand.category,
-                        callback: defaultCommand.callback
                     };
                 }
                 return { ...profile, shortcuts: updatedProfileShortcuts };
@@ -104,12 +81,15 @@ function checkNumCalls() {
 export function removeOldKeybindings() {
     const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
     const currentCommandKeys = store.get('commandKeys', {});
+    console.log(currentCommandKeys);
     let updatedCommandKeys = currentCommandKeys;
 
     // remove keybindings that don't exist in any of the shuttleControlEvents arrays
     Object.entries(currentCommandKeys).forEach(([key, keybinding]) => {
         const event = allShuttleControlEvents[key];
-        if (event === undefined && keybinding.category !== MACRO_CATEGORY) {
+        // if the category doesn't exist, it's not a macro
+        // but if it's an old keybinding that still stores the category info, make sure it's not a macro
+        if (event === undefined && (!keybinding.category || keybinding.category !== MACRO_CATEGORY)) {
             delete updatedCommandKeys[key];
         }
     });
@@ -119,10 +99,11 @@ export function removeOldKeybindings() {
     const currentGamepadProfiles = store.get('workspace.gamepad.profiles', []);
     const updatedGamepadProfiles = currentGamepadProfiles.map(profile => {
         const shortcuts = profile.shortcuts;
+        console.log(shortcuts);
         let updatedProfileShortcuts = shortcuts;
         Object.entries(shortcuts).forEach(([key, keybinding]) => {
             const event = allShuttleControlEvents[key];
-            if (event === undefined && keybinding.category !== MACRO_CATEGORY) {
+            if (event === undefined && (!keybinding.category || keybinding.category !== MACRO_CATEGORY)) {
                 delete updatedProfileShortcuts[key];
             }
         });

--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -189,7 +189,8 @@ const migrateStore = () => {
         return;
     }
 
-    if (semver.lt(cnc.version, '1.2.3') || semver.lt(cnc.version, '1.2.3-EDGE')) {
+    if (semver.lt(cnc.version, '1.2.4') || semver.lt(cnc.version, '1.2.4-EDGE')) {
+        console.log('hello');
         const currentCommandKeys = store.get('commandKeys');
         let newCommandKeysList = {};
 
@@ -199,12 +200,23 @@ const migrateStore = () => {
                     element.cmd = element.id;
                 }
                 delete element.id;
-                // set flag so keybindings hook knows to change properties to the defaults
-                element.resetFlag = true;
                 newCommandKeysList[element.cmd] = element;
             });
-            store.replace('commandKeys', newCommandKeysList);
+        } else {
+            newCommandKeysList = currentCommandKeys;
         }
+
+        Object.entries(newCommandKeysList).forEach(([key, shortcut]) => {
+            delete shortcut.title;
+            delete shortcut.payload;
+            delete shortcut.preventDefault;
+            delete shortcut.category;
+            delete shortcut.callback;
+            newCommandKeysList[key] = shortcut;
+        });
+
+        console.log(newCommandKeysList);
+        store.replace('commandKeys', newCommandKeysList);
 
         const currentGamepadProfiles = store.get('workspace.gamepad.profiles', []);
         const updatedGamepadProfiles = currentGamepadProfiles.map(profile => {
@@ -219,7 +231,18 @@ const migrateStore = () => {
                     delete element.id;
                     updatedProfileShortcuts[element.cmd] = element;
                 });
+            } else {
+                updatedProfileShortcuts = shortcuts;
             }
+
+            Object.entries(updatedProfileShortcuts).forEach(([key, shortcut]) => {
+                delete shortcut.title;
+                delete shortcut.payload;
+                delete shortcut.preventDefault;
+                delete shortcut.category;
+                delete shortcut.callback;
+                updatedProfileShortcuts[key] = shortcut;
+            });
 
             if (!Array.isArray(profile.id)) {
                 profile.id = [profile.id];

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -88,6 +88,7 @@ import {
 } from './constants';
 import SecondaryVisualizer from './SecondaryVisualizer';
 import useKeybinding from '../../lib/useKeybinding';
+import shuttleEvents from '../../lib/shuttleEvents';
 
 const displayWebGLErrorMessage = () => {
     portal(({ onClose }) => (
@@ -1241,11 +1242,12 @@ class VisualizerWidget extends PureComponent {
             category: GENERAL_CATEGORY,
             callback: () => {
                 const shortcuts = store.get('commandKeys', {});
+                const allShuttleControlEvents = shuttleEvents.allShuttleControlEvents;
 
                 // Ignore shortcut for toggling all other shortcuts to
                 // allow them to be turned on and off
                 const allDisabled = Object.entries(shortcuts)
-                    .filter(([key, shortcut]) => shortcut.title !== 'Toggle Shortcuts')
+                    .filter(([key, shortcut]) => (allShuttleControlEvents[key] ? allShuttleControlEvents[key].title : shortcut.title) !== 'Toggle Shortcuts')
                     .every(([key, shortcut]) => !shortcut.isActive);
                 const keybindings = _.cloneDeep(shortcuts);
                 Object.entries(keybindings).forEach(([key, keybinding]) => {


### PR DESCRIPTION
- remove unnecessary shortcut info from store
- keybinds now only store cmd, keys, keysName, and isActive (where applicable)
- other properties are pulled from allShuttleControlEvents