### PR TITLE
[MI-1993]: Standard Block Settings Show Up in Modified When Default

### DIFF
--- a/src/app/src/definitions/firmware.ts
+++ b/src/app/src/definitions/firmware.ts
@@ -1,4 +1,5 @@
 import { FIRMWARE_TYPES, HOMING_LOCATIONS } from '../constants';
+import { BasicType } from './general';
 
 // Types
 
@@ -22,6 +23,33 @@ export interface EEPROMDescriptions {
     format: string;
     unitString: string;
     details: string;
+}
+
+export interface FilteredEEPROM {
+    unit: string;
+    setting: EEPROM;
+    message?: string;
+    category?: string;
+    units?: string;
+    inputType?: string;
+    maxChars?: number;
+    defaultValue?: BasicType;
+    values?: BasicType;
+    min?: number;
+    step?: number;
+    max?: number;
+    bits?: number;
+    numBits?: number;
+    requiredBit?: number;
+    globalIndex: number;
+    value: string;
+    description?: string;
+    details?: string;
+    group: BasicType;
+    groupID: number;
+    dataType?: string;
+    format?: string;
+    unitString?: string;
 }
 
 export interface RotaryModeFirmwareSettings {

--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -29,7 +29,7 @@ import { SquaringToolWizard } from 'app/features/Config/components/wizards/Squar
 import { XJogWizard } from 'app/features/Config/components/wizards/XJogWizard.tsx';
 import { YJogWizard } from 'app/features/Config/components/wizards/YJogWizard.tsx';
 import { ZJogWizard } from 'app/features/Config/components/wizards/ZJogWizard.tsx';
-import {GRBL, GRBLHAL, LIGHTWEIGHT_OPTIONS, OUTLINE_MODES} from 'app/constants';
+import { GRBL, GRBLHAL, LIGHTWEIGHT_OPTIONS, OUTLINE_MODES } from 'app/constants';
 import { LaserWizard } from 'app/features/Config/components/wizards/LaserWizard.tsx';
 import {
     GamepadLinkWizard,
@@ -39,6 +39,7 @@ import controller from 'app/lib/controller.ts';
 import get from 'lodash/get';
 import store from 'app/store';
 import pubsub from 'pubsub-js';
+import { EEPROM } from 'app/definitions/firmware';
 
 export interface SettingsMenuSection {
     label: string;
@@ -74,7 +75,7 @@ export interface gSenderSetting {
     description?: string | any[];
     options?: string[] | number[];
     unit?: string;
-    eID?: string;
+    eID?: EEPROM;
     globalIndex?: number;
     value?: gSenderSettingsValues;
     defaultValue?: any;
@@ -101,7 +102,7 @@ export type gSenderSettings = gSenderSetting | gSenderSubSection;
 export type gSenderEEEPROMSettings = gSenderEEPROMSettingSection[];
 
 export interface gSenderEEPROMSetting {
-    eId: string;
+    eId: EEPROM;
     value?: gSenderSettingsValues;
     defaultValue?: gSenderSettingsValues;
     description?: string;

--- a/src/app/src/features/Config/utils/EEPROM.ts
+++ b/src/app/src/features/Config/utils/EEPROM.ts
@@ -1,5 +1,5 @@
 import get from 'lodash/get';
-import {GRBL_SETTINGS} from "app/features/Config/assets/SettingsDescriptions.ts";
+import { GRBL_HAL_SETTINGS, GRBL_SETTINGS } from "app/features/Config/assets/SettingsDescriptions.ts";
 import BooleanInput from 'app/features/Config/components/EEPROMInputs/BooleanInput.tsx';
 import BitfieldInput from 'app/features/Config/components/EEPROMInputs/BitfieldInput.tsx';
 import ExclusiveBitfieldInput from 'app/features/Config/components/EEPROMInputs/ExclusiveBitfieldInput.tsx';
@@ -10,6 +10,8 @@ import DecimalInput from 'app/features/Config/components/EEPROMInputs/DecimalInp
 import StringInput from 'app/features/Config/components/EEPROMInputs/StringInput.tsx';
 import PasswordInput from 'app/features/Config/components/EEPROMInputs/PasswordInput.tsx';
 import Ipv4Input from 'app/features/Config/components/EEPROMInputs/Ipv4Input.tsx';
+import { EEPROM, EEPROMDescriptions, EEPROMSettings, FilteredEEPROM } from 'app/definitions/firmware';
+import { BasicObject } from 'app/definitions/general';
 export const BOOLEAN_ID = 0;
 export const BITFIELD_ID = 1;
 export const EXCLUSIVE_BITFIELD_ID = 2;
@@ -22,17 +24,17 @@ export const PASSWORD_ID = 8;
 export const IPV4_ID = 9;
 
 export function getFilteredEEPROMSettings(
-    settings,
-    eeprom,
-    halDescriptions,
-    halGroups,
-) {
+    settings: typeof GRBL_HAL_SETTINGS | typeof GRBL_SETTINGS,
+    eeprom: EEPROMSettings,
+    halDescriptions: EEPROMDescriptions,
+    halGroups: BasicObject,
+): FilteredEEPROM[] {
     return Object.keys(eeprom).map((setting, index) => {
-        const properties = settings.find((obj) => obj.setting === setting);
+        const properties = settings.find((obj) => obj.setting === (setting as EEPROM));
 
         // Below is to grab the grbl unit as configured and use it as a fallback if it's not parsed
         // in the settings description.  It will be replaced in grblHAL by the actual unit.
-        const grblProperties = GRBL_SETTINGS.find((obj) => obj.setting === setting);
+        const grblProperties = GRBL_SETTINGS.find((obj) => obj.setting === (setting as EEPROM));
 
         let baseUnit = '';
         if (grblProperties) {
@@ -50,8 +52,8 @@ export function getFilteredEEPROMSettings(
             unit: baseUnit,
             ...(properties || {}),
             globalIndex: index,
-            setting,
-            value: eeprom[setting],
+            setting: setting as EEPROM,
+            value: eeprom[setting as EEPROM],
             ...halData,
             group: halGroup,
             groupID: halData.group,


### PR DESCRIPTION
- fix standard block touchplate settings showing up under modified when they are default
- add typescript definitions