### PR TITLE
Spindle Slider Not Grabbing Values Correctly

### DIFF
--- a/src/app/widgets/Spindle/index.jsx
+++ b/src/app/widgets/Spindle/index.jsx
@@ -267,12 +267,37 @@ class SpindleWidget extends PureComponent {
             mode,
             laser
         } = this.state;
+        const {
+            spindleMax,
+            spindleMin
+        } = this.props;
 
         this.config.set('laser.duration', laser.duration);
         this.config.set('laser.power', laser.power);
         this.config.set('mode', mode);
         this.config.set('minimized', minimized);
-        this.config.set('speed', spindleSpeed);
+
+        // set speed, taking the limits into account
+        let newSpindleSpeed = spindleSpeed;
+        if (mode === SPINDLE_MODE) {
+            if (spindleSpeed > spindleMax) {
+                newSpindleSpeed = spindleMax;
+            } else if (spindleSpeed < spindleMin) {
+                newSpindleSpeed = spindleMin;
+            }
+        }
+        this.config.set('speed', newSpindleSpeed);
+        // update the new spindle speed in state and send it to the controller
+        this.updateSpindleSpeed(newSpindleSpeed);
+    }
+
+    updateSpindleSpeed(speed) {
+        const { spindleSpeed } = this.state;
+        // only update if there is a change
+        if (spindleSpeed !== speed) {
+            this.setState({ spindleSpeed: speed });
+            controller.command('spindlespeed:change', speed);
+        }
     }
 
     getInitialState() {
@@ -289,16 +314,25 @@ class SpindleWidget extends PureComponent {
     }
 
     enableSpindleMode() {
-        const { units } = this.props;
+        const { units, spindleMax: maxPower, spindleMin: minPower } = this.props;
         const preferredUnits = store.get('workspace.units') === IMPERIAL_UNITS ? 'G20' : 'G21';
         const active = this.getSpindleActiveState();
+
+        // get previously saved spindle values
+        const spindleMin = this.config.get('spindleMin');
+        const spindleMax = this.config.get('spindleMax');
+
+        // save current laser values
+        let laser = this.config.get('laser');
+        laser.maxPower = maxPower;
+        laser.minPower = minPower;
+        this.config.set('laser', laser);
+
         if (active) {
             this.isSpindleOn = false;
             controller.command('gcode', 'M5');
             //this.setInactive();
         }
-        const spindleMin = this.config.get('spindleMin');
-        const spindleMax = this.config.get('spindleMax');
         const commands = [
             preferredUnits,
             ...this.getSpindleOffsetCode(),
@@ -407,12 +441,18 @@ class SpindleWidget extends PureComponent {
 
 
     enableLaserMode() {
-        const { units } = this.props;
+        const { units, spindleMax, spindleMin } = this.props;
         const preferredUnits = store.get('workspace.units') === IMPERIAL_UNITS ? 'G20' : 'G21';
         const active = this.getSpindleActiveState();
-        const laser = this.config.get('laser');
 
+        // get previously saved laser values
+        const laser = this.config.get('laser');
         const { minPower, maxPower } = laser;
+
+        // save current spindle values
+        this.config.set('spindleMin', spindleMin);
+        this.config.set('spindleMax', spindleMax);
+
         if (active) {
             this.isLaserOn = false;
             controller.command('gcode', 'M5');
@@ -456,8 +496,8 @@ class SpindleWidget extends PureComponent {
     }
 
     render() {
-        const { embedded, spindleModal } = this.props;
-        const { minimized, isFullscreen, spindleMin, spindleMax } = this.state;
+        const { embedded, spindleModal, spindleMin, spindleMax } = this.props;
+        const { minimized, isFullscreen } = this.state;
         const state = {
             ...this.state,
             spindleModal,

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gSender",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "productName": "gSender",
   "description": "CNC Milling Controller",
   "author": {


### PR DESCRIPTION
The code now uses the store to save spindle max/min and laser power max/min values when switching modes, and redux for the current values that should be used in the UI. This fixed issues with the spindle slider numbers not updating properly when changing the limits, and when switching from laser to spindle mode. The current spindle slider value should now change based on the limits (ex. if it is 50000 and the max is changed to 30000, the value would change to 30000).