### PR TITLE
MI-1108-MAIN-fix-copyright-in-About-component-to-get-current-year-from-Date-instance

### DIFF
--- a/src/app/containers/Preferences/About/HeaderArea.js
+++ b/src/app/containers/Preferences/About/HeaderArea.js
@@ -7,6 +7,7 @@ import { version } from '../../../../package.json';
 import styles from './index.styl';
 
 const HeaderArea = () => {
+    const year = new Date().getFullYear();
     return (
         <div className={styles.headerArea}>
             <div className={styles.headerLeft}>
@@ -19,7 +20,7 @@ const HeaderArea = () => {
             </div>
 
             <div className={styles.headerRight}>
-                <p>Copyright &copy; 2022 Sienci Labs Inc.</p>
+                <p>Copyright &copy; {year} Sienci Labs Inc.</p>
                 <div className={styles.country}><span>Made in Canada</span> <img src={canadaFlagIcon} alt="Canada Flag" /></div>
                 <p>
                     <a


### PR DESCRIPTION
### Changes:
- Dynamic copyright year in about section

<img width="1056" alt="Screenshot 2023-06-08 at 9 59 11 AM" src="https://github.com/Sienci-Labs/gsender/assets/39333609/04e43589-4a4a-4de0-920a-9ad16479ece3">
