### PR TITLE
Mi 1073 main responsiveness on mobile version visualizer still appearing

### DIFF
--- a/src/app/components/NavLogo/index.styl
+++ b/src/app/components/NavLogo/index.styl
@@ -59,7 +59,7 @@ animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);
 }
 }
 
-@media (max-width:599px) {
+@media (max-width:639px) {
   .NavLogo{
     display: none;  
   }

--- a/src/app/components/NavLogo/index.styl
+++ b/src/app/components/NavLogo/index.styl
@@ -59,7 +59,7 @@ animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);
 }
 }
 
-@media (max-width:639px) {
+@media (max-width: 639px), (max-device-width: 639px) {
   .NavLogo{
     display: none;  
   }

--- a/src/app/components/Widget/index.styl
+++ b/src/app/components/Widget/index.styl
@@ -131,7 +131,7 @@ PRIMARY_COLOR = #3e85c7;
         padding: 15px;
         min-width: 330px;
         background-color: #e5e7eb;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             padding: 10px;
         }
     }

--- a/src/app/components/Widget/index.styl
+++ b/src/app/components/Widget/index.styl
@@ -131,7 +131,7 @@ PRIMARY_COLOR = #3e85c7;
         padding: 15px;
         min-width: 330px;
         background-color: #e5e7eb;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             padding: 10px;
         }
     }

--- a/src/app/containers/Header/Header.jsx
+++ b/src/app/containers/Header/Header.jsx
@@ -299,11 +299,11 @@ class Header extends PureComponent {
 
     addResizeEventListener() {
         this.onResizeThrottled = _.throttle(this.updateScreenSize, 25);
-        window.visualViewport.addEventListener('resize', this.onResizeThrottled);
+        window.addEventListener('resize', this.onResizeThrottled);
     }
 
     removeResizeEventListener() {
-        window.visualViewport.removeEventListener('resize', this.onResizeThrottled);
+        window.removeEventListener('resize', this.onResizeThrottled);
         this.onResizeThrottled = null;
     }
 
@@ -325,7 +325,7 @@ class Header extends PureComponent {
     }
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width <= 599;
+        const isMobile = window.screen.width <= 639;
         this.setState({
             mobile: isMobile
         });

--- a/src/app/containers/NavSidebar/index.styl
+++ b/src/app/containers/NavSidebar/index.styl
@@ -85,7 +85,7 @@
   }
 }
 
-@media (max-width: 639px) {
+@media (max-width: 639px), (max-device-width: 639px) {
   .Sidebar{
     display: none;
   }

--- a/src/app/containers/NavSidebar/index.styl
+++ b/src/app/containers/NavSidebar/index.styl
@@ -85,7 +85,7 @@
   }
 }
 
-@media (max-width: 599px) {
+@media (max-width: 639px) {
   .Sidebar{
     display: none;
   }

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -305,11 +305,11 @@ class Workspace extends PureComponent {
     };
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width <= 639;
+        const isMobile = window.screen.width <= 639;
         this.setState({
             mobile: isMobile
         });
-        const isTablet = window.visualViewport.width > 639; //width smaller than height and wider than a phone
+        const isTablet = window.screen.width > 639; //width smaller than height and wider than a phone
         this.setState({
             tablet: isTablet
         });
@@ -492,11 +492,11 @@ class Workspace extends PureComponent {
             this.updateScreenSize();
             this.resizeDefaultContainer();
         }, 25);
-        window.visualViewport.addEventListener('resize', this.onResizeThrottled);
+        window.addEventListener('resize', this.onResizeThrottled);
     }
 
     removeResizeEventListener() {
-        window.visualViewport.removeEventListener('resize', this.onResizeThrottled);
+        window.removeEventListener('resize', this.onResizeThrottled);
         this.onResizeThrottled = null;
     }
 

--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -305,11 +305,11 @@ class Workspace extends PureComponent {
     };
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width <= 599;
+        const isMobile = window.visualViewport.width <= 639;
         this.setState({
             mobile: isMobile
         });
-        const isTablet = window.visualViewport.width > 599; //width smaller than height and wider than a phone
+        const isTablet = window.visualViewport.width > 639; //width smaller than height and wider than a phone
         this.setState({
             tablet: isTablet
         });

--- a/src/app/containers/Workspace/index.styl
+++ b/src/app/containers/Workspace/index.styl
@@ -99,9 +99,6 @@
         max-height: 100%;
         background-color: #d1d5db
         position: relative;
