### PR TITLE
Add BitZero V2 probe support

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -17,6 +17,7 @@ import { IconType } from 'react-icons';
 import {
     TOUCHPLATE_TYPE_3D,
     TOUCHPLATE_TYPE_AUTOZERO,
+    TOUCHPLATE_TYPE_BITZERO,
     TOUCHPLATE_TYPE_STANDARD,
     TOUCHPLATE_TYPE_ZERO,
 } from 'app/lib/constants';
@@ -544,6 +545,7 @@ export const SettingsMenu: SettingsMenuSection[] = [
                             TOUCHPLATE_TYPE_AUTOZERO,
                             TOUCHPLATE_TYPE_ZERO,
                             TOUCHPLATE_TYPE_3D,
+                            TOUCHPLATE_TYPE_BITZERO,
                         ],
                     },
                     {
@@ -628,6 +630,38 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         },
                     },
                     {
+                        label: 'BitZero thickness (XYZ)',
+                        key: 'workspace.probeProfile.zThickness.bitZero',
+                        description:
+                            'Plate thickness for XYZ probing where the bit touches the inset surface inside the bore. (Default 13)',
+                        type: 'number',
+                        unit: 'mm',
+                        hidden: () => {
+                            const probeType = store.get(
+                                'workspace.probeProfile.touchplateType',
+                                '',
+                            );
+                            // Hidden if we are not using BitZero
+                            return probeType !== TOUCHPLATE_TYPE_BITZERO;
+                        },
+                    },
+                    {
+                        label: 'BitZero thickness (Z-only)',
+                        key: 'workspace.probeProfile.zThickness.bitZeroZOnly',
+                        description:
+                            'Plate thickness for Z-only probing where the probe is placed flat on the surface. (Default 15.5)',
+                        type: 'number',
+                        unit: 'mm',
+                        hidden: () => {
+                            const probeType = store.get(
+                                'workspace.probeProfile.touchplateType',
+                                '',
+                            );
+                            // Hidden if we are not using BitZero
+                            return probeType !== TOUCHPLATE_TYPE_BITZERO;
+                        },
+                    },
+                    {
                         label: 'XY thickness',
                         key: 'workspace.probeProfile.xyThickness',
                         description:
@@ -672,8 +706,8 @@ export const SettingsMenu: SettingsMenuSection[] = [
                                 'workspace.probeProfile.touchplateType',
                                 '',
                             );
-                            // Hidden if we are using AutoZero touchplate
-                            return probeType === TOUCHPLATE_TYPE_AUTOZERO;
+                            // Hidden if we are using AutoZero or BitZero touchplate
+                            return probeType === TOUCHPLATE_TYPE_AUTOZERO || probeType === TOUCHPLATE_TYPE_BITZERO;
                         },
                     },
                     {
@@ -688,8 +722,8 @@ export const SettingsMenu: SettingsMenuSection[] = [
                                 'workspace.probeProfile.touchplateType',
                                 '',
                             );
-                            // Hidden if we are using AutoZero touchplate
-                            return probeType === TOUCHPLATE_TYPE_AUTOZERO;
+                            // Hidden if we are using AutoZero or BitZero touchplate
+                            return probeType === TOUCHPLATE_TYPE_AUTOZERO || probeType === TOUCHPLATE_TYPE_BITZERO;
                         },
                     },
                     {
@@ -704,8 +738,8 @@ export const SettingsMenu: SettingsMenuSection[] = [
                                 'workspace.probeProfile.touchplateType',
                                 '',
                             );
-                            // Hidden if we are using AutoZero touchplate
-                            return probeType === TOUCHPLATE_TYPE_AUTOZERO;
+                            // Hidden if we are using AutoZero or BitZero touchplate
+                            return probeType === TOUCHPLATE_TYPE_AUTOZERO || probeType === TOUCHPLATE_TYPE_BITZERO;
                         },
                     },
                     {
@@ -720,8 +754,8 @@ export const SettingsMenu: SettingsMenuSection[] = [
                                 'workspace.probeProfile.touchplateType',
                                 '',
                             );
-                            // Hidden if we are using AutoZero touchplate
-                            return probeType === TOUCHPLATE_TYPE_AUTOZERO;
+                            // Hidden if we are using AutoZero or BitZero touchplate
+                            return probeType === TOUCHPLATE_TYPE_AUTOZERO || probeType === TOUCHPLATE_TYPE_BITZERO;
                         },
                     },
                     {

--- a/src/app/src/features/Probe/ProbeDiameter.tsx
+++ b/src/app/src/features/Probe/ProbeDiameter.tsx
@@ -34,6 +34,7 @@ import { X, Plus, ChevronDown } from 'lucide-react';
 
 import {
     TOUCHPLATE_TYPE_AUTOZERO,
+    TOUCHPLATE_TYPE_BITZERO,
     PROBE_TYPE_AUTO,
     PROBE_TYPE_TIP,
     PROBE_TYPE_DIAMETER,
@@ -129,7 +130,7 @@ const ProbeDiameter = ({ actions, state, probeCommand }: Props) => {
         const baseOptions: Option[] = [];
         const toolsObjects = convertAvailableTools(availableTools, units);
 
-        if (touchplateType === TOUCHPLATE_TYPE_AUTOZERO) {
+        if (touchplateType === TOUCHPLATE_TYPE_AUTOZERO || touchplateType === TOUCHPLATE_TYPE_BITZERO) {
             baseOptions.push(
                 { value: PROBE_TYPE_AUTO, label: PROBE_TYPE_AUTO, tool: null },
                 { value: PROBE_TYPE_TIP, label: PROBE_TYPE_TIP, tool: null },

--- a/src/app/src/features/Probe/ProbeImage.tsx
+++ b/src/app/src/features/Probe/ProbeImage.tsx
@@ -25,6 +25,7 @@ import React from 'react';
 import {
     TOUCHPLATE_TYPE_STANDARD,
     TOUCHPLATE_TYPE_AUTOZERO,
+    TOUCHPLATE_TYPE_BITZERO,
     TOUCHPLATE_TYPE_ZERO,
     TOUCHPLATE_TYPE_3D,
 } from 'app/lib/constants';
@@ -53,7 +54,7 @@ const ProbeImage: React.FC<Props> = ({
 }) => {
     const getProbeImage = () => {
         const { id } = probeCommand;
-        if (touchplateType === TOUCHPLATE_TYPE_AUTOZERO) {
+        if (touchplateType === TOUCHPLATE_TYPE_AUTOZERO || touchplateType === TOUCHPLATE_TYPE_BITZERO) {
             if (id === 'Z Touch') {
                 return AutoZProbe;
             }

--- a/src/app/src/features/Probe/definitions.ts
+++ b/src/app/src/features/Probe/definitions.ts
@@ -22,6 +22,8 @@ export interface ProbeProfile {
         autoZero: number;
         zProbe: number;
         probe3D: number;
+        bitZero: number;
+        bitZeroZOnly: number;
     };
     plateWidth: number;
     plateLength: number;
@@ -72,6 +74,8 @@ export interface ProbingOptions {
         autoZero: number;
         zProbe: number;
         probe3D: number;
+        bitZero: number;
+        bitZeroZOnly: number;
     };
     xThickness?: number;
     yThickness?: number;

--- a/src/app/src/lib/constants.ts
+++ b/src/app/src/lib/constants.ts
@@ -29,11 +29,13 @@ export const TOUCHPLATE_TYPE_STANDARD = 'Standard Block';
 export const TOUCHPLATE_TYPE_AUTOZERO = 'AutoZero';
 export const TOUCHPLATE_TYPE_ZERO = 'Z Probe';
 export const TOUCHPLATE_TYPE_3D = '3D Probe';
+export const TOUCHPLATE_TYPE_BITZERO = 'BitZero';
 export const TOUCHPLATE_TYPES = {
     TOUCHPLATE_TYPE_STANDARD: 'Standard Block',
     TOUCHPLATE_TYPE_AUTOZERO: 'AutoZero',
     TOUCHPLATE_TYPE_ZERO: 'Z Probe',
     TOUCHPLATE_TYPE_3D: '3D Probe',
+    TOUCHPLATE_TYPE_BITZERO: 'BitZero',
 };
 
 export const PROBE_TYPE_AUTO = 'Auto';

--- a/src/app/src/lib/toolChangeUtils.ts
+++ b/src/app/src/lib/toolChangeUtils.ts
@@ -4,6 +4,7 @@ import { store as reduxStore } from '../store/redux';
 import {
     TOUCHPLATE_TYPE_3D,
     TOUCHPLATE_TYPE_AUTOZERO,
+    TOUCHPLATE_TYPE_BITZERO,
     TOUCHPLATE_TYPE_ZERO,
 } from '../lib/constants';
 import { UNITS_GCODE } from 'app/definitions/general';
@@ -29,6 +30,9 @@ export const getProbeSettings = (): ProbeWidgetSettings => {
         probeThickness = probeProfile.zThickness.zProbe;
     } else if (touchplateType === TOUCHPLATE_TYPE_3D) {
         probeThickness = probeProfile.zThickness.probe3D;
+    } else if (touchplateType === TOUCHPLATE_TYPE_BITZERO) {
+        // Use Z-only thickness for tool change (probe placed flat on surface)
+        probeThickness = probeProfile.zThickness.bitZeroZOnly;
     }
 
     return {

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -96,6 +96,8 @@ const defaultState: State = {
                 autoZero: 5,
                 zProbe: 15,
                 probe3D: 0,
+                bitZero: 13,
+                bitZeroZOnly: 15.5,
             },
             plateWidth: 50,
             plateLength: 50,


### PR DESCRIPTION
This PR adds full support for the BitZero V2 touch probe, a bore-style probe commonly used with Carbide3D machines.

**Features**
5 Probing Modes:

XYZ - Full 3-axis probing (finds bore center, then probes Z on top plate)
XY - Horizontal centering only
Z-only - Height detection with probe placed flat
X-only - Single axis centering
Y-only - Single axis centering
4 Corner Directions: Bottom-Left, Top-Left, Top-Right, Bottom-Right

**Configurable Settings**:

XYZ thickness (default: 13mm) - for probing inside the bore
Z-only thickness (default: 15.5mm) - for flat surface probing
Tool Change Integration: Automatic thickness selection for tool change operations

**Technical Details**
Bore diameter: 15mm
Two-speed probing (100mm/min fast, then 50mm/min for precision)
Safe height retract: 15mm
Compatible with GRBL and grblHAL firmware
Files Changed
src/app/src/lib/constants.ts - Added TOUCHPLATE_TYPE_BITZERO
src/app/src/lib/Probing.ts - Core probing routines (~340 lines)
src/app/src/lib/toolChangeUtils.ts - Tool change support
src/app/src/features/Probe/definitions.ts - Type definitions
src/app/src/features/Probe/ProbeDiameter.tsx - UI integration
src/app/src/features/Probe/ProbeImage.tsx - Image display
src/app/src/features/Config/assets/SettingsMenu.ts - Settings UI
src/app/src/store/defaultState/index.ts - Default values

**Testing**
Select "BitZero" from Settings > Probe > Touchplate Type
Configure thickness values if different from defaults
Position tool inside the BitZero bore
Run probe cycle (XYZ, XY, Z, X, or Y)
Verify work coordinates are set correctly

**References**
Based on proven algorithms from [nomad3-cncjs-macros](https://github.com/AustinSaintAubin)
BitZero V2 specifications from Carbide3D