### PR TITLE
Mi 1034 disable go to z when rotary mode is enabled

### DIFF
--- a/src/app/widgets/Location/DisplayPanel.jsx
+++ b/src/app/widgets/Location/DisplayPanel.jsx
@@ -160,7 +160,7 @@ class DisplayPanel extends PureComponent {
         }
     }
 
-    renderAxis = (axis, disabled = false) => {
+    renderAxis = (axis, disabled = false, disableGoTo = false) => {
         const { canClick, machinePosition, workPosition, actions, safeRetractHeight, units, homingEnabled } = this.props;
         let mpos = !disabled ? machinePosition[axis] : '0.00';
         const wpos = !disabled ? workPosition[axis] : '0.00';
@@ -189,7 +189,7 @@ class DisplayPanel extends PureComponent {
             <tr>
                 <td className={styles.coordinate}>
                     <GoToButton
-                        disabled={!canClick || disabled}
+                        disabled={!canClick || disabled || disableGoTo}
                         onClick={() => {
                             const commands = [];
                             const modal = (units === METRIC_UNITS) ? 'G21' : 'G20';
@@ -307,7 +307,7 @@ class DisplayPanel extends PureComponent {
                                     <tbody>
                                         {hasAxisX && this.renderAxis(AXIS_X)}
                                         {!isInRotaryMode && hasAxisY ? this.renderAxis(AXIS_Y) : this.renderAxis(AXIS_Y, true)}
-                                        {hasAxisZ && this.renderAxis(AXIS_Z)}
+                                        {hasAxisZ && this.renderAxis(AXIS_Z, false, isInRotaryMode)}
                                     </tbody>
                                 )
                                 : (
@@ -378,8 +378,7 @@ class DisplayPanel extends PureComponent {
                                                 disabled={!canHome}
                                                 buttons={['X', 'Y', 'Z', 'A']}
                                                 onClick={this.actions.startSingleAxisHoming}
-                                            >
-                                            </ButtonCollection>
+                                            />
                                         </>
                                     ) : (
                                         <FunctionButton

--- a/src/app/widgets/Location/index.jsx
+++ b/src/app/widgets/Location/index.jsx
@@ -62,6 +62,7 @@ import {
     AXIS_Y,
     AXIS_Z,
     AXIS_A,
+    WORKSPACE_MODE
 } from '../../constants';
 import {
     MODAL_NONE,
@@ -434,6 +435,14 @@ class LocationWidget extends PureComponent {
             const { state } = this.props;
             const { machinePosition, safeRetractHeight, homingEnabled } = this.state;
             const activeState = get(state, 'status.activeState');
+
+            const { ROTARY } = WORKSPACE_MODE;
+            const isInRotaryMode = store.get('workspace.mode') === ROTARY;
+
+            //Disable "Go to" shortcuts for Z axis when in rotary mode
+            if (isInRotaryMode && axisList[0] === AXIS_Z) {
+                return;
+            }
 
             if (!axisList || axisList.length === 0 || activeState !== GRBL_ACTIVE_STATE_IDLE) {
                 return;


### PR DESCRIPTION
### Changes:

1. Disabled the “Go to” button for the Z axis when the rotary mode is on.
2. Disabled “Go to” shortcuts for the Z axis when the rotary mode is on.

### Tests:

1. The “Go to” Z button is disabled when the Rotary mode toggle is turned on and vice versa.
2. No other buttons are affected.
3. Go to Z shortcut “Shift F” does not work when the Rotary mode is toggled on; vice versa. X-axis Go to shortcut still worked.
<img width="532" alt="Screenshot 2023-04-27 at 2 50 53 PM" src="https://user-images.githubusercontent.com/39333609/234964968-debb971b-11a9-4bec-9955-c0944dae3273.png">

