### PR TITLE
add "GrblHAL Toolchange Protocol" as a gSender toolchange strategy

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -1765,6 +1765,7 @@ export const SettingsMenu: SettingsMenuSection[] = [
                             'Standard wizard will guide you through the steps to manually set up a new tool and resume cutting.\n\nFlexible is similar but uses a touch plate like a tool length sensor.\n\nFixed is also guided but fully automated, moving around and measuring tools for you. Homing and TLS required.\n\nCode is for fully custom setups.',
                         options: [
                             'Ignore',
+                            'GrblHAL Toolchange Protocol',
                             'Pause',
                             'Standard Re-zero',
                             'Flexible Re-zero',

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -53,6 +53,7 @@ export interface Workspace {
     };
     toolChangeOption:
         | 'Ignore'
+        | 'GrblHAL Toolchange Protocol'
         | 'Pause'
         | 'Standard Re-zero'
         | 'Flexible Re-zero'

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -64,7 +64,8 @@ import {
     GRBL_HAL_ACTIVE_STATE_IDLE,
     GRBL_HAL_ACTIVE_STATE_CHECK,
     GRBL_HAL_ACTIVE_STATE_RUN,
-    GRBL_HAL_ACTIVE_STATE_ALARM
+    GRBL_HAL_ACTIVE_STATE_ALARM,
+    GRBL_HAL_ACTIVE_STATE_TOOL
 } from './constants';
 import {
     METRIC_UNITS,
@@ -152,6 +153,8 @@ class GrblHalController {
     settings = {};
 
     toolChangeContext = {};
+
+    grblHalToolChangePending = false;
 
     queryTimer = null;
 
@@ -531,7 +534,10 @@ class GrblHalController {
 
                     // Handle specific cases for macro and pause, ignore is default and comments line out with no other action
                     // If toolchange is at very beginning of file, ignore it
-                    if (toolChangeOption !== 'Ignore') {
+                    if (toolChangeOption === 'GrblHAL Toolchange Protocol') {
+                        // Firmware handles M6 and will enter Tool state; we respond via status handler
+                        // Pass M6 through unmodified - no gSender workflow involved
+                    } else if (toolChangeOption !== 'Ignore') {
                         if (tool) {
                             commentString = `(${tool?.[0]}) ` + commentString;
                         }
@@ -561,7 +567,7 @@ class GrblHalController {
                     }
 
                     const passthroughM6 = _.get(this.toolChangeContext, 'passthrough', false);
-                    if (!passthroughM6 || toolChangeOption === 'Code') {
+                    if (toolChangeOption !== 'GrblHAL Toolchange Protocol' && (!passthroughM6 || toolChangeOption === 'Code')) {
                         line = line.replace('M6', '(M6)');
                     }
                     //line = line.replace(`${tool?.[0]}`, `(${tool?.[0]})`);
@@ -695,6 +701,19 @@ class GrblHalController {
         });
 
         this.runner.on('status', (res) => {
+            // grblHAL manual tool change protocol:
+            // When firmware enters Tool state, send ACK (0xA3) once
+            if (res.activeState === GRBL_HAL_ACTIVE_STATE_TOOL) {
+                if (this.toolChangeContext.toolChangeOption === 'GrblHAL Toolchange Protocol' && !this.grblHalToolChangePending) {
+                    this.grblHalToolChangePending = true;
+                    log.info('grblHAL toolchange protocol: sending ACK (0xA3), suspending sender');
+                    this.write(GRBLHAL_REALTIME_COMMANDS.TOOL_CHANGE_ACK);
+                    this.workflow.pause({ data: 'grblhal-toolchange' });
+                }
+            } else if (this.grblHalToolChangePending) {
+                this.grblHalToolChangePending = false;
+            }
+
             // Make sure we also have axs parsed - at most two times or we get endless loop
             if (!this.runner.hasAXS() && res.activeState === GRBL_HAL_ACTIVE_STATE_IDLE && this.actionMask.axsReportCount < 2) {
                 this.writeln('$I');

--- a/src/server/controllers/Grblhal/constants.js
+++ b/src/server/controllers/Grblhal/constants.js
@@ -27,6 +27,7 @@ export const GRBLHAL = 'grblHAL';
 
 // Active State
 export const GRBL_HAL_ACTIVE_STATE_IDLE = 'Idle';
+export const GRBL_HAL_ACTIVE_STATE_TOOL = 'Tool';
 export const GRBL_HAL_ACTIVE_STATE_RUN = 'Run';
 export const GRBL_HAL_ACTIVE_STATE_HOLD = 'Hold';
 export const GRBL_HAL_ACTIVE_STATE_DOOR = 'Door';


### PR DESCRIPTION
this add support for sending grblhal TOOL_CHANGE_ACK command when using the grblhal semi automatic toolchange, it builds on top of "Passthrough" option but instead of just ignoring M6 it will ack when the controller enters TOOL state

without this change (with passthrough enabled and "ignore" as strategy) grblhal will initiate toolchange, but when you press cycle/start ... it will not finish the TLO process and it will not continue the job.

by making this a strategy option, it should not have any effect unless the "GrblHAL Toolchange Protocol" is selected .. hopefully making this somewhat safe addition.

its been working nicely for the past few weeks on my machine ...