### PR TITLE
Mi 1042 revisit outline tool for rotary files

### DIFF
--- a/src/app/workers/Outline.worker.js
+++ b/src/app/workers/Outline.worker.js
@@ -39,11 +39,13 @@ onmessage = ({ data }) => {
             addLine: ({ motion }, v1, v2) => {
                 if (motion === 'G1' || motion === 'G0') {
                     if (shouldRotate(v1.a) || shouldRotate(v2.a)) {
-                        v1.y = rotateAxis('y', v1);
-                        v1.z = rotateAxis('z', v1);
+                        const newV1 = rotateAxis('y', v1);
+                        v1.y = newV1.y;
+                        v1.z = newV1.z;
 
-                        v2.y = rotateAxis('y', v2);
-                        v2.z = rotateAxis('z', v2);
+                        const newV2 = rotateAxis('y', v2);
+                        v2.y = newV2.y;
+                        v2.z = newV2.z;
                     }
 
                     vertices.push(vertex(v2.x, v2.y));


### PR DESCRIPTION
### Changes:
Updated the outline add line logic for files with A-axis (rotary files)

### Tests:
- Outline behaviour on 2D files looks the same with rotary mode OFF
- No more errors, it can outline 3D files now with rotary mode ON.

### Limitations with the current changes:
A user needs to turn ON or OFF Rotary Mode for a 3D or 2D file, respectively for the outline feature to work the right way.

