### PR TITLE
MI-1099-MAIN-connect-from-remote-client-stops-job-in-main-client

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1293,6 +1293,9 @@ class GrblController {
             },
             'gcode:load': () => {
                 let [name, gcode, context = {}, callback = noop] = args;
+                if (this.workflow.state === WORKFLOW_STATE_RUNNING) {
+                    return;
+                }
                 if (typeof context === 'function') {
                     callback = context;
                     context = {};

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -323,12 +323,8 @@ class CNCEngine {
 
                 controller.addConnection(socket);
 
-                // Check if a job is already loaded and running
-                if (this.hasFileLoaded() && this.isJobRunning()) {
-                    // A job is already running, don't load the file
-                    log.debug('A job is already loaded and running on the controller');
-                    socket.emit('file:load', this.gcode, this.meta.size, this.meta.name);
-                } else if (this.hasFileLoaded()) { // Load file to controller if it exists
+                // Load file to controller if it exists
+                if (this.hasFileLoaded()) {
                     if (numClients === 0) {
                         controller.loadFile(this.gcode, this.meta);
                         socket.emit('file:load', this.gcode, this.meta.size, this.meta.name);

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -322,7 +322,6 @@ class CNCEngine {
                 }
 
                 controller.addConnection(socket);
-
                 // Load file to controller if it exists
                 if (this.hasFileLoaded()) {
                     if (numClients === 0) {
@@ -363,7 +362,6 @@ class CNCEngine {
                     callback(null);
                 });
             });
-
 
             // Close serial port
             socket.on('close', (port, callback = noop) => {
@@ -526,10 +524,6 @@ class CNCEngine {
 
     hasFileLoaded() {
         return this.gcode !== null;
-    }
-
-    isJobRunning() {
-        return this.server !== null;
     }
 }
 

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -322,8 +322,13 @@ class CNCEngine {
                 }
 
                 controller.addConnection(socket);
-                // Load file to controller if it exists
-                if (this.hasFileLoaded()) {
+
+                // Check if a job is already loaded and running
+                if (this.hasFileLoaded() && this.isJobRunning()) {
+                    // A job is already running, don't load the file
+                    log.debug('A job is already loaded and running on the controller');
+                    socket.emit('file:load', this.gcode, this.meta.size, this.meta.name);
+                } else if (this.hasFileLoaded()) { // Load file to controller if it exists
                     if (numClients === 0) {
                         controller.loadFile(this.gcode, this.meta);
                         socket.emit('file:load', this.gcode, this.meta.size, this.meta.name);
@@ -362,6 +367,7 @@ class CNCEngine {
                     callback(null);
                 });
             });
+
 
             // Close serial port
             socket.on('close', (port, callback = noop) => {
@@ -524,6 +530,10 @@ class CNCEngine {
 
     hasFileLoaded() {
         return this.gcode !== null;
+    }
+
+    isJobRunning() {
+        return this.server !== null;
     }
 }
 


### PR DESCRIPTION
### Changes:

- Added guard so that when a job is running on the server and a client reconnects, it only loads the file to the visualizer and not on the controller. That means a job won’t stop if you reconnect a client if it is running on the server. 

### Tests:

- Does not stop a job if you close the window and connect from a new window.
- It does not stop a job if you refresh the page.
- It does not stop a job if auto-connect is off and you connect a machine after refreshing a page or re-open it from a different browser.


https://github.com/Sienci-Labs/gsender/assets/39333609/3de7be1e-f377-42f7-ab79-0f0bd008310c

