### PR TITLE
Emit the `gcode:load` event

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -1473,6 +1473,7 @@ class GrblController {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
+                this.emit('gcode:load', name, gcode, context);
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);
 

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -1505,7 +1505,7 @@ class GrblHalController {
                     callback(new Error(`Invalid G-code: name=${name}`));
                     return;
                 }
-
+                this.emit('gcode:load', name, gcode, context);
 
                 log.debug(`Load G-code: name="${this.sender.state.name}", size=${this.sender.state.gcode.length}, total=${this.sender.state.total}`);
 


### PR DESCRIPTION
:wave: I maintain  a cncjs pendant ([cncjs-pendant-streamdeck](https://github.com/Billiam/cncjs-pendant-streamdeck)) and am looking to add support for gsender.

One feature missing from gsender (that is available in cncjs) is the `gcode:load` event. This allows rendering/animating the currently loaded gcode in the pendant, as well as displaying dimensions and extent.