### PR TITLE
Mi 1002 issue with continuous jogging for gamepad

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1626,7 +1626,6 @@ class GrblController {
                 this.command('gcode', code);
             },
             'jog:start': () => {
-                log.debug('INSIDE JOG START');
                 let [axes, feedrate = 1000, units = METRIC_UNITS] = args;
                 //const JOG_COMMAND_INTERVAL = 80;
                 let unitModal = (units === METRIC_UNITS) ? 'G21' : 'G20';
@@ -1638,13 +1637,11 @@ class GrblController {
                     $130 = Number($130);
                     $131 = Number($131);
                     $132 = Number($132);
-                    log.debug($130, $131, $132);
                     // Convert feedrate to metric if working in imperial - easier to convert feedrate and treat everything else as MM than opposite
                     if (units !== METRIC_UNITS) {
                         feedrate = (feedrate * 25.4).toFixed(2);
                         unitModal = 'G21';
                     }
-                    log.debug(`FEEDRATE :${feedrate}`);
 
                     const FIXED = 2;
 
@@ -1653,7 +1650,6 @@ class GrblController {
                     //we are moving in the negative direction we need to subtract the max travel
                     //by it to reach the maximum amount in that direction
                     const calculateAxisValue = ({ direction, position, maxTravel }) => {
-                        log.debug(`MAX TRAVEL: ${maxTravel}, DIRECTION: ${direction}, POSITION: ${position}`);
                         const OFFSET = 1;
 
                         // if (position === 0) {
@@ -1679,32 +1675,25 @@ class GrblController {
                     });
 
                     if (this.homingFlagSet) {
-                        log.debug('homingFlagSet IS TRUE');
                         const [xMaxLoc, yMaxLoc] = getAxisMaximumLocation($23);
 
                         if (axes.X) {
-                            axes.X = determineMaxMovement(Math.abs(mpos.x), axes.X, xMaxLoc, $130);
-                            log.debug(axes.X);
+                            axes.X = determineMaxMovement({ position: Math.abs(mpos.x), movementDirection: axes.X, limitLocation: xMaxLoc, limit: $130 });
                         }
                         if (axes.Y) {
-                            axes.Y = determineMaxMovement(Math.abs(mpos.y), axes.Y, yMaxLoc, $131);
-                            log.debug(axes.Y);
+                            axes.Y = determineMaxMovement({ position: Math.abs(mpos.y), movementDirection: axes.Y, limitLocation: yMaxLoc, limit: $131 });
                         }
                     } else {
-                        log.debug('homingFlagSet IS FALSE');
                         if (axes.X) {
                             axes.X = calculateAxisValue({ direction: Math.sign(axes.X), position: Math.abs(mpos.x), maxTravel: $130 });
-                            log.debug(axes.X);
                         }
                         if (axes.Y) {
                             axes.Y = calculateAxisValue({ direction: Math.sign(axes.Y), position: Math.abs(mpos.y), maxTravel: $131 });
-                            log.debug(axes.Y);
                         }
                     }
 
                     if (axes.Z) {
                         axes.Z = calculateAxisValue({ direction: Math.sign(axes.Z), position: Math.abs(mpos.z), maxTravel: $132 });
-                        log.debug(axes.Z);
                     }
                 } else {
                     jogFeedrate = 1250;

--- a/src/server/lib/homing.js
+++ b/src/server/lib/homing.js
@@ -43,10 +43,9 @@ export const getHomingLocation = (setting) => {
     return BACK_RIGHT;
 };
 
-export const determineMaxMovement = (position, movementDirection, limitLocation, limit) => {
+export const determineMaxMovement = ({ position, movementDirection, limitLocation, limit }) => {
     const OFFSET = 1;
     limit -= OFFSET; // We add a slight offset to make sure calculations don't fail due to rounding, 1.1mm is not noticeable in most cases
-
     if (position === 0) {
         if (movementDirection !== limitLocation) {
             return 0;


### PR DESCRIPTION
### Bug fixed:

**When the homing flag is false:**

1. The Jog direction and steps calculation bug was fixed.
2.  If the homing flag is false, the movements are limited to negative space only.
3. Negative jog = max travel limit - position - offset
4. Positive jog = position - offset

**When the homing flag is true:**

1. Negative values were sent into the function “determineMaxMovement” for situations where the drill is in negative locations; this would send the jog further in the -ve direction rather than positive when you try to jog in the +ve direction.
2. Now only absolute values are being sent to the above function, that fixes things.

### Tests:

**When the homing flag is false:**

1. Start the app and unlock the machine, initial position (0,0,0)
2. Used jog control widgets, keyboard shortcuts and Xbox controller
- As the machine position is (0,0,0), _positive jogs_ send X0, Y0 or Z0 commands and won’t go past the origin.
- _Negative jogs_ move axes in a negative direction, away from the origin, as the axis is far from the origin, a positive jog now takes the drill back to the origin.
3. Everything works as expected, but when you invert homing direction for any of the axes ($23), the axes won’t jog in a negative direction anymore because of the firmware image.

**When the homing flag is true:**

1. When none of the homing directions are inverted
- X-axis jogs are between (0 and -ve limit)
- Y-axis jogs are between (0 and -ve limit)
- Z-axis jogs are between (0 and -ve limit)
2. Invert homing direction for X-axis only.
- X-axis jogs now exist between (0 and +ve limit)
- Y and Z axis jogs exist between (0 and -ve limit)
3. Invert homing direction for Y-axis only.
- Y-axis jogs are now between (0 and +ve limit) only.
- X and Z axis jogs exist only between (0 and -ve limit)
4. Invert homing direction for the Z-axis.
- Not applicable for non-rotary jobs, cannot go in a negative direction otherwise.
5. Invert homing direction for both X and Y axis.
- Both X and Y-axis jogs exist only in (0 to +ve limit) space.
- Z axis jog stays the same (jogs only between 0 and -ve side of the axis)