### PR TITLE
User configurable toast duration

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -61,6 +61,7 @@ import {
     SPINDLE_LASER_T,
 } from 'app/features/Spindle/definitions';
 import { updateWorkspaceMode } from 'app/lib/rotary';
+import { TOASTER_DISABLED, TOASTER_LONG, TOASTER_UNTIL_CLOSE } from 'app/lib/toaster/ToasterLib';
 
 export interface SettingsMenuSection {
     label: string;
@@ -360,6 +361,16 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         description:
                             'Show upcoming maintenance tasks at the end of each job.',
                         type: 'boolean',
+                    },
+                    {
+                        label: 'Pop-up notification duration',
+                        key: 'workspace.toastDuration',
+                        description:
+                            `How long pop-up notifications should stay visible (in milliseconds) before auto-dismissing. Set to 0 to keep default pop-up notification durations. Set to ${TOASTER_UNTIL_CLOSE} to keep them visible until manually dismissed. Set to ${TOASTER_DISABLED} to disable pop-up notifications entirely.`,
+                        type: 'number',
+                        defaultValue: 0,
+                        min: TOASTER_DISABLED,
+                        max: TOASTER_LONG,
                     },
                 ],
             },

--- a/src/app/src/lib/toaster/ToasterLib.js
+++ b/src/app/src/lib/toaster/ToasterLib.js
@@ -34,6 +34,7 @@ export const TOASTER_SHORT = 2000;
 export const TOASTER_DEFAULT = 5000;
 export const TOASTER_LONG = 10000;
 export const TOASTER_UNTIL_CLOSE = -1;
+export const TOASTER_DISABLED = -2;
 
 export const Toaster = {
     pop: (options) => {

--- a/src/app/src/lib/toaster/index.ts
+++ b/src/app/src/lib/toaster/index.ts
@@ -2,11 +2,39 @@ import { toast as sonnerToast } from 'sonner';
 import uuid from 'uuid';
 import get from 'lodash/get';
 
+import store from 'app/store';
 import { Notification } from 'app/workspace/definitions';
 import reduxStore from 'app/store/redux';
 import { setNotifications } from 'app/store/redux/slices/preferences.slice';
+import {
+    TOASTER_DEFAULT,
+    TOASTER_DISABLED,
+    TOASTER_UNTIL_CLOSE,
+} from './ToasterLib';
 
 type SonnerToastType = typeof sonnerToast;
+
+const getToastDuration = (options: Record<string, any> = {}) => {
+    // Get the configured duration from workspace store settings
+    let duration: number = store.get('workspace.toastDuration');
+
+    // Set duration to default if configured to 0 (use library default)
+    if (duration === 0) {
+        duration = options.duration ?? TOASTER_DEFAULT;
+    }
+
+    // Set duration to Infinity if configured to stay until manually closed
+    if (duration === TOASTER_UNTIL_CLOSE) {
+        duration = Infinity;
+    }
+
+    // TOASTER_DISABLED is handled in the proxy to skip showing the toast entirely
+
+    return {
+        ...options,
+        duration: duration,
+    };
+};
 
 const saveNotificationToStore = ({
     message,
@@ -44,12 +72,21 @@ const toastHandler: ProxyHandler<SonnerToastType> = {
         if (prop in target) {
             return function (...args: any[]) {
                 const notificationText: string = args[0];
+                const options = args[1] || {};
 
                 saveNotificationToStore({
                     message: notificationText,
                     type: prop as Notification['type'],
                 });
-                // Call the original method
+
+                args[1] = getToastDuration(options);
+
+                // Disable the toast if duration is TOASTER_DISABLED
+                if (args[1].duration === TOASTER_DISABLED) {
+                    return;
+                }
+
+                // Call the original method with updated args
                 return Reflect.apply(target[prop], target, args);
             };
         }
@@ -57,11 +94,19 @@ const toastHandler: ProxyHandler<SonnerToastType> = {
     },
     apply(target, _, args) {
         const notificationText: string = args[0];
+        const options = args[1] || {};
 
         saveNotificationToStore({
             message: notificationText,
             type: 'info',
         });
+
+        args[1] = getToastDuration(options);
+
+        // Disable the toast if duration is TOASTER_DISABLED
+        if (args[1].duration === TOASTER_DISABLED) {
+            return;
+        }
 
         return Reflect.apply(target.info, undefined, args);
     },

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -156,6 +156,7 @@ const defaultState: State = {
         },
         park: { x: 0, y: 0, z: 0 },
         notifications: [],
+        toastDuration: 0,
         enableDarkMode: false,
     },
     widgets: {

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -85,5 +85,6 @@ export interface Workspace {
         };
     };
     notifications: Notification[];
+    toastDuration: number;
     enableDarkMode: boolean;
 }


### PR DESCRIPTION
This PR updates the toast notifications duration to be user configurable

- Value of any number makes the toast duration that many number of milliseconds
- Value of 0 keeps durations as they are
- Value of -1 sets the toast as permanent until the user manually dismisses
- Value of -2 disables toasts all together

These changes close #731. Please let me know if you would like any tweaks or changes!