### PR TITLE
Fixes issue where manual bit diameter probing positioned zero point incorrectly #723

### DIFF
--- a/src/app/src/lib/Probing.ts
+++ b/src/app/src/lib/Probing.ts
@@ -272,18 +272,17 @@ export const get3AxisStandardRoutine = (
 
 const determineAutoPlateOffsetValues = (
     direction: PROBE_DIRECTIONS,
-    _diameter: PROBE_TYPES_T | number = null,
+    diameter: PROBE_TYPES_T | number = null,
 ): [number, number] => {
     let xOff = 22.5;
     let yOff = 22.5;
 
-    // we already compensate for the tool in another place, so we don't need this
-    // if (diameter && !(diameter in PROBE_TYPES)) {
-    //     // math to compensate for tool
-    //     const toolRadius = (diameter as number) / 2;
-    //     xOff -= toolRadius;
-    //     yOff -= toolRadius;
-    // }
+    if (diameter && typeof diameter === 'number') {
+        // math to compensate for tool radius
+        const toolRadius = diameter / 2;
+        xOff -= toolRadius;
+        yOff -= toolRadius;
+    }
 
     if (direction === BR) {
         return [xOff * -1, yOff];


### PR DESCRIPTION
fix: correct tool radius compensation in auto touch plate probing

When using manual bit diameter with auto touch plate, the zero point was being set tangent to X and Y axes instead of intersecting them by half the bit diameter. This was caused by the tool radius compensation logic being commented out in determineAutoPlateOffsetValues.

- Uncommented and fixed tool radius compensation in determineAutoPlateOffsetValues
- Changed condition from !(diameter in PROBE_TYPES) to typeof diameter === 'number'
- Now properly compensates for tool radius when manual diameter is specified
- Auto bit size detection continues to work correctly without compensation