### PR TITLE
MI-1069-MAIN-Outline still appears on clicking percentages on chart

### DIFF
--- a/src/app/containers/Preferences/components/CustomPieChart.js
+++ b/src/app/containers/Preferences/components/CustomPieChart.js
@@ -5,18 +5,30 @@
 import React from 'react';
 import uniqueId from 'lodash/uniqueId';
 import { PieChart, Pie, Legend, Cell, Label } from 'recharts';
+import styled from '@emotion/styled';
+import './styles.css';
 
+const Text = styled.text`
+    font-size: 1rem;
+`;
+const G = styled.g`
+    &:focus {
+    outline: none;
+    border: none;
+  }
+`;
 
 const CustomPieChart = ({ propsData, height, width, showAnimation }) => {
     const renderLabelContent = (props) => {
         const { value, percent, x, y, midAngle } = props;
         return (
-            <g transform={`translate(${x}, ${y})`} textAnchor={midAngle < -90 || midAngle >= 90 ? 'end' : 'start'}>
-                <text x={0} y={0}>{`${value}`}</text>
-                <text x={0} y={20}>{`(${(percent * 100).toFixed(2)}%)`}</text>
-            </g>
+            <G transform={`translate(${x}, ${y})`} textAnchor={midAngle < -90 || midAngle >= 90 ? 'end' : 'start'}>
+                <Text x={0} y={0}>{`${value}`}</Text>
+                <Text x={0} y={20}>{`(${(percent * 100).toFixed(2)}%)`}</Text>
+            </G>
         );
     };
+
 
     return (
         <PieChart width={width} height={height} style={{ marginBottom: '30px' }}>
@@ -34,7 +46,9 @@ const CustomPieChart = ({ propsData, height, width, showAnimation }) => {
                 style={{ outline: 'none' }}
             >
                 {propsData.map((entry, index) => (
-                    <Cell style={{ outline: 'none' }} key={`slice-${uniqueId()}`} fill={entry.color} />
+                    <Cell
+                        style={{ outline: 'none' }} key={`slice-${uniqueId()}`} fill={entry.color}
+                    />
                 ))}
                 <Label width={50} position="center">
                     Jobs Run

--- a/src/app/containers/Preferences/components/styles.css
+++ b/src/app/containers/Preferences/components/styles.css
@@ -1,0 +1,4 @@
+.recharts-layer{
+  border: none;
+  outline: none;
+}


### PR DESCRIPTION
### Changes:

- Added CSS to hide focus borders and outlines.
- Changed Pichart font size to 1rem to fix hidden texts.

<img width="1276" alt="Screenshot 2023-05-19 at 5 39 41 PM" src="https://github.com/Sienci-Labs/gsender/assets/39333609/0ddf5935-912a-4a16-8926-fd1aaea94cb6">