-         @media (max-width: 639px), (max-device-width: 639px) {
-            height: 100%;
-        }
     }
 
     .workspace-table-row {
@@ -152,13 +149,7 @@
     .primary-container-mobile {
         height: 100%;
         width: 100%;
-        min-width: 365px;
-        max-width: 500px;
-        overflow: hidden;
-        @media (max-width: 639px), (max-device-width: 639px) {
-            min-width: auto;
-            max-width: auto;
-        }
+        overflow-y: auto;
         &.hidden {
             display: none;
         }

--- a/src/app/containers/Workspace/index.styl
+++ b/src/app/containers/Workspace/index.styl
@@ -45,7 +45,7 @@
     line-height: 1.5rem;
     background: none;
     position: relative;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
     overflow-y: visible;
     }
     &::-webkit-scrollbar {
@@ -99,7 +99,7 @@
         max-height: 100%;
         background-color: #d1d5db
         position: relative;
-         @media (max-width: 599px) {
+         @media (max-width: 639px) {
             height: 100%;
         }
     }
@@ -155,7 +155,7 @@
         min-width: 365px;
         max-width: 500px;
         overflow: hidden;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             min-width: auto;
             max-width: auto;
         }
@@ -186,7 +186,7 @@
     }
 }
 
-@media (max-width: 599px) {
+@media (max-width: 639px) {
     .primary-container{
         min-height: 650px;
     }

--- a/src/app/containers/Workspace/index.styl
+++ b/src/app/containers/Workspace/index.styl
@@ -45,7 +45,7 @@
     line-height: 1.5rem;
     background: none;
     position: relative;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
     overflow-y: visible;
     }
     &::-webkit-scrollbar {
@@ -99,7 +99,7 @@
         max-height: 100%;
         background-color: #d1d5db
         position: relative;
-         @media (max-width: 639px) {
+         @media (max-width: 639px), (max-device-width: 639px) {
             height: 100%;
         }
     }
@@ -155,7 +155,7 @@
         min-width: 365px;
         max-width: 500px;
         overflow: hidden;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             min-width: auto;
             max-width: auto;
         }
@@ -186,7 +186,7 @@
     }
 }
 
-@media (max-width: 639px) {
+@media (max-width: 639px), (max-device-width: 639px) {
     .primary-container{
         min-height: 650px;
     }

--- a/src/app/containers/Workspace/widgets.styl
+++ b/src/app/containers/Workspace/widgets.styl
@@ -27,7 +27,7 @@
     grid-template-rows: minmax(0, 32fr) minmax(0, 38fr) minmax(0, 30fr);
     grid-gap: 0.5rem;
     width: 100%;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
             grid-template: none;
     }
     :global {
@@ -54,7 +54,7 @@
     min-width: 360px;
     background-color: #d1d5db;
     width: auto;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         display: none;
     }
     @media (min-width: 1921px) {

--- a/src/app/containers/Workspace/widgets.styl
+++ b/src/app/containers/Workspace/widgets.styl
@@ -27,7 +27,7 @@
     grid-template-rows: minmax(0, 32fr) minmax(0, 38fr) minmax(0, 30fr);
     grid-gap: 0.5rem;
     width: 100%;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
             grid-template: none;
     }
     :global {
@@ -54,7 +54,7 @@
     min-width: 360px;
     background-color: #d1d5db;
     width: auto;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         display: none;
     }
     @media (min-width: 1921px) {

--- a/src/app/widgets/JogControl/index.styl
+++ b/src/app/widgets/JogControl/index.styl
@@ -111,7 +111,7 @@
     display: grid;
     grid-gap: 2rem;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         grid-gap: 5px;
     }
 }
@@ -214,7 +214,7 @@
     height: 100%;
     align-self: center;
     align-items: center;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         display: block;
     }
 }
@@ -228,7 +228,7 @@
     @media (max-height: 820px) {
         width: 43%;
     }
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         width: 91%;
         grid-gap: 12px;
     }
@@ -256,7 +256,7 @@
     button + button {
         margin-left: 0;
     }
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         display: flex;
         width: 89%;
         margin: 1rem;

--- a/src/app/widgets/JogControl/index.styl
+++ b/src/app/widgets/JogControl/index.styl
@@ -111,7 +111,7 @@
     display: grid;
     grid-gap: 2rem;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         grid-gap: 5px;
     }
 }
@@ -214,7 +214,7 @@
     height: 100%;
     align-self: center;
     align-items: center;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         display: block;
     }
 }
