### PR TITLE
Support Negative Thickness Values for Probing (XY and Z)

### DIFF
--- a/src/app/src/features/Preferences/Preferences.jsx
+++ b/src/app/src/features/Preferences/Preferences.jsx
@@ -422,14 +422,14 @@ class PreferencesPage extends PureComponent {
                 });
             },
             changeXYThickness: (e) => {
-                const value = Math.abs(Number(e.target.value));
+                const value = Number(e.target.value);
                 const probe = { ...this.state.probe };
                 const { units } = this.state;
 
                 const metricValue =
                     units === METRIC_UNITS
                         ? value
-                        : Math.abs(convertToMetric(value));
+                        : convertToMetric(value);
 
                 this.setState({
                     probe: {
@@ -440,7 +440,7 @@ class PreferencesPage extends PureComponent {
                 pubsub.publish('probe:updated');
             },
             changeZThickness: (e) => {
-                const value = Math.abs(Number(e.target.value));
+                const value = Number(e.target.value);
                 const probe = { ...this.state.probe };
                 const { units } = this.state;
 


### PR DESCRIPTION
**Summary**
This update adds support for negative thickness values during XY and Z probing operations. This enhancement is particularly useful for users utilizing 3D probes, which often incorporate spring-loaded tips that introduce a small offset needing compensation.

**Motivation**
3D probes have a physical spring mechanism that can slightly compress upon contact, requiring the ability to input negative thickness values to ensure accurate probing results.

**Changes**

Updated the input validation logic to allow negative values for thickness in XY and Z probing.

**Benefits**
Enables accurate probing with 3D probes.

Improves flexibility and user customization of probing routines.

**Notes**
No changes to the probing hardware logic—only parameter input and validation have been updated.
Tested with standard probing routines to ensure backward compatibility.

Here's the video of testing: https://youtu.be/8EzMtqeyHCw
