### PR TITLE
Ignore USB vendor/product ID casing in device list

### DIFF
--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -64,6 +64,14 @@ const caseInsensitiveEquals = (str1, str2) => {
     return str1 === str2;
 };
 
+// Case insensitive includes.
+// @param {array} arr Array to check.
+// @param {string} val Value to check for in the array.
+// @return {boolean} True if val is in arr, ignoring case.
+const caseInsensitiveIncludes = (arr, val) => {
+    return arr.some((arrVal) => caseInsensitiveEquals(arrVal, val));
+};
+
 const isValidController = (controller) => (
     // Standard GRBL
     caseInsensitiveEquals(GRBL, controller) ||
@@ -275,7 +283,13 @@ class CNCEngine {
                         const validProductIDs = ['6015', '6001', '606D', '003D', '0042', '0043', '2341', '7523', 'EA60', '2303', '2145', '0AD8', '08D8', '5740', '0FA7'];
                         const validVendorIDs = ['1D50', '0403', '2341', '0042', '1A86', '10C4', '067B', '03EB', '16D0', '0483'];
                         let [recognizedPorts, unrecognizedPorts] = partition(ports, (port) => {
-                            return validProductIDs.includes(port.productId) && validVendorIDs.includes(port.vendorId);
+                            if (!port.vendorId || !port.productId) {
+                                return false;
+                            }
+                            return (
+                                caseInsensitiveIncludes(validProductIDs, port.productId) &&
+                                caseInsensitiveIncludes(validVendorIDs, port.vendorId)
+                            );
                         });
 
                         const portInfoMapFn = (port) => {


### PR DESCRIPTION
On macOS, USB product/vendor IDs are lower-case hex encoded strings. This change implements case-insensitive comparison for product and vendor IDs, ensuring that recognized devices (such as ESP32) appear correctly under the "Recognized Devices" section.

A new `caseInsensitiveIncludes` function has been added to perform case-insensitive checks on array values. The port recognition logic now uses this function to compare product and vendor IDs, accommodating both upper and lower case hex strings.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jC1q6l54FyZpiin2fzbi/ef431ee0-4d03-4daf-b457-4172dead5745.png)