@@ -228,7 +228,7 @@
     @media (max-height: 820px) {
         width: 43%;
     }
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         width: 91%;
         grid-gap: 12px;
     }
@@ -256,7 +256,7 @@
     button + button {
         margin-left: 0;
     }
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         display: flex;
         width: 89%;
         margin: 1rem;

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -97,7 +97,7 @@
     width: 100%;
     display: flex;
     justify-content: space-around;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         display: block;
     }
 }
@@ -112,7 +112,7 @@
     grid-template-columns: repeat(3,minmax(0,1fr));
     height: max-content;
     margin: auto;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         margin-top: 1rem;
         width: 50%;
         height: 40%
@@ -163,7 +163,7 @@
         transform: translateX(5%) rotate(45deg);
         width: 300%;
         text-align: left;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             width: 277%;
             transform: translateX(9%) rotate(45deg);
             font-size: 1.4rem !important;
@@ -185,7 +185,7 @@
          transform: translateX(-72%) rotate(-45deg);
         width: 300%;
         text-align: right;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             width: 271%;
             transform: translateX(-73%) rotate(-45deg);
             font-size: 1.4rem !important;
@@ -210,7 +210,7 @@
         position: relative;
         bottom: 8px;
 		display: block;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             width: 97%;
             transform: translateX(1%) rotate(135deg);
             font-size: 1.4rem !important;
@@ -236,7 +236,7 @@
         bottom: 8px;
 		display: block;
 		text-align: right;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             width: 99%;
             transform: translate(3%) rotate(225deg)
             font-size: 1.4rem !important;

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -97,7 +97,7 @@
     width: 100%;
     display: flex;
     justify-content: space-around;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         display: block;
     }
 }
@@ -112,7 +112,7 @@
     grid-template-columns: repeat(3,minmax(0,1fr));
     height: max-content;
     margin: auto;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         margin-top: 1rem;
         width: 50%;
         height: 40%
@@ -163,7 +163,7 @@
         transform: translateX(5%) rotate(45deg);
         width: 300%;
         text-align: left;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             width: 277%;
             transform: translateX(9%) rotate(45deg);
             font-size: 1.4rem !important;
@@ -185,7 +185,7 @@
          transform: translateX(-72%) rotate(-45deg);
         width: 300%;
         text-align: right;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             width: 271%;
             transform: translateX(-73%) rotate(-45deg);
             font-size: 1.4rem !important;
@@ -210,7 +210,7 @@
         position: relative;
         bottom: 8px;
 		display: block;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             width: 97%;
             transform: translateX(1%) rotate(135deg);
             font-size: 1.4rem !important;
@@ -236,7 +236,7 @@
         bottom: 8px;
 		display: block;
 		text-align: right;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             width: 99%;
             transform: translate(3%) rotate(225deg)
             font-size: 1.4rem !important;

--- a/src/app/widgets/Location/index.styl
+++ b/src/app/widgets/Location/index.styl
@@ -77,6 +77,9 @@
 }
 
 .control-buttons {
+    @media (max-width: 639px), (max-device-width: 639px) {
+        max-width: 33%;
+    }
     padding: 0 2rem
     display: flex;
     flex-grow 1;
@@ -84,6 +87,12 @@
    padding: 0 1rem;
     button {
         margin-bottom: 10px;
+    }
+}
+
+.displaypanelTable{
+     @media (max-width: 639px), (max-device-width: 639px) {
+        width: 50%;
     }
 }
 

--- a/src/app/widgets/NavbarConnection/Index.styl
+++ b/src/app/widgets/NavbarConnection/Index.styl
@@ -248,7 +248,7 @@
   min-height: 50px;
 }
 
