### PR TITLE
MI-1067-MAIN-Start from Line should also toggle overrides

### DIFF
--- a/src/app/widgets/Visualizer/WorkflowControl.jsx
+++ b/src/app/widgets/Visualizer/WorkflowControl.jsx
@@ -338,7 +338,7 @@ class WorkflowControl extends PureComponent {
         this.setState(prev => ({ startFromLine: { ...prev.startFromLine, showModal: false, needsRecovery: false } }));
         const newSafeHeight = units === IMPERIAL_UNITS ? safeHeight * 25.4 : safeHeight;
         controller.command('gcode:start', value, zMax, newSafeHeight);
-
+        reduxStore.dispatch({ type: UPDATE_JOB_OVERRIDES, payload: { isChecked: true, toggleStatus: 'overrides' } });
         Toaster.pop({
             msg: 'Running Start From Specific Line Command',
             type: TOASTER_SUCCESS,


### PR DESCRIPTION
### Changes:
Starting a job from any line now toggles to job overrides.

### Tests:

1. Loaded the Circle_Diamond_Square_Calibration file and started multiple times from different line numbers. Turns on override every time and goes back to file stats when stopped.
2. Tested out the normal flow, works as expected for all other scenarios.