### PR TITLE
Mi 1101 main size and filename swapped in meta object

### DIFF
--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -370,7 +370,6 @@ class Workspace extends PureComponent {
                 .then((res) => {
                     const { name = '', gcode = '' } = { ...res.body };
                     pubsub.publish('gcode:load', { name, gcode });
-                    log.error('Failed to upload G-code file');
                 })
                 .catch((res) => {
                     log.error('Failed to upload G-code file');

--- a/src/app/widgets/JobStatus/JobStatus.jsx
+++ b/src/app/widgets/JobStatus/JobStatus.jsx
@@ -99,8 +99,7 @@ class JobStatus extends PureComponent {
                                 <>
                                     <div className={styles['file-name']}>
                                         <TooltipCustom content={`${name} (${this.fileSizeFormat(size)}, ${total} lines)`} style={{ wordWrap: 'break-word' }}>
-                                            <span className={styles['file-text']}>{name}</span>{' '}<span>({this.fileSizeFormat(size)}, {total} lines)</span>
-                                            <span style={{ marginLeft: '2rem' }} />
+                                            <span className={styles['file-text']}>{name}</span>{' '}<span style={{ marginRight: '2rem' }}>({this.fileSizeFormat(size)}, {total} lines)</span>
                                         </TooltipCustom>
                                         {connection.isConnected
                                             ? (

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -326,7 +326,7 @@ class CNCEngine {
                 if (this.hasFileLoaded()) {
                     if (numClients === 0) {
                         controller.loadFile(this.gcode, this.meta);
-                        socket.emit('file:load', this.gcode, this.meta.name, this.meta.size);
+                        socket.emit('file:load', this.gcode, this.meta.size, this.meta.name);
                     } else {
                         log.debug('File already loaded in another socket');
                     }


### PR DESCRIPTION
### Bug fix:
- The event 'file:load' now sends data in the right order on page refresh or content reload.

<img width="1593" alt="Screenshot 2023-06-05 at 2 42 40 PM" src="https://github.com/Sienci-Labs/gsender/assets/39333609/f426ca47-6b7e-48fb-beef-d34da2306927">