-@media (max-width: 639px) {
+@media (max-width: 639px), (max-device-width: 639px) {
   .NavbarConnection{
     margin: auto;  
   }

--- a/src/app/widgets/NavbarConnection/Index.styl
+++ b/src/app/widgets/NavbarConnection/Index.styl
@@ -248,7 +248,7 @@
   min-height: 50px;
 }
 
-@media (max-width: 599px) {
+@media (max-width: 639px) {
   .NavbarConnection{
     margin: auto;  
   }

--- a/src/app/widgets/NavbarConnection/NavbarConnection.jsx
+++ b/src/app/widgets/NavbarConnection/NavbarConnection.jsx
@@ -57,16 +57,16 @@ class NavbarConnection extends PureComponent {
 
     addResizeEventListener() {
         this.onResizeThrottled = _.throttle(this.updateScreenSize, 25);
-        window.visualViewport.addEventListener('resize', this.onResizeThrottled);
+        window.addEventListener('resize', this.onResizeThrottled);
     }
 
     removeResizeEventListener() {
-        window.visualViewport.removeEventListener('resize', this.onResizeThrottled);
+        window.removeEventListener('resize', this.onResizeThrottled);
         this.onResizeThrottled = null;
     }
 
     updateScreenSize = () => {
-        const isMobile = window.visualViewport.width <= 599;
+        const isMobile = window.screen.width <= 639;
         this.setState({
             mobile: isMobile
         });
@@ -124,7 +124,7 @@ class NavbarConnection extends PureComponent {
         const { connected, ports, connecting, baudrate, controllerType, alertMessage, port, unrecognizedPorts, showUnrecognized } = state;
         const { isActive } = this.state;
         const iconState = this.getIconState(connected, connecting, alertMessage);
-        const isMobile = window.visualViewport.width <= 599;
+        const isMobile = window.screen.width <= 639;
 
         return (
             <div

--- a/src/app/widgets/Probe/index.styl
+++ b/src/app/widgets/Probe/index.styl
@@ -91,7 +91,7 @@
     span {
         margin-top: 10px;
     }
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         margin-top: 1rem;
     }
 }
@@ -129,7 +129,7 @@
     min-height: 200px;
     display: flex;
     flex-direction: row;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         width: 100%;
         display: flex; 
         flex-direction: column;
@@ -137,7 +137,7 @@
 }
 
 .modalOverride{
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         min-width: 20% !important;
         max-width: 80% !important;
     }
@@ -148,7 +148,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-     @media (max-width: 599px) {
+     @media (max-width: 639px) {
         width: 100%;
         order: 2;
     }
@@ -157,7 +157,7 @@
     width: 40%;
     display: flex;
     flex-direction: column;
-    @media (max-width: 599px) {
+    @media (max-width: 639px) {
         margin: auto;
         margin-bottom: 1rem;
     }
@@ -181,7 +181,7 @@
     > img {
         width: 15vh;
         margin: 0 auto;
-        @media (max-width: 599px) {
+        @media (max-width: 639px) {
             width: 80%;
         }
     }

--- a/src/app/widgets/Probe/index.styl
+++ b/src/app/widgets/Probe/index.styl
@@ -91,7 +91,7 @@
     span {
         margin-top: 10px;
     }
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         margin-top: 1rem;
     }
 }
@@ -129,7 +129,7 @@
     min-height: 200px;
     display: flex;
     flex-direction: row;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         width: 100%;
         display: flex; 
         flex-direction: column;
@@ -137,7 +137,7 @@
 }
 
 .modalOverride{
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         min-width: 20% !important;
         max-width: 80% !important;
     }
@@ -148,7 +148,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-     @media (max-width: 639px) {
+     @media (max-width: 639px), (max-device-width: 639px) {
         width: 100%;
         order: 2;
     }
@@ -157,7 +157,7 @@
     width: 40%;
     display: flex;
     flex-direction: column;
-    @media (max-width: 639px) {
+    @media (max-width: 639px), (max-device-width: 639px) {
         margin: auto;
         margin-bottom: 1rem;
     }
@@ -181,7 +181,7 @@
     > img {
         width: 15vh;
         margin: 0 auto;
-        @media (max-width: 639px) {
+        @media (max-width: 639px), (max-device-width: 639px) {
             width: 80%;
         }
     }

--- a/webpack.config.app.production.js
+++ b/webpack.config.app.production.js
@@ -238,6 +238,9 @@ module.exports = {
         new HtmlWebpackPlugin({
             chunksSortMode: 'dependency', // Sort chunks by dependency
             title: `gSender ${pkg.version}`,
+            meta: {
+                'viewport': 'width=device-width, initial-scale=1, maximum-scale=1',
+            }
         })
     ],
     resolve: {


### PR DESCRIPTION
### Changes:
- Visualizer shows up only for screens wider than 639px.
- Added max-device-width styles so the CSS now checks both viewport width and screen resolution.
- Users with smaller-resolution desktop screens (480p) will see a visualizer now.
- Force-injected viewport into the build <head>

### Things to note:
- Have forced it to hide the visualizer on 'desktop view' on a mobile phone, but as this option forces in a desktop screen size, users will see a bit stretched-out view of what they would generally see on a mobile view.