### PR TITLE
[MI-2096]: Keyboard Shortcuts UI still crashing

### DIFF
--- a/src/app/src/features/Keyboard/index.jsx
+++ b/src/app/src/features/Keyboard/index.jsx
@@ -1,12 +1,11 @@
-import React, { useRef } from 'react';
-import ReactToPrint from 'react-to-print';
-import { Button } from 'react-bootstrap';
-
-import PrintableShortcuts from './printableShortcuts';
+import { useEffect, useState } from 'react';
 import KeyboardShortcuts from './Keyboard';
+import { useTypedSelector } from 'app/hooks/useTypedSelector';
+import pubsub from 'pubsub-js';
 
 const Shortcuts = () => {
-    const componentRef = useRef();
+    const { isFinished } = useTypedSelector((state) => state.shortcuts);
+    // const componentRef = useRef();
 
     return (
         <>
@@ -22,7 +21,7 @@ const Shortcuts = () => {
                     <PrintableShortcuts ref={componentRef} />
                 </div> */}
 
-            <KeyboardShortcuts />
+            {isFinished && <KeyboardShortcuts />}
         </>
     );
 };

--- a/src/app/src/lib/useKeybinding.ts
+++ b/src/app/src/lib/useKeybinding.ts
@@ -7,6 +7,8 @@ import {
     ShuttleControlEvents,
     ShuttleEvent,
 } from './definitions/shortcuts';
+import reduxStore from 'app/store/redux';
+import { updateShuttleStatus } from 'app/store/redux/slices/shortcuts.slice';
 
 const TARGET_NUM_CALLS = 15; // this is the current number of times that useKeybinding is called throughout the program
 let numCalls = 0; // number of useKeybinding hooks that have been called
@@ -91,6 +93,9 @@ function useKeybinding(shuttleControlEvents: ShuttleControlEvents): void {
 function checkNumCalls(): void {
     if (numCalls === TARGET_NUM_CALLS) {
         removeOldKeybindings();
+        reduxStore.dispatch(
+            updateShuttleStatus({ isFinished: true })
+        );
     }
 }
 

--- a/src/app/src/store/definitions.ts
+++ b/src/app/src/store/definitions.ts
@@ -233,3 +233,7 @@ export interface ConsoleState {
     history: string[];
     inputHistory: string[];
 }
+
+export interface ShortcutSliceState {
+    isFinished: boolean
+}

--- a/src/app/src/store/redux/index.ts
+++ b/src/app/src/store/redux/index.ts
@@ -8,6 +8,7 @@ import preferences from './slices/preferences.slice';
 import console from './slices/console.slice';
 import helper from './slices/helper.slice';
 import gSenderInfo from './slices/gSenderInfo.slice.ts';
+import shortcuts from './slices/shortcuts.slice.ts';
 import { sagaMiddleware } from './sagas';
 
 export const store = configureStore({
@@ -20,6 +21,7 @@ export const store = configureStore({
         console,
         helper,
         gSenderInfo,
+        shortcuts,
     },
     middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware().concat(sagaMiddleware),

--- a/src/app/src/store/redux/slices/shortcuts.slice.ts
+++ b/src/app/src/store/redux/slices/shortcuts.slice.ts
@@ -1,0 +1,23 @@
+import { ShortcutSliceState } from 'app/store/definitions.ts';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+const initialState: ShortcutSliceState = {
+    isFinished: false,
+};
+
+const shortcutsSlice = createSlice({
+    name: 'gSenderInfo',
+    initialState,
+    reducers: {
+        updateShuttleStatus: (
+            state: ShortcutSliceState,
+            action: PayloadAction<{ isFinished: boolean }>,
+        ) => {
+            state.isFinished = action.payload.isFinished;
+        },
+    },
+});
+
+export const { updateShuttleStatus } = shortcutsSlice.actions;
+
+export default shortcutsSlice.reducer;


### PR DESCRIPTION
If you refresh on the keyboard shortcuts page, it loads that component before the workspace component finishes mounting. Therefore, the shuttle control events are still not finished being populated and the error with localeCompare still occurs. To fix this, I've added some state checking to ensure all the initialization work with the shortcuts is finished before the keyboard shortcuts table is allowed to be rendered.

tldr:
- useKeybinding now updates redux with a new boolean value
- keyboard shortcuts table only renders when the new redux value is true