### PR TITLE
[FEAT] Add app display scaling that's independent from OS display scaling

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -1825,7 +1825,10 @@ export const SettingsMenu: SettingsMenuSection[] = [
                                 'workspace.toolChange.moveToManualPosition',
                                 false,
                             );
-                            return strategy !== 'Fixed Tool Sensor' || !moveToLocation;
+                            return (
+                                strategy !== 'Fixed Tool Sensor' ||
+                                !moveToLocation
+                            );
                         },
                     },
                     {
@@ -2111,7 +2114,9 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         description: 'Play sound when a job finishes.',
                         type: 'boolean',
                         hidden: () =>
-                            !store.get('workspace.accessibility.audioCues.enabled'),
+                            !store.get(
+                                'workspace.accessibility.audioCues.enabled',
+                            ),
                         onUpdate: () => {
                             pubsub.publish('accessibility:update');
                         },
@@ -2123,7 +2128,9 @@ export const SettingsMenu: SettingsMenuSection[] = [
                             'Play sound when the machine enters an alarm state.',
                         type: 'boolean',
                         hidden: () =>
-                            !store.get('workspace.accessibility.audioCues.enabled'),
+                            !store.get(
+                                'workspace.accessibility.audioCues.enabled',
+                            ),
                         onUpdate: () => {
                             pubsub.publish('accessibility:update');
                         },
@@ -2131,10 +2138,13 @@ export const SettingsMenu: SettingsMenuSection[] = [
                     {
                         label: 'Tool change sound',
                         key: 'workspace.accessibility.audioCues.toolChange',
-                        description: 'Play sound when a tool change is required.',
+                        description:
+                            'Play sound when a tool change is required.',
                         type: 'boolean',
                         hidden: () =>
-                            !store.get('workspace.accessibility.audioCues.enabled'),
+                            !store.get(
+                                'workspace.accessibility.audioCues.enabled',
+                            ),
                         onUpdate: () => {
                             pubsub.publish('accessibility:update');
                         },
@@ -2145,7 +2155,9 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         description: 'Play sound after a successful probe.',
                         type: 'boolean',
                         hidden: () =>
-                            !store.get('workspace.accessibility.audioCues.enabled'),
+                            !store.get(
+                                'workspace.accessibility.audioCues.enabled',
+                            ),
                         onUpdate: () => {
                             pubsub.publish('accessibility:update');
                         },
@@ -2193,6 +2205,29 @@ export const SettingsMenu: SettingsMenuSection[] = [
                             'Choose between a slider or a number input for adjusting spindle speed.',
                         options: ['Slider', 'Number'],
                         defaultValue: 'Slider',
+                    },
+                    {
+                        label: 'App display scale',
+                        key: 'workspace.accessibility.displayScaleFactor',
+                        type: 'number',
+                        min: 0,
+                        max: 5,
+                        description:
+                            "Override the app's display scale independently of Windows DPI settings. Set to 0 (or leave blank) to follow system scaling. Valid range: 0 - 5. (Requires a restart to take effect)",
+                        hidden: () => !isElectron(),
+                        onUpdate: () => {
+                            if (isElectron()) {
+                                const scaleFactor = store.get(
+                                    'workspace.accessibility.displayScaleFactor',
+                                    0,
+                                );
+                                // @ts-ignore
+                                window.ipcRenderer.send(
+                                    'save-display-scale',
+                                    scaleFactor,
+                                );
+                            }
+                        },
                     },
                 ],
             },

--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -2209,18 +2209,30 @@ export const SettingsMenu: SettingsMenuSection[] = [
                     {
                         label: 'App display scale',
                         key: 'workspace.accessibility.displayScaleFactor',
-                        type: 'number',
-                        min: 0,
-                        max: 5,
+                        type: 'select',
+                        options: [
+                            '50%',
+                            '67%',
+                            '75%',
+                            '100%',
+                            '125%',
+                            '150%',
+                            '175%',
+                            '200%',
+                        ],
+                        defaultValue: '100%',
                         description:
-                            "Override the app's display scale independently of Windows DPI settings. Set to 0 (or leave blank) to follow system scaling. Valid range: 0 - 5. (Requires a restart to take effect)",
+                            "Override the app's display scale independently of your OS' DPI settings.",
                         hidden: () => !isElectron(),
                         onUpdate: () => {
                             if (isElectron()) {
-                                const scaleFactor = store.get(
+                                const scaleFactorStr = store.get(
                                     'workspace.accessibility.displayScaleFactor',
-                                    0,
+                                    '100%',
                                 );
+                                // Normalize percentage to decimal (e.g., "100%" -> 1.0)
+                                const scaleFactor =
+                                    parseFloat(scaleFactorStr) / 100;
                                 // @ts-ignore
                                 window.ipcRenderer.send(
                                     'save-display-scale',

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -194,7 +194,7 @@ const defaultState: State = {
                 showVisually: false,
             },
             showKeyboardMap: false,
-            displayScaleFactor: 0,
+            displayScaleFactor: '100%',
         },
         preventJoggingPastLimits: false,
     },
@@ -370,7 +370,7 @@ const defaultState: State = {
                 minPower: 0,
                 maxPower: 255,
             },
-            inputType: 'Slider'
+            inputType: 'Slider',
         },
         surfacing: {
             bitDiameter: 22,

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -194,6 +194,7 @@ const defaultState: State = {
                 showVisually: false,
             },
             showKeyboardMap: false,
+            displayScaleFactor: 0,
         },
         preventJoggingPastLimits: false,
     },

--- a/src/app/src/store/definitions.ts
+++ b/src/app/src/store/definitions.ts
@@ -186,6 +186,7 @@ export interface PreferencesState {
             showVisually: boolean;
         };
         showKeyboardMap: boolean;
+        displayScaleFactor?: number;
     };
     preventJoggingPastLimits: boolean;
 }

--- a/src/app/src/store/definitions.ts
+++ b/src/app/src/store/definitions.ts
@@ -24,9 +24,7 @@ import {
     Visualizer,
     ATC,
 } from 'app/features/Visualizer/definitions';
-import {
-    Modal,
-} from 'app/lib/definitions/gcode_virtualization';
+import { Modal } from 'app/lib/definitions/gcode_virtualization';
 import { Feeder, Sender } from 'app/lib/definitions/sender_feeder';
 import { CommandKeys } from 'app/lib/definitions/shortcuts';
 import { Notification, Workspace } from 'app/workspace/definitions';
@@ -186,7 +184,7 @@ export interface PreferencesState {
             showVisually: boolean;
         };
         showKeyboardMap: boolean;
-        displayScaleFactor?: number;
+        displayScaleFactor?: string;
     };
     preventJoggingPastLimits: boolean;
 }

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -117,6 +117,7 @@ export interface Workspace {
             showVisually: boolean;
         };
         showKeyboardMap: boolean;
+        displayScaleFactor?: number;
     };
     preventJoggingPastLimits: boolean;
 }

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -117,7 +117,7 @@ export interface Workspace {
             showVisually: boolean;
         };
         showKeyboardMap: boolean;
-        displayScaleFactor?: number;
+        displayScaleFactor?: string;
     };
     preventJoggingPastLimits: boolean;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -22,515 +22,542 @@
  */
 
 import {
-    app,
-    ipcMain,
-    dialog,
-    powerSaveBlocker,
-    powerMonitor,
-    screen,
-    session,
-    clipboard,
-} from 'electron';
-import { autoUpdater } from 'electron-updater';
-import Store from 'electron-store';
-import chalk from 'chalk';
-import mkdirp from 'mkdirp';
-import isOnline from 'is-online';
-import log from 'electron-log';
-import path from 'path';
-import fs from 'fs';
-import * as Sentry from '@sentry/electron/main';
-import WindowManager from './electron-app/WindowManager';
-import launchServer from './server-cli';
-import pkg from './package.json';
-import { parseAndReturnGCode } from './electron-app/RecentFiles';
-import { asyncCallWithTimeout } from './electron-app/AsyncTimeout';
-import { getGRBLLog } from './electron-app/grblLogs';
+  app,
+  ipcMain,
+  dialog,
+  powerSaveBlocker,
+  powerMonitor,
+  screen,
+  session,
+  clipboard,
+} from "electron";
+import { autoUpdater } from "electron-updater";
+import Store from "electron-store";
+import chalk from "chalk";
+import mkdirp from "mkdirp";
+import isOnline from "is-online";
+import log from "electron-log";
+import path from "path";
+import fs from "fs";
+import * as Sentry from "@sentry/electron/main";
+import WindowManager from "./electron-app/WindowManager";
+import launchServer from "./server-cli";
+import pkg from "./package.json";
+import { parseAndReturnGCode } from "./electron-app/RecentFiles";
+import { asyncCallWithTimeout } from "./electron-app/AsyncTimeout";
+import { getGRBLLog } from "./electron-app/grblLogs";
 
 // Hot reload in development
-if (process.env.NODE_ENV === 'development') {
-    try {
-        require('electron-reloader')(module, {
-            debug: false,
-            watchRenderer: false, // Vite handles frontend
-            ignore: [
-                /node_modules/,
-                /output\/app/,
-                /\.map$/,
-            ],
-        });
-    } catch (err) {
-        // electron-reloader not available, continue without it
-    }
+if (process.env.NODE_ENV === "development") {
+  try {
+    require("electron-reloader")(module, {
+      debug: false,
+      watchRenderer: false, // Vite handles frontend
+      ignore: [/node_modules/, /output\/app/, /\.map$/],
+    });
+  } catch (err) {
+    // electron-reloader not available, continue without it
+  }
 }
 
 let windowManager = null;
 let hostInformation = {};
-let grblLog = log.create('grbl');
+let grblLog = log.create("grbl");
 let logPath;
-const externalRendererUrl = process.env.NODE_ENV === 'development'
+const externalRendererUrl =
+  process.env.NODE_ENV === "development"
     ? process.env.ELECTRON_RENDERER_URL
-    : '';
+    : "";
 
-if (process.env.NODE_ENV === 'production') {
-    Sentry.init({
-        dsn: 'https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560',
-        release: pkg.version,
-    });
+if (process.env.NODE_ENV === "production") {
+  Sentry.init({
+    dsn: "https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560",
+    release: pkg.version,
+  });
 }
 
 const main = () => {
-    // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
-    const gotSingleInstanceLock = app.requestSingleInstanceLock();
-    const shouldQuitImmediately = !gotSingleInstanceLock;
+  // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
+  const gotSingleInstanceLock = app.requestSingleInstanceLock();
+  const shouldQuitImmediately = !gotSingleInstanceLock;
 
-    // Initialize remote main
-    require('@electron/remote/main').initialize();
+  // Initialize remote main
+  require("@electron/remote/main").initialize();
 
-    let prevDirectory = '';
-    let pendingFileToOpen = null;
-    let isRendererReady = false;
+  let prevDirectory = "";
+  let pendingFileToOpen = null;
+  let isRendererReady = false;
 
-    if (shouldQuitImmediately) {
-        app.quit();
-        return;
-    }
+  if (shouldQuitImmediately) {
+    app.quit();
+    return;
+  }
 
-    app.on('second-instance', (event, commandLine, workingDirectory) => {
+  app.on("second-instance", (event, commandLine, workingDirectory) => {
     // Someone tried to run a second instance, we should focus our window.
-        if (!windowManager) {
-            return;
-        }
+    if (!windowManager) {
+      return;
+    }
 
-        const window = windowManager.getWindow();
-        if (window) {
-            if (window.isMinimized()) {
-                window.restore();
-            }
-            window.focus();
-            const filePath = commandLine.find(arg =>
-                /\.(gcode|gc|nc|tap|cnc)$/i.test(arg)
+    const window = windowManager.getWindow();
+    if (window) {
+      if (window.isMinimized()) {
+        window.restore();
+      }
+      window.focus();
+      const filePath = commandLine.find((arg) =>
+        /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
+      );
+      if (filePath) {
+        loadFileAssociation(filePath, window);
+      }
+    }
+  });
+
+  app.on("open-file", (event, filePath) => {
+    event.preventDefault();
+    const window = windowManager?.getWindow();
+    if (window && isRendererReady) {
+      loadFileAssociation(filePath, window);
+    } else {
+      pendingFileToOpen = filePath;
+    }
+  });
+
+  const store = new Store();
+
+  // Increase V8 heap size of the main process
+  if (process.arch === "x64") {
+    const memoryLimit = 1024 * 8; // 8GB
+    app.commandLine.appendSwitch(
+      "--js-flags",
+      `--max-old-space-size=${memoryLimit}`,
+    );
+  }
+
+  if (process.platform === "linux") {
+    app.commandLine.appendSwitch("--no-sandbox");
+  }
+
+  const savedScaleFactor = Number(store.get("displayScaleFactor", 0));
+  if (savedScaleFactor > 0 && savedScaleFactor <= 5) {
+    app.commandLine.appendSwitch(
+      "force-device-scale-factor",
+      String(savedScaleFactor),
+    );
+  }
+
+  // Create the user data directory if it does not exist
+  const userData = app.getPath("userData");
+  mkdirp.sync(userData);
+  // Extra logging
+  logPath = path.join(app.getPath("userData"), "logs/grbl.log");
+  grblLog.transports.file.resolvePath = () => logPath;
+
+  const loadFileAssociation = async (filePath, window) => {
+    try {
+      const fileMetadata = await parseAndReturnGCode({ filePath });
+      window.webContents.send("returned-upload-dialog-data", {
+        data: fileMetadata.result,
+        size: fileMetadata.size,
+        name: fileMetadata.name,
+        path: fileMetadata.fullPath,
+      });
+    } catch (err) {
+      log.error(`Error loading file association: ${err}`);
+    }
+  };
+
+  app.whenReady().then(async () => {
+    try {
+      await session.defaultSession.clearCache();
+
+      windowManager = new WindowManager();
+      // Create and show splash before server starts
+      const splashScreen = windowManager.createSplashScreen({
+        width: 600,
+        height: 400,
+        show: false,
+        frame: false,
+        transparent: true,
+        backgroundColor: "#00000000",
+      });
+      splashScreen.loadFile(
+        path.join(__dirname, "app/assets/Splashscreen.webp"),
+      );
+      splashScreen.webContents.on("did-finish-load", () => {
+        splashScreen.show();
+      });
+
+      splashScreen.on("show", () => {
+        splashScreen.focus();
+      });
+
+      let url = "";
+      let kiosk = false;
+
+      if (externalRendererUrl) {
+        url = externalRendererUrl;
+        try {
+          const parsedUrl = new URL(url);
+          hostInformation = {
+            address: parsedUrl.hostname,
+            port:
+              Number(parsedUrl.port) ||
+              (parsedUrl.protocol === "https:" ? 443 : 80),
+          };
+        } catch (error) {
+          hostInformation = {};
+        }
+        log.info(`Using external renderer URL in development: ${url}`);
+      } else if (process.env.NODE_ENV === "development") {
+        const errorMessage =
+          "ELECTRON_RENDERER_URL is required in development mode";
+        log.error(errorMessage);
+        await dialog.showMessageBox({
+          type: "error",
+          title: "Development Startup Error",
+          message: errorMessage,
+        });
+        app.exit(1);
+        return;
+      } else {
+        let res;
+        try {
+          res = await launchServer();
+        } catch (error) {
+          const isBindingError =
+            error.errData?.bindingErr ||
+            /EADDR|address not available|address already in use/i.test(
+              error.message,
             );
-            if (filePath) {
-                loadFileAssociation(filePath, window);
-            }
+
+          if (isBindingError) {
+            log.warn(
+              "Remote mode binding failed — remote config has been reset.",
+            );
+            dialog.showMessageBoxSync(null, {
+              title: "Remote Mode Configuration Error",
+              message:
+                "gSender could not connect to the configured remote address.",
+              detail:
+                "Remote mode has been disabled and the configuration has been reset. Please restart gSender.",
+            });
+          } else {
+            log.error("Unexpected server startup error:", error);
+            dialog.showMessageBoxSync(null, {
+              title: "Server Startup Error",
+              message:
+                "gSender encountered an unexpected error while starting.",
+              detail: String(error.message),
+            });
+          }
+          app.exit(-1);
+          return;
         }
-    });
 
-    app.on('open-file', (event, filePath) => {
-        event.preventDefault();
-        const window = windowManager?.getWindow();
-        if (window && isRendererReady) {
-            loadFileAssociation(filePath, window);
-        } else {
-            pendingFileToOpen = filePath;
+        const { address, port, kiosk: resolvedKiosk } = { ...res };
+        kiosk = resolvedKiosk;
+        log.info(`Returned - http://${address}:${port}`);
+        hostInformation = {
+          address,
+          port,
+        };
+        if (!(address && port)) {
+          log.error(
+            "Unable to start the server at " +
+              chalk.cyan(`http://${address}:${port}`),
+          );
+          return;
         }
-    });
 
-    const store = new Store();
+        url = `http://${address}:${port}`;
+      }
+      // The bounds is a rectangle object with the following properties:
+      // * `x` Number - The x coordinate of the origin of the rectangle.
+      // * `y` Number - The y coordinate of the origin of the rectangle.
+      // * `width` Number - The width of the rectangle.
+      // * `height` Number - The height of the rectangle.
+      // resolution used to be 1024x768
+      const bounds = {
+        minWidth: 1044,
+        minHeight: 768,
+        ...store.get("bounds"),
+      };
+      const options = {
+        ...bounds,
+        title: `gSender ${pkg.version}`,
+        kiosk,
+      };
+      const window = await windowManager.openWindow(url, options, splashScreen);
 
-    // Increase V8 heap size of the main process
-    if (process.arch === 'x64') {
-        const memoryLimit = 1024 * 8; // 8GB
-        app.commandLine.appendSwitch(
-            '--js-flags',
-            `--max-old-space-size=${memoryLimit}`,
+      // Check argv for file path on Windows/Linux cold start
+      if (process.platform !== "darwin") {
+        const filePath = process.argv.find((arg) =>
+          /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
         );
-    }
-
-    if (process.platform === 'linux') {
-        app.commandLine.appendSwitch('--no-sandbox');
-    }
-
-    // Create the user data directory if it does not exist
-    const userData = app.getPath('userData');
-    mkdirp.sync(userData);
-    // Extra logging
-    logPath = path.join(app.getPath('userData'), 'logs/grbl.log');
-    grblLog.transports.file.resolvePath = () => logPath;
-
-    const loadFileAssociation = async (filePath, window) => {
-        try {
-            const fileMetadata = await parseAndReturnGCode({ filePath });
-            window.webContents.send('returned-upload-dialog-data', {
-                data: fileMetadata.result,
-                size: fileMetadata.size,
-                name: fileMetadata.name,
-                path: fileMetadata.fullPath,
-            });
-        } catch (err) {
-            log.error(`Error loading file association: ${err}`);
+        if (filePath) {
+          pendingFileToOpen = filePath;
         }
-    };
+      }
 
-    app.whenReady().then(async () => {
+      ipcMain.on("file-association-ready", () => {
+        isRendererReady = true;
+        if (pendingFileToOpen) {
+          loadFileAssociation(pendingFileToOpen, window);
+          pendingFileToOpen = null;
+        }
+      });
+
+      // Power saver - display sleep higher precedence over app suspension
+      powerSaveBlocker.start("prevent-display-sleep");
+      powerMonitor.on("lock-screen", () => {
+        powerSaveBlocker.start("prevent-display-sleep");
+      });
+      powerMonitor.on("suspend", () => {
+        powerSaveBlocker.start("prevent-app-suspension");
+        log.info("Prevented suspension");
+      });
+
+      // Save window size and position
+      window.on("close", () => {
+        store.set("bounds", window.getBounds());
+      });
+
+      // Include release notes
+      //autoUpdater.fullChangelog = true;
+
+      if (process.platform === "win32") {
+        autoUpdater.on("update-available", (info) => {
+          setTimeout(() => {
+            window.webContents.send("update_available", info);
+          }, 8000);
+        });
+
+        autoUpdater.on("error", (err) => {
+          window.webContents.send("updated_error", err);
+          log.error(err);
+        });
+
+        autoUpdater.on("download-progress", (info) => {
+          window.webContents.send("update_download_progress", info.percent);
+        });
+
+        ipcMain.once("restart_app", async () => {
+          await autoUpdater.downloadUpdate();
+          autoUpdater.quitAndInstall(false, false);
+        });
+      }
+
+      ipcMain.on("load-recent-file", async (msg, recentFile) => {
         try {
-            await session.defaultSession.clearCache();
+          const fileMetadata = await parseAndReturnGCode(recentFile);
+          window.webContents.send("loaded-recent-file", fileMetadata);
+        } catch (err) {
+          log.error(err);
+          window.webContents.send("remove-recent-file", {
+            err: err.message,
+            path: recentFile.filePath,
+          });
+        }
+      });
 
-            windowManager = new WindowManager();
-            // Create and show splash before server starts
-            const splashScreen = windowManager.createSplashScreen({
-                width: 600,
-                height: 400,
-                show: false,
-                frame: false,
-                transparent: true,
-                backgroundColor: '#00000000',
-            });
-            splashScreen.loadFile(
-                path.join(__dirname, 'app/assets/Splashscreen.webp'),
-            );
-            splashScreen.webContents.on('did-finish-load', () => {
-                splashScreen.show();
-            });
+      ipcMain.on("logError:electron", (channel, error) => {
+        if ("type" in error) {
+          log.transports.file.level = "error";
+        }
 
-            splashScreen.on('show', () => {
-                splashScreen.focus();
-            });
+        if (error.type.includes("GRBL_HAL")) {
+          error.type === "GRBL_HAL_ERROR"
+            ? grblLog.error(
+                `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+              )
+            : grblLog.error(
+                `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
+              );
+        } else {
+          error.type === "GRBL_ERROR"
+            ? grblLog.error(
+                `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+              )
+            : grblLog.error(
+                `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
+              );
+        }
+      });
 
-            let url = '';
-            let kiosk = false;
+      ipcMain.handle("copy-to-clipboard", (_channel, text) => {
+        if (!text) {
+          return { success: false, error: "No text to copy" };
+        }
 
-            if (externalRendererUrl) {
-                url = externalRendererUrl;
-                try {
-                    const parsedUrl = new URL(url);
-                    hostInformation = {
-                        address: parsedUrl.hostname,
-                        port: Number(parsedUrl.port) || (parsedUrl.protocol === 'https:' ? 443 : 80),
-                    };
-                } catch (error) {
-                    hostInformation = {};
-                }
-                log.info(`Using external renderer URL in development: ${url}`);
-            } else if (process.env.NODE_ENV === 'development') {
-                const errorMessage = 'ELECTRON_RENDERER_URL is required in development mode';
-                log.error(errorMessage);
-                await dialog.showMessageBox({
-                    type: 'error',
-                    title: 'Development Startup Error',
-                    message: errorMessage,
-                });
-                app.exit(1);
-                return;
-            } else {
-                let res;
-                try {
-                    res = await launchServer();
-                } catch (error) {
-                    const isBindingError = error.errData?.bindingErr ||
-                        /EADDR|address not available|address already in use/i.test(error.message);
+        clipboard.writeText(text);
 
-                    if (isBindingError) {
-                        log.warn('Remote mode binding failed — remote config has been reset.');
-                        dialog.showMessageBoxSync(null, {
-                            title: 'Remote Mode Configuration Error',
-                            message: 'gSender could not connect to the configured remote address.',
-                            detail: 'Remote mode has been disabled and the configuration has been reset. Please restart gSender.',
-                        });
-                    } else {
-                        log.error('Unexpected server startup error:', error);
-                        dialog.showMessageBoxSync(null, {
-                            title: 'Server Startup Error',
-                            message: 'gSender encountered an unexpected error while starting.',
-                            detail: String(error.message),
-                        });
-                    }
-                    app.exit(-1);
-                    return;
-                }
+        return { success: true };
+      });
 
-                const { address, port, kiosk: resolvedKiosk } = { ...res };
-                kiosk = resolvedKiosk;
-                log.info(`Returned - http://${address}:${port}`);
-                hostInformation = {
-                    address,
-                    port,
-                };
-                if (!(address && port)) {
-                    log.error(
-                        'Unable to start the server at ' +
-                chalk.cyan(`http://${address}:${port}`),
-                    );
-                    return;
-                }
+      ipcMain.handle("grblLog:fetch", async (channel) => {
+        const data = await getGRBLLog(logPath);
+        return data;
+      });
 
-                url = `http://${address}:${port}`;
-            }
-            // The bounds is a rectangle object with the following properties:
-            // * `x` Number - The x coordinate of the origin of the rectangle.
-            // * `y` Number - The y coordinate of the origin of the rectangle.
-            // * `width` Number - The width of the rectangle.
-            // * `height` Number - The height of the rectangle.
-            // resolution used to be 1024x768
-            const bounds = {
-                minWidth: 1044,
-                minHeight: 768,
-                ...store.get('bounds'),
-            };
-            const options = {
-                ...bounds,
-                title: `gSender ${pkg.version}`,
-                kiosk,
-            };
-            const window = await windowManager.openWindow(url, options, splashScreen);
+      ipcMain.handle("check-remote-status", (channel) => {
+        log.debug(hostInformation);
+        return hostInformation;
+      });
 
-            // Check argv for file path on Windows/Linux cold start
-            if (process.platform !== 'darwin') {
-                const filePath = process.argv.find(arg =>
-                    /\.(gcode|gc|nc|tap|cnc)$/i.test(arg)
-                );
-                if (filePath) {
-                    pendingFileToOpen = filePath;
-                }
-            }
-
-            ipcMain.on('file-association-ready', () => {
-                isRendererReady = true;
-                if (pendingFileToOpen) {
-                    loadFileAssociation(pendingFileToOpen, window);
-                    pendingFileToOpen = null;
-                }
-            });
-
-            // Power saver - display sleep higher precedence over app suspension
-            powerSaveBlocker.start('prevent-display-sleep');
-            powerMonitor.on('lock-screen', () => {
-                powerSaveBlocker.start('prevent-display-sleep');
-            });
-            powerMonitor.on('suspend', () => {
-                powerSaveBlocker.start('prevent-app-suspension');
-                log.info('Prevented suspension');
-            });
-
-            // Save window size and position
-            window.on('close', () => {
-                store.set('bounds', window.getBounds());
-            });
-
-            // Include release notes
-            //autoUpdater.fullChangelog = true;
-
-            if (process.platform === 'win32') {
-                autoUpdater.on('update-available', (info) => {
-                    setTimeout(() => {
-                        window.webContents.send('update_available', info);
-                    }, 8000);
-                });
-
-                autoUpdater.on('error', (err) => {
-                    window.webContents.send('updated_error', err);
-                    log.error((err));
-                });
-
-                autoUpdater.on('download-progress', (info) => {
-                    window.webContents.send('update_download_progress', info.percent);
-                });
-
-                ipcMain.once('restart_app', async () => {
-                    await autoUpdater.downloadUpdate();
-                    autoUpdater.quitAndInstall(false, false);
-                });
-            }
-
-            ipcMain.on('load-recent-file', async (msg, recentFile) => {
-                try {
-                    const fileMetadata = await parseAndReturnGCode(recentFile);
-                    window.webContents.send('loaded-recent-file', fileMetadata);
-                } catch (err) {
-                    log.error(err);
-                    window.webContents.send('remove-recent-file', {
-                        err: err.message,
-                        path: recentFile.filePath,
-                    });
-                }
-            });
-
-            ipcMain.on('logError:electron', (channel, error) => {
-                if ('type' in error) {
-                    log.transports.file.level = 'error';
-                }
-
-                if (error.type.includes('GRBL_HAL')) {
-                    error.type === 'GRBL_HAL_ERROR'
-                        ? grblLog.error(
-                            `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-                        )
-                        : grblLog.error(
-                            `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
-                        );
-                } else {
-                    error.type === 'GRBL_ERROR'
-                        ? grblLog.error(
-                            `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-                        )
-                        : grblLog.error(
-                            `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
-                        );
-                }
-            });
-
-            ipcMain.handle('copy-to-clipboard', (_channel, text) => {
-                if (!text) {
-                    return { success: false, error: 'No text to copy' };
-                }
-
-                clipboard.writeText(text);
-
-                return { success: true };
-            });
-
-            ipcMain.handle('grblLog:fetch', async (channel) => {
-                const data = await getGRBLLog(logPath);
-                return data;
-            });
-
-            ipcMain.handle('check-remote-status', (channel) => {
-                log.debug(hostInformation);
-                return hostInformation;
-            });
-
-            /**
+      /**
        * gSender config events - move electron store changes out of renderer process
        */
-            ipcMain.on('open-upload-dialog', async () => {
-                try {
-                    let additionalOptions = {};
-                    let gSenderWindow = windowManager.getWindow();
+      ipcMain.on("open-upload-dialog", async () => {
+        try {
+          let additionalOptions = {};
+          let gSenderWindow = windowManager.getWindow();
 
-                    if (prevDirectory) {
-                        additionalOptions.defaultPath = prevDirectory;
-                    }
-                    const file = await dialog.showOpenDialog(gSenderWindow, {
-                        properties: ['openFile'],
-                        filters: [
-                            {
-                                name: 'G-Code Files',
-                                extensions: ['gcode', 'gc', 'nc', 'tap', 'cnc'],
-                            },
-                            { name: 'All Files', extensions: ['*'] },
-                        ],
-                    });
+          if (prevDirectory) {
+            additionalOptions.defaultPath = prevDirectory;
+          }
+          const file = await dialog.showOpenDialog(gSenderWindow, {
+            properties: ["openFile"],
+            filters: [
+              {
+                name: "G-Code Files",
+                extensions: ["gcode", "gc", "nc", "tap", "cnc"],
+              },
+              { name: "All Files", extensions: ["*"] },
+            ],
+          });
 
-                    if (!file) {
-                        return;
-                    }
-                    if (file.canceled) {
-                        return;
-                    }
+          if (!file) {
+            return;
+          }
+          if (file.canceled) {
+            return;
+          }
 
-                    const FULL_FILE_PATH = file.filePaths[0];
-                    const getFileInformation = (file) => {
-                        const { base, dir } = path.parse(file);
-                        return [dir, base];
-                    };
+          const FULL_FILE_PATH = file.filePaths[0];
+          const getFileInformation = (file) => {
+            const { base, dir } = path.parse(file);
+            return [dir, base];
+          };
 
-                    const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
+          const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
 
-                    prevDirectory = filePath; // set previous directory
+          prevDirectory = filePath; // set previous directory
 
-                    fs.readFile(FULL_FILE_PATH, 'utf8', (err, data) => {
-                        if (err) {
-                            log.error(`Error in readFile: ${err}`);
-                            return;
-                        }
+          fs.readFile(FULL_FILE_PATH, "utf8", (err, data) => {
+            if (err) {
+              log.error(`Error in readFile: ${err}`);
+              return;
+            }
 
-                        const { size } = fs.statSync(FULL_FILE_PATH);
-                        window.webContents.send('returned-upload-dialog-data', {
-                            data,
-                            size,
-                            name: fileName,
-                            path: FULL_FILE_PATH,
-                        });
-                    });
-                } catch (e) {
-                    log.error(`Caught error in listener - ${e}`);
-                }
+            const { size } = fs.statSync(FULL_FILE_PATH);
+            window.webContents.send("returned-upload-dialog-data", {
+              data,
+              size,
+              name: fileName,
+              path: FULL_FILE_PATH,
             });
+          });
+        } catch (e) {
+          log.error(`Caught error in listener - ${e}`);
+        }
+      });
 
-            ipcMain.on('open-new-window', (msg, route) => {
-                const factor = screen.getPrimaryDisplay().scaleFactor;
-                const childOptions = {
-                    width: 550 / factor,
-                    height: 460 / factor,
-                    minWidth: 550 / factor,
-                    minHeight: 460 / factor,
-                    useContentSize: true,
-                    title: 'gSender',
-                    parent: window,
-                };
-                // Hash router URL should look like '{url}/#/widget/:id'
-                const address = `${url}/#${route}`;
-                const shouldMaximize = false;
-                const isChild = true;
+      ipcMain.on("open-new-window", (msg, route) => {
+        const factor = screen.getPrimaryDisplay().scaleFactor;
+        const childOptions = {
+          width: 550 / factor,
+          height: 460 / factor,
+          minWidth: 550 / factor,
+          minHeight: 460 / factor,
+          useContentSize: true,
+          title: "gSender",
+          parent: window,
+        };
+        // Hash router URL should look like '{url}/#/widget/:id'
+        const address = `${url}/#${route}`;
+        const shouldMaximize = false;
+        const isChild = true;
 
-                windowManager.openWindow(
-                    address,
-                    childOptions,
-                    null,
-                    shouldMaximize,
-                    isChild,
-                );
-            });
+        windowManager.openWindow(
+          address,
+          childOptions,
+          null,
+          shouldMaximize,
+          isChild,
+        );
+      });
 
-            ipcMain.on('reconnect-main', (event, options) => {
-                let shouldReconnect = false;
-                try {
-                    if (event && event.sender && event.sender.browserWindowOptions) {
-                        shouldReconnect =
+      ipcMain.on("reconnect-main", (event, options) => {
+        let shouldReconnect = false;
+        try {
+          if (event && event.sender && event.sender.browserWindowOptions) {
+            shouldReconnect =
               !event.sender.browserWindowOptions.parent &&
               windowManager.childWindows.length > 0;
-                    }
-                } catch (err) {
-                    log.error(err);
-                }
-                if (shouldReconnect) {
-                    windowManager.childWindows.forEach((window) => {
-                        window.webContents.send('reconnect', options);
-                    });
-                }
-            });
-
-            ipcMain.on('get-data', (event, widget) => {
-                window.webContents.send('get-data-' + widget);
-            });
-
-            ipcMain.on('receive-data', (event, msg) => {
-                const { widget, data } = msg;
-                windowManager.childWindows.forEach((window) => {
-                    window.webContents.send('recieve-data-' + widget, data);
-                });
-            });
-
-            //Handle app restart with remote settings
-            ipcMain.on('remoteMode-restart', (event, headlessSettings) => {
-                app.relaunch(); // flags are handled in server/index.js
-                app.exit(0);
-            });
+          }
         } catch (err) {
-            log.error(err);
-            log.err(err.name);
-            await dialog.showMessageBox({
-                message: err,
-            });
+          log.error(err);
         }
-        //Check for available updates at end to avoid try-catch failing to load events
-        if (process.platform === 'win32') {
-            const internetConnectivity = await isOnline();
-            if (internetConnectivity) {
-                autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
-                // There may be situations where something is blocking the update check outside of internet connectivity
-                // This sets a 4 second timeout on the await.
-                try {
-                    asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
-                } catch (e) {
-                    log.info(
-                        'Unable to check for app updates, likely no internet connection.',
-                    );
-                }
-            }
+        if (shouldReconnect) {
+          windowManager.childWindows.forEach((window) => {
+            window.webContents.send("reconnect", options);
+          });
         }
-    });
+      });
+
+      ipcMain.on("get-data", (event, widget) => {
+        window.webContents.send("get-data-" + widget);
+      });
+
+      ipcMain.on("receive-data", (event, msg) => {
+        const { widget, data } = msg;
+        windowManager.childWindows.forEach((window) => {
+          window.webContents.send("recieve-data-" + widget, data);
+        });
+      });
+
+      // Persist display scale factor chosen in settings so it can be
+      // applied via force-device-scale-factor on the next launch.
+      ipcMain.on("save-display-scale", (_event, scaleFactor) => {
+        const value = Number(scaleFactor);
+        if (value > 0) {
+          store.set("displayScaleFactor", value);
+        } else {
+          store.delete("displayScaleFactor");
+        }
+      });
+
+      //Handle app restart with remote settings
+      ipcMain.on("remoteMode-restart", (event, headlessSettings) => {
+        app.relaunch(); // flags are handled in server/index.js
+        app.exit(0);
+      });
+    } catch (err) {
+      log.error(err);
+      log.err(err.name);
+      await dialog.showMessageBox({
+        message: err,
+      });
+    }
+    //Check for available updates at end to avoid try-catch failing to load events
+    if (process.platform === "win32") {
+      const internetConnectivity = await isOnline();
+      if (internetConnectivity) {
+        autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
+        // There may be situations where something is blocking the update check outside of internet connectivity
+        // This sets a 4 second timeout on the await.
+        try {
+          asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
+        } catch (e) {
+          log.info(
+            "Unable to check for app updates, likely no internet connection.",
+          );
+        }
+      }
+    }
+  });
 };
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -22,532 +22,536 @@
  */
 
 import {
-    app,
-    ipcMain,
-    dialog,
-    powerSaveBlocker,
-    powerMonitor,
-    screen,
-    session,
-    clipboard,
-} from 'electron';
-import { autoUpdater } from 'electron-updater';
-import Store from 'electron-store';
-import chalk from 'chalk';
-import mkdirp from 'mkdirp';
-import isOnline from 'is-online';
-import log from 'electron-log';
-import path from 'path';
-import fs from 'fs';
-import * as Sentry from '@sentry/electron/main';
-import WindowManager from './electron-app/WindowManager';
-import launchServer from './server-cli';
-import pkg from './package.json';
-import { parseAndReturnGCode } from './electron-app/RecentFiles';
-import { asyncCallWithTimeout } from './electron-app/AsyncTimeout';
-import { getGRBLLog } from './electron-app/grblLogs';
+  app,
+  ipcMain,
+  dialog,
+  powerSaveBlocker,
+  powerMonitor,
+  screen,
+  session,
+  clipboard,
+} from "electron";
+import { autoUpdater } from "electron-updater";
+import Store from "electron-store";
+import chalk from "chalk";
+import mkdirp from "mkdirp";
+import isOnline from "is-online";
+import log from "electron-log";
+import path from "path";
+import fs from "fs";
+import * as Sentry from "@sentry/electron/main";
+import WindowManager from "./electron-app/WindowManager";
+import launchServer from "./server-cli";
+import pkg from "./package.json";
+import { parseAndReturnGCode } from "./electron-app/RecentFiles";
+import { asyncCallWithTimeout } from "./electron-app/AsyncTimeout";
+import { getGRBLLog } from "./electron-app/grblLogs";
 
 // Hot reload in development
-if (process.env.NODE_ENV === 'development') {
-    try {
-        require('electron-reloader')(module, {
-            debug: false,
-            watchRenderer: false, // Vite handles frontend
-            ignore: [/node_modules/, /output\/app/, /\.map$/],
-        });
-    } catch (err) {
+if (process.env.NODE_ENV === "development") {
+  try {
+    require("electron-reloader")(module, {
+      debug: false,
+      watchRenderer: false, // Vite handles frontend
+      ignore: [/node_modules/, /output\/app/, /\.map$/],
+    });
+  } catch (err) {
     // electron-reloader not available, continue without it
-    }
+  }
 }
 
 let windowManager = null;
 let hostInformation = {};
-let grblLog = log.create('grbl');
+let grblLog = log.create("grbl");
 let logPath;
 const externalRendererUrl =
-  process.env.NODE_ENV === 'development'
-      ? process.env.ELECTRON_RENDERER_URL
-      : '';
+  process.env.NODE_ENV === "development"
+    ? process.env.ELECTRON_RENDERER_URL
+    : "";
 
-if (process.env.NODE_ENV === 'production') {
-    Sentry.init({
-        dsn: 'https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560',
-        release: pkg.version,
-    });
+if (process.env.NODE_ENV === "production") {
+  Sentry.init({
+    dsn: "https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560",
+    release: pkg.version,
+  });
 }
 
 const main = () => {
-    // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
-    const gotSingleInstanceLock = app.requestSingleInstanceLock();
-    const shouldQuitImmediately = !gotSingleInstanceLock;
+  // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
+  const gotSingleInstanceLock = app.requestSingleInstanceLock();
+  const shouldQuitImmediately = !gotSingleInstanceLock;
 
-    // Initialize remote main
-    require('@electron/remote/main').initialize();
+  // Initialize remote main
+  require("@electron/remote/main").initialize();
 
-    let prevDirectory = '';
-    let pendingFileToOpen = null;
-    let isRendererReady = false;
+  let prevDirectory = "";
+  let pendingFileToOpen = null;
+  let isRendererReady = false;
 
-    if (shouldQuitImmediately) {
-        app.quit();
-        return;
-    }
+  if (shouldQuitImmediately) {
+    app.quit();
+    return;
+  }
 
-    app.on('second-instance', (event, commandLine, workingDirectory) => {
+  app.on("second-instance", (event, commandLine, workingDirectory) => {
     // Someone tried to run a second instance, we should focus our window.
-        if (!windowManager) {
-            return;
-        }
-
-        const window = windowManager.getWindow();
-        if (window) {
-            if (window.isMinimized()) {
-                window.restore();
-            }
-            window.focus();
-            const filePath = commandLine.find((arg) => /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),);
-            if (filePath) {
-                loadFileAssociation(filePath, window);
-            }
-        }
-    });
-
-    app.on('open-file', (event, filePath) => {
-        event.preventDefault();
-        const window = windowManager?.getWindow();
-        if (window && isRendererReady) {
-            loadFileAssociation(filePath, window);
-        } else {
-            pendingFileToOpen = filePath;
-        }
-    });
-
-    const store = new Store();
-
-    // Increase V8 heap size of the main process
-    if (process.arch === 'x64') {
-        const memoryLimit = 1024 * 8; // 8GB
-        app.commandLine.appendSwitch(
-            '--js-flags',
-            `--max-old-space-size=${memoryLimit}`,
-        );
+    if (!windowManager) {
+      return;
     }
 
-    if (process.platform === 'linux') {
-        app.commandLine.appendSwitch('--no-sandbox');
+    const window = windowManager.getWindow();
+    if (window) {
+      if (window.isMinimized()) {
+        window.restore();
+      }
+      window.focus();
+      const filePath = commandLine.find((arg) =>
+        /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
+      );
+      if (filePath) {
+        loadFileAssociation(filePath, window);
+      }
     }
+  });
 
-    // Create the user data directory if it does not exist
-    const userData = app.getPath('userData');
-    mkdirp.sync(userData);
-    // Extra logging
-    logPath = path.join(app.getPath('userData'), 'logs/grbl.log');
-    grblLog.transports.file.resolvePath = () => logPath;
+  app.on("open-file", (event, filePath) => {
+    event.preventDefault();
+    const window = windowManager?.getWindow();
+    if (window && isRendererReady) {
+      loadFileAssociation(filePath, window);
+    } else {
+      pendingFileToOpen = filePath;
+    }
+  });
 
-    const loadFileAssociation = async (filePath, window) => {
+  const store = new Store();
+
+  // Increase V8 heap size of the main process
+  if (process.arch === "x64") {
+    const memoryLimit = 1024 * 8; // 8GB
+    app.commandLine.appendSwitch(
+      "--js-flags",
+      `--max-old-space-size=${memoryLimit}`,
+    );
+  }
+
+  if (process.platform === "linux") {
+    app.commandLine.appendSwitch("--no-sandbox");
+  }
+
+  // Create the user data directory if it does not exist
+  const userData = app.getPath("userData");
+  mkdirp.sync(userData);
+  // Extra logging
+  logPath = path.join(app.getPath("userData"), "logs/grbl.log");
+  grblLog.transports.file.resolvePath = () => logPath;
+
+  const loadFileAssociation = async (filePath, window) => {
+    try {
+      const fileMetadata = await parseAndReturnGCode({ filePath });
+      window.webContents.send("returned-upload-dialog-data", {
+        data: fileMetadata.result,
+        size: fileMetadata.size,
+        name: fileMetadata.name,
+        path: fileMetadata.fullPath,
+      });
+    } catch (err) {
+      log.error(`Error loading file association: ${err}`);
+    }
+  };
+
+  app.whenReady().then(async () => {
+    try {
+      await session.defaultSession.clearCache();
+
+      windowManager = new WindowManager();
+      // Create and show splash before server starts
+      const splashScreen = windowManager.createSplashScreen({
+        width: 600,
+        height: 400,
+        show: false,
+        frame: false,
+        transparent: true,
+        backgroundColor: "#00000000",
+      });
+      splashScreen.loadFile(
+        path.join(__dirname, "app/assets/Splashscreen.webp"),
+      );
+      splashScreen.webContents.on("did-finish-load", () => {
+        splashScreen.show();
+      });
+
+      splashScreen.on("show", () => {
+        splashScreen.focus();
+      });
+
+      let url = "";
+      let kiosk = false;
+
+      if (externalRendererUrl) {
+        url = externalRendererUrl;
         try {
-            const fileMetadata = await parseAndReturnGCode({ filePath });
-            window.webContents.send('returned-upload-dialog-data', {
-                data: fileMetadata.result,
-                size: fileMetadata.size,
-                name: fileMetadata.name,
-                path: fileMetadata.fullPath,
-            });
-        } catch (err) {
-            log.error(`Error loading file association: ${err}`);
-        }
-    };
-
-    app.whenReady().then(async () => {
-        try {
-            await session.defaultSession.clearCache();
-
-            windowManager = new WindowManager();
-            // Create and show splash before server starts
-            const splashScreen = windowManager.createSplashScreen({
-                width: 600,
-                height: 400,
-                show: false,
-                frame: false,
-                transparent: true,
-                backgroundColor: '#00000000',
-            });
-            splashScreen.loadFile(
-                path.join(__dirname, 'app/assets/Splashscreen.webp'),
-            );
-            splashScreen.webContents.on('did-finish-load', () => {
-                splashScreen.show();
-            });
-
-            splashScreen.on('show', () => {
-                splashScreen.focus();
-            });
-
-            let url = '';
-            let kiosk = false;
-
-            if (externalRendererUrl) {
-                url = externalRendererUrl;
-                try {
-                    const parsedUrl = new URL(url);
-                    hostInformation = {
-                        address: parsedUrl.hostname,
-                        port:
+          const parsedUrl = new URL(url);
+          hostInformation = {
+            address: parsedUrl.hostname,
+            port:
               Number(parsedUrl.port) ||
-              (parsedUrl.protocol === 'https:' ? 443 : 80),
-                    };
-                } catch (error) {
-                    hostInformation = {};
-                }
-                log.info(`Using external renderer URL in development: ${url}`);
-            } else if (process.env.NODE_ENV === 'development') {
-                const errorMessage =
-          'ELECTRON_RENDERER_URL is required in development mode';
-                log.error(errorMessage);
-                await dialog.showMessageBox({
-                    type: 'error',
-                    title: 'Development Startup Error',
-                    message: errorMessage,
-                });
-                app.exit(1);
-                return;
-            } else {
-                let res;
-                try {
-                    res = await launchServer();
-                } catch (error) {
-                    const isBindingError =
+              (parsedUrl.protocol === "https:" ? 443 : 80),
+          };
+        } catch (error) {
+          hostInformation = {};
+        }
+        log.info(`Using external renderer URL in development: ${url}`);
+      } else if (process.env.NODE_ENV === "development") {
+        const errorMessage =
+          "ELECTRON_RENDERER_URL is required in development mode";
+        log.error(errorMessage);
+        await dialog.showMessageBox({
+          type: "error",
+          title: "Development Startup Error",
+          message: errorMessage,
+        });
+        app.exit(1);
+        return;
+      } else {
+        let res;
+        try {
+          res = await launchServer();
+        } catch (error) {
+          const isBindingError =
             error.errData?.bindingErr ||
             /EADDR|address not available|address already in use/i.test(
-                error.message,
+              error.message,
             );
 
-                    if (isBindingError) {
-                        log.warn(
-                            'Remote mode binding failed — remote config has been reset.',
-                        );
-                        dialog.showMessageBoxSync(null, {
-                            title: 'Remote Mode Configuration Error',
-                            message:
-                'gSender could not connect to the configured remote address.',
-                            detail:
-                'Remote mode has been disabled and the configuration has been reset. Please restart gSender.',
-                        });
-                    } else {
-                        log.error('Unexpected server startup error:', error);
-                        dialog.showMessageBoxSync(null, {
-                            title: 'Server Startup Error',
-                            message:
-                'gSender encountered an unexpected error while starting.',
-                            detail: String(error.message),
-                        });
-                    }
-                    app.exit(-1);
-                    return;
-                }
+          if (isBindingError) {
+            log.warn(
+              "Remote mode binding failed — remote config has been reset.",
+            );
+            dialog.showMessageBoxSync(null, {
+              title: "Remote Mode Configuration Error",
+              message:
+                "gSender could not connect to the configured remote address.",
+              detail:
+                "Remote mode has been disabled and the configuration has been reset. Please restart gSender.",
+            });
+          } else {
+            log.error("Unexpected server startup error:", error);
+            dialog.showMessageBoxSync(null, {
+              title: "Server Startup Error",
+              message:
+                "gSender encountered an unexpected error while starting.",
+              detail: String(error.message),
+            });
+          }
+          app.exit(-1);
+          return;
+        }
 
-                const { address, port, kiosk: resolvedKiosk } = { ...res };
-                kiosk = resolvedKiosk;
-                log.info(`Returned - http://${address}:${port}`);
-                hostInformation = {
-                    address,
-                    port,
-                };
-                if (!(address && port)) {
-                    log.error(
-                        'Unable to start the server at ' +
+        const { address, port, kiosk: resolvedKiosk } = { ...res };
+        kiosk = resolvedKiosk;
+        log.info(`Returned - http://${address}:${port}`);
+        hostInformation = {
+          address,
+          port,
+        };
+        if (!(address && port)) {
+          log.error(
+            "Unable to start the server at " +
               chalk.cyan(`http://${address}:${port}`),
-                    );
-                    return;
-                }
+          );
+          return;
+        }
 
-                url = `http://${address}:${port}`;
-            }
-            // The bounds is a rectangle object with the following properties:
-            // * `x` Number - The x coordinate of the origin of the rectangle.
-            // * `y` Number - The y coordinate of the origin of the rectangle.
-            // * `width` Number - The width of the rectangle.
-            // * `height` Number - The height of the rectangle.
-            // resolution used to be 1024x768
-            const bounds = {
-                minWidth: 1044,
-                minHeight: 768,
-                ...store.get('bounds'),
-            };
-            const options = {
-                ...bounds,
-                title: `gSender ${pkg.version}`,
-                kiosk,
-            };
-            const window = await windowManager.openWindow(url, options, splashScreen);
+        url = `http://${address}:${port}`;
+      }
+      // The bounds is a rectangle object with the following properties:
+      // * `x` Number - The x coordinate of the origin of the rectangle.
+      // * `y` Number - The y coordinate of the origin of the rectangle.
+      // * `width` Number - The width of the rectangle.
+      // * `height` Number - The height of the rectangle.
+      // resolution used to be 1024x768
+      const bounds = {
+        minWidth: 1044,
+        minHeight: 768,
+        ...store.get("bounds"),
+      };
+      const options = {
+        ...bounds,
+        title: `gSender ${pkg.version}`,
+        kiosk,
+      };
+      const window = await windowManager.openWindow(url, options, splashScreen);
 
-            window.on('ready-to-show', () => {
-                const savedScaleFactor = Number(store.get('displayScaleFactor', 1.0));
+      window.on("ready-to-show", () => {
+        const savedScaleFactor = Number(store.get("displayScaleFactor", 1.0));
 
-                window.webContents.setZoomFactor(savedScaleFactor);
-            });
+        window.webContents.setZoomFactor(savedScaleFactor);
+      });
 
-            // Check argv for file path on Windows/Linux cold start
-            if (process.platform !== 'darwin') {
-                const filePath = process.argv.find((arg) => /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),);
-                if (filePath) {
-                    pendingFileToOpen = filePath;
-                }
-            }
+      // Check argv for file path on Windows/Linux cold start
+      if (process.platform !== "darwin") {
+        const filePath = process.argv.find((arg) =>
+          /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
+        );
+        if (filePath) {
+          pendingFileToOpen = filePath;
+        }
+      }
 
-            ipcMain.on('file-association-ready', () => {
-                isRendererReady = true;
-                if (pendingFileToOpen) {
-                    loadFileAssociation(pendingFileToOpen, window);
-                    pendingFileToOpen = null;
-                }
-            });
+      ipcMain.on("file-association-ready", () => {
+        isRendererReady = true;
+        if (pendingFileToOpen) {
+          loadFileAssociation(pendingFileToOpen, window);
+          pendingFileToOpen = null;
+        }
+      });
 
-            // Power saver - display sleep higher precedence over app suspension
-            powerSaveBlocker.start('prevent-display-sleep');
-            powerMonitor.on('lock-screen', () => {
-                powerSaveBlocker.start('prevent-display-sleep');
-            });
-            powerMonitor.on('suspend', () => {
-                powerSaveBlocker.start('prevent-app-suspension');
-                log.info('Prevented suspension');
-            });
+      // Power saver - display sleep higher precedence over app suspension
+      powerSaveBlocker.start("prevent-display-sleep");
+      powerMonitor.on("lock-screen", () => {
+        powerSaveBlocker.start("prevent-display-sleep");
+      });
+      powerMonitor.on("suspend", () => {
+        powerSaveBlocker.start("prevent-app-suspension");
+        log.info("Prevented suspension");
+      });
 
-            // Save window size and position
-            window.on('close', () => {
-                store.set('bounds', window.getBounds());
-            });
+      // Save window size and position
+      window.on("close", () => {
+        store.set("bounds", window.getBounds());
+      });
 
-            // Include release notes
-            //autoUpdater.fullChangelog = true;
+      // Include release notes
+      //autoUpdater.fullChangelog = true;
 
-            if (process.platform === 'win32') {
-                autoUpdater.on('update-available', (info) => {
-                    setTimeout(() => {
-                        window.webContents.send('update_available', info);
-                    }, 8000);
-                });
+      if (process.platform === "win32") {
+        autoUpdater.on("update-available", (info) => {
+          setTimeout(() => {
+            window.webContents.send("update_available", info);
+          }, 8000);
+        });
 
-                autoUpdater.on('error', (err) => {
-                    window.webContents.send('updated_error', err);
-                    log.error(err);
-                });
+        autoUpdater.on("error", (err) => {
+          window.webContents.send("updated_error", err);
+          log.error(err);
+        });
 
-                autoUpdater.on('download-progress', (info) => {
-                    window.webContents.send('update_download_progress', info.percent);
-                });
+        autoUpdater.on("download-progress", (info) => {
+          window.webContents.send("update_download_progress", info.percent);
+        });
 
-                ipcMain.once('restart_app', async () => {
-                    await autoUpdater.downloadUpdate();
-                    autoUpdater.quitAndInstall(false, false);
-                });
-            }
+        ipcMain.once("restart_app", async () => {
+          await autoUpdater.downloadUpdate();
+          autoUpdater.quitAndInstall(false, false);
+        });
+      }
 
-            ipcMain.on('load-recent-file', async (msg, recentFile) => {
-                try {
-                    const fileMetadata = await parseAndReturnGCode(recentFile);
-                    window.webContents.send('loaded-recent-file', fileMetadata);
-                } catch (err) {
-                    log.error(err);
-                    window.webContents.send('remove-recent-file', {
-                        err: err.message,
-                        path: recentFile.filePath,
-                    });
-                }
-            });
+      ipcMain.on("load-recent-file", async (msg, recentFile) => {
+        try {
+          const fileMetadata = await parseAndReturnGCode(recentFile);
+          window.webContents.send("loaded-recent-file", fileMetadata);
+        } catch (err) {
+          log.error(err);
+          window.webContents.send("remove-recent-file", {
+            err: err.message,
+            path: recentFile.filePath,
+          });
+        }
+      });
 
-            ipcMain.on('logError:electron', (channel, error) => {
-                if ('type' in error) {
-                    log.transports.file.level = 'error';
-                }
+      ipcMain.on("logError:electron", (channel, error) => {
+        if ("type" in error) {
+          log.transports.file.level = "error";
+        }
 
-                if (error.type.includes('GRBL_HAL')) {
-                    error.type === 'GRBL_HAL_ERROR'
-                        ? grblLog.error(
-                            `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-                        )
-                        : grblLog.error(
-                            `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
-                        );
-                } else {
-                    error.type === 'GRBL_ERROR'
-                        ? grblLog.error(
-                            `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-                        )
-                        : grblLog.error(
-                            `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
-                        );
-                }
-            });
+        if (error.type.includes("GRBL_HAL")) {
+          error.type === "GRBL_HAL_ERROR"
+            ? grblLog.error(
+                `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+              )
+            : grblLog.error(
+                `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
+              );
+        } else {
+          error.type === "GRBL_ERROR"
+            ? grblLog.error(
+                `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+              )
+            : grblLog.error(
+                `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
+              );
+        }
+      });
 
-            ipcMain.handle('copy-to-clipboard', (_channel, text) => {
-                if (!text) {
-                    return { success: false, error: 'No text to copy' };
-                }
+      ipcMain.handle("copy-to-clipboard", (_channel, text) => {
+        if (!text) {
+          return { success: false, error: "No text to copy" };
+        }
 
-                clipboard.writeText(text);
+        clipboard.writeText(text);
 
-                return { success: true };
-            });
+        return { success: true };
+      });
 
-            ipcMain.handle('grblLog:fetch', async (channel) => {
-                const data = await getGRBLLog(logPath);
-                return data;
-            });
+      ipcMain.handle("grblLog:fetch", async (channel) => {
+        const data = await getGRBLLog(logPath);
+        return data;
+      });
 
-            ipcMain.handle('check-remote-status', (channel) => {
-                log.debug(hostInformation);
-                return hostInformation;
-            });
+      ipcMain.handle("check-remote-status", (channel) => {
+        log.debug(hostInformation);
+        return hostInformation;
+      });
 
-            /**
+      /**
        * gSender config events - move electron store changes out of renderer process
        */
-            ipcMain.on('open-upload-dialog', async () => {
-                try {
-                    let additionalOptions = {};
-                    let gSenderWindow = windowManager.getWindow();
+      ipcMain.on("open-upload-dialog", async () => {
+        try {
+          let additionalOptions = {};
+          let gSenderWindow = windowManager.getWindow();
 
-                    if (prevDirectory) {
-                        additionalOptions.defaultPath = prevDirectory;
-                    }
-                    const file = await dialog.showOpenDialog(gSenderWindow, {
-                        properties: ['openFile'],
-                        filters: [
-                            {
-                                name: 'G-Code Files',
-                                extensions: ['gcode', 'gc', 'nc', 'tap', 'cnc'],
-                            },
-                            { name: 'All Files', extensions: ['*'] },
-                        ],
-                    });
+          if (prevDirectory) {
+            additionalOptions.defaultPath = prevDirectory;
+          }
+          const file = await dialog.showOpenDialog(gSenderWindow, {
+            properties: ["openFile"],
+            filters: [
+              {
+                name: "G-Code Files",
+                extensions: ["gcode", "gc", "nc", "tap", "cnc"],
+              },
+              { name: "All Files", extensions: ["*"] },
+            ],
+          });
 
-                    if (!file) {
-                        return;
-                    }
-                    if (file.canceled) {
-                        return;
-                    }
+          if (!file) {
+            return;
+          }
+          if (file.canceled) {
+            return;
+          }
 
-                    const FULL_FILE_PATH = file.filePaths[0];
-                    const getFileInformation = (file) => {
-                        const { base, dir } = path.parse(file);
-                        return [dir, base];
-                    };
+          const FULL_FILE_PATH = file.filePaths[0];
+          const getFileInformation = (file) => {
+            const { base, dir } = path.parse(file);
+            return [dir, base];
+          };
 
-                    const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
+          const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
 
-                    prevDirectory = filePath; // set previous directory
+          prevDirectory = filePath; // set previous directory
 
-                    fs.readFile(FULL_FILE_PATH, 'utf8', (err, data) => {
-                        if (err) {
-                            log.error(`Error in readFile: ${err}`);
-                            return;
-                        }
+          fs.readFile(FULL_FILE_PATH, "utf8", (err, data) => {
+            if (err) {
+              log.error(`Error in readFile: ${err}`);
+              return;
+            }
 
-                        const { size } = fs.statSync(FULL_FILE_PATH);
-                        window.webContents.send('returned-upload-dialog-data', {
-                            data,
-                            size,
-                            name: fileName,
-                            path: FULL_FILE_PATH,
-                        });
-                    });
-                } catch (e) {
-                    log.error(`Caught error in listener - ${e}`);
-                }
+            const { size } = fs.statSync(FULL_FILE_PATH);
+            window.webContents.send("returned-upload-dialog-data", {
+              data,
+              size,
+              name: fileName,
+              path: FULL_FILE_PATH,
             });
+          });
+        } catch (e) {
+          log.error(`Caught error in listener - ${e}`);
+        }
+      });
 
-            ipcMain.on('open-new-window', (msg, route) => {
-                const factor = screen.getPrimaryDisplay().scaleFactor;
-                const childOptions = {
-                    width: 550 / factor,
-                    height: 460 / factor,
-                    minWidth: 550 / factor,
-                    minHeight: 460 / factor,
-                    useContentSize: true,
-                    title: 'gSender',
-                    parent: window,
-                };
-                // Hash router URL should look like '{url}/#/widget/:id'
-                const address = `${url}/#${route}`;
-                const shouldMaximize = false;
-                const isChild = true;
+      ipcMain.on("open-new-window", (msg, route) => {
+        const factor = screen.getPrimaryDisplay().scaleFactor;
+        const childOptions = {
+          width: 550 / factor,
+          height: 460 / factor,
+          minWidth: 550 / factor,
+          minHeight: 460 / factor,
+          useContentSize: true,
+          title: "gSender",
+          parent: window,
+        };
+        // Hash router URL should look like '{url}/#/widget/:id'
+        const address = `${url}/#${route}`;
+        const shouldMaximize = false;
+        const isChild = true;
 
-                windowManager.openWindow(
-                    address,
-                    childOptions,
-                    null,
-                    shouldMaximize,
-                    isChild,
-                );
-            });
+        windowManager.openWindow(
+          address,
+          childOptions,
+          null,
+          shouldMaximize,
+          isChild,
+        );
+      });
 
-            ipcMain.on('reconnect-main', (event, options) => {
-                let shouldReconnect = false;
-                try {
-                    if (event && event.sender && event.sender.browserWindowOptions) {
-                        shouldReconnect =
+      ipcMain.on("reconnect-main", (event, options) => {
+        let shouldReconnect = false;
+        try {
+          if (event && event.sender && event.sender.browserWindowOptions) {
+            shouldReconnect =
               !event.sender.browserWindowOptions.parent &&
               windowManager.childWindows.length > 0;
-                    }
-                } catch (err) {
-                    log.error(err);
-                }
-                if (shouldReconnect) {
-                    windowManager.childWindows.forEach((window) => {
-                        window.webContents.send('reconnect', options);
-                    });
-                }
-            });
-
-            ipcMain.on('get-data', (event, widget) => {
-                window.webContents.send('get-data-' + widget);
-            });
-
-            ipcMain.on('receive-data', (event, msg) => {
-                const { widget, data } = msg;
-                windowManager.childWindows.forEach((window) => {
-                    window.webContents.send('recieve-data-' + widget, data);
-                });
-            });
-
-            ipcMain.on('save-display-scale', (_event, scaleFactor) => {
-                const value = Number(scaleFactor) || 1.0;
-
-                store.set('displayScaleFactor', value);
-                window.webContents.setZoomFactor(value);
-            });
-
-            //Handle app restart with remote settings
-            ipcMain.on('remoteMode-restart', (event, headlessSettings) => {
-                app.relaunch(); // flags are handled in server/index.js
-                app.exit(0);
-            });
+          }
         } catch (err) {
-            log.error(err);
-            log.err(err.name);
-            await dialog.showMessageBox({
-                message: err,
-            });
+          log.error(err);
         }
-        //Check for available updates at end to avoid try-catch failing to load events
-        if (process.platform === 'win32') {
-            const internetConnectivity = await isOnline();
-            if (internetConnectivity) {
-                autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
-                // There may be situations where something is blocking the update check outside of internet connectivity
-                // This sets a 4 second timeout on the await.
-                try {
-                    asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
-                } catch (e) {
-                    log.info(
-                        'Unable to check for app updates, likely no internet connection.',
-                    );
-                }
-            }
+        if (shouldReconnect) {
+          windowManager.childWindows.forEach((window) => {
+            window.webContents.send("reconnect", options);
+          });
         }
-    });
+      });
+
+      ipcMain.on("get-data", (event, widget) => {
+        window.webContents.send("get-data-" + widget);
+      });
+
+      ipcMain.on("receive-data", (event, msg) => {
+        const { widget, data } = msg;
+        windowManager.childWindows.forEach((window) => {
+          window.webContents.send("recieve-data-" + widget, data);
+        });
+      });
+
+      ipcMain.on("save-display-scale", (_event, scaleFactor) => {
+        const value = Number(scaleFactor) || 1.0;
+
+        store.set("displayScaleFactor", value);
+        window.webContents.setZoomFactor(value);
+      });
+
+      //Handle app restart with remote settings
+      ipcMain.on("remoteMode-restart", (event, headlessSettings) => {
+        app.relaunch(); // flags are handled in server/index.js
+        app.exit(0);
+      });
+    } catch (err) {
+      log.error(err);
+      log.err(err.name);
+      await dialog.showMessageBox({
+        message: err,
+      });
+    }
+    //Check for available updates at end to avoid try-catch failing to load events
+    if (process.platform === "win32") {
+      const internetConnectivity = await isOnline();
+      if (internetConnectivity) {
+        autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
+        // There may be situations where something is blocking the update check outside of internet connectivity
+        // This sets a 4 second timeout on the await.
+        try {
+          asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
+        } catch (e) {
+          log.info(
+            "Unable to check for app updates, likely no internet connection.",
+          );
+        }
+      }
+    }
+  });
 };
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -22,536 +22,532 @@
  */
 
 import {
-  app,
-  ipcMain,
-  dialog,
-  powerSaveBlocker,
-  powerMonitor,
-  screen,
-  session,
-  clipboard,
-} from "electron";
-import { autoUpdater } from "electron-updater";
-import Store from "electron-store";
-import chalk from "chalk";
-import mkdirp from "mkdirp";
-import isOnline from "is-online";
-import log from "electron-log";
-import path from "path";
-import fs from "fs";
-import * as Sentry from "@sentry/electron/main";
-import WindowManager from "./electron-app/WindowManager";
-import launchServer from "./server-cli";
-import pkg from "./package.json";
-import { parseAndReturnGCode } from "./electron-app/RecentFiles";
-import { asyncCallWithTimeout } from "./electron-app/AsyncTimeout";
-import { getGRBLLog } from "./electron-app/grblLogs";
+    app,
+    ipcMain,
+    dialog,
+    powerSaveBlocker,
+    powerMonitor,
+    screen,
+    session,
+    clipboard,
+} from 'electron';
+import { autoUpdater } from 'electron-updater';
+import Store from 'electron-store';
+import chalk from 'chalk';
+import mkdirp from 'mkdirp';
+import isOnline from 'is-online';
+import log from 'electron-log';
+import path from 'path';
+import fs from 'fs';
+import * as Sentry from '@sentry/electron/main';
+import WindowManager from './electron-app/WindowManager';
+import launchServer from './server-cli';
+import pkg from './package.json';
+import { parseAndReturnGCode } from './electron-app/RecentFiles';
+import { asyncCallWithTimeout } from './electron-app/AsyncTimeout';
+import { getGRBLLog } from './electron-app/grblLogs';
 
 // Hot reload in development
-if (process.env.NODE_ENV === "development") {
-  try {
-    require("electron-reloader")(module, {
-      debug: false,
-      watchRenderer: false, // Vite handles frontend
-      ignore: [/node_modules/, /output\/app/, /\.map$/],
-    });
-  } catch (err) {
+if (process.env.NODE_ENV === 'development') {
+    try {
+        require('electron-reloader')(module, {
+            debug: false,
+            watchRenderer: false, // Vite handles frontend
+            ignore: [/node_modules/, /output\/app/, /\.map$/],
+        });
+    } catch (err) {
     // electron-reloader not available, continue without it
-  }
+    }
 }
 
 let windowManager = null;
 let hostInformation = {};
-let grblLog = log.create("grbl");
+let grblLog = log.create('grbl');
 let logPath;
 const externalRendererUrl =
-  process.env.NODE_ENV === "development"
-    ? process.env.ELECTRON_RENDERER_URL
-    : "";
+  process.env.NODE_ENV === 'development'
+      ? process.env.ELECTRON_RENDERER_URL
+      : '';
 
-if (process.env.NODE_ENV === "production") {
-  Sentry.init({
-    dsn: "https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560",
-    release: pkg.version,
-  });
+if (process.env.NODE_ENV === 'production') {
+    Sentry.init({
+        dsn: 'https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560',
+        release: pkg.version,
+    });
 }
 
 const main = () => {
-  // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
-  const gotSingleInstanceLock = app.requestSingleInstanceLock();
-  const shouldQuitImmediately = !gotSingleInstanceLock;
+    // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
+    const gotSingleInstanceLock = app.requestSingleInstanceLock();
+    const shouldQuitImmediately = !gotSingleInstanceLock;
 
-  // Initialize remote main
-  require("@electron/remote/main").initialize();
+    // Initialize remote main
+    require('@electron/remote/main').initialize();
 
-  let prevDirectory = "";
-  let pendingFileToOpen = null;
-  let isRendererReady = false;
+    let prevDirectory = '';
+    let pendingFileToOpen = null;
+    let isRendererReady = false;
 
-  if (shouldQuitImmediately) {
-    app.quit();
-    return;
-  }
-
-  app.on("second-instance", (event, commandLine, workingDirectory) => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (!windowManager) {
-      return;
-    }
-
-    const window = windowManager.getWindow();
-    if (window) {
-      if (window.isMinimized()) {
-        window.restore();
-      }
-      window.focus();
-      const filePath = commandLine.find((arg) =>
-        /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
-      );
-      if (filePath) {
-        loadFileAssociation(filePath, window);
-      }
-    }
-  });
-
-  app.on("open-file", (event, filePath) => {
-    event.preventDefault();
-    const window = windowManager?.getWindow();
-    if (window && isRendererReady) {
-      loadFileAssociation(filePath, window);
-    } else {
-      pendingFileToOpen = filePath;
-    }
-  });
-
-  const store = new Store();
-
-  // Increase V8 heap size of the main process
-  if (process.arch === "x64") {
-    const memoryLimit = 1024 * 8; // 8GB
-    app.commandLine.appendSwitch(
-      "--js-flags",
-      `--max-old-space-size=${memoryLimit}`,
-    );
-  }
-
-  if (process.platform === "linux") {
-    app.commandLine.appendSwitch("--no-sandbox");
-  }
-
-  // Create the user data directory if it does not exist
-  const userData = app.getPath("userData");
-  mkdirp.sync(userData);
-  // Extra logging
-  logPath = path.join(app.getPath("userData"), "logs/grbl.log");
-  grblLog.transports.file.resolvePath = () => logPath;
-
-  const loadFileAssociation = async (filePath, window) => {
-    try {
-      const fileMetadata = await parseAndReturnGCode({ filePath });
-      window.webContents.send("returned-upload-dialog-data", {
-        data: fileMetadata.result,
-        size: fileMetadata.size,
-        name: fileMetadata.name,
-        path: fileMetadata.fullPath,
-      });
-    } catch (err) {
-      log.error(`Error loading file association: ${err}`);
-    }
-  };
-
-  app.whenReady().then(async () => {
-    try {
-      await session.defaultSession.clearCache();
-
-      windowManager = new WindowManager();
-      // Create and show splash before server starts
-      const splashScreen = windowManager.createSplashScreen({
-        width: 600,
-        height: 400,
-        show: false,
-        frame: false,
-        transparent: true,
-        backgroundColor: "#00000000",
-      });
-      splashScreen.loadFile(
-        path.join(__dirname, "app/assets/Splashscreen.webp"),
-      );
-      splashScreen.webContents.on("did-finish-load", () => {
-        splashScreen.show();
-      });
-
-      splashScreen.on("show", () => {
-        splashScreen.focus();
-      });
-
-      let url = "";
-      let kiosk = false;
-
-      if (externalRendererUrl) {
-        url = externalRendererUrl;
-        try {
-          const parsedUrl = new URL(url);
-          hostInformation = {
-            address: parsedUrl.hostname,
-            port:
-              Number(parsedUrl.port) ||
-              (parsedUrl.protocol === "https:" ? 443 : 80),
-          };
-        } catch (error) {
-          hostInformation = {};
-        }
-        log.info(`Using external renderer URL in development: ${url}`);
-      } else if (process.env.NODE_ENV === "development") {
-        const errorMessage =
-          "ELECTRON_RENDERER_URL is required in development mode";
-        log.error(errorMessage);
-        await dialog.showMessageBox({
-          type: "error",
-          title: "Development Startup Error",
-          message: errorMessage,
-        });
-        app.exit(1);
+    if (shouldQuitImmediately) {
+        app.quit();
         return;
-      } else {
-        let res;
+    }
+
+    app.on('second-instance', (event, commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+        if (!windowManager) {
+            return;
+        }
+
+        const window = windowManager.getWindow();
+        if (window) {
+            if (window.isMinimized()) {
+                window.restore();
+            }
+            window.focus();
+            const filePath = commandLine.find((arg) => /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),);
+            if (filePath) {
+                loadFileAssociation(filePath, window);
+            }
+        }
+    });
+
+    app.on('open-file', (event, filePath) => {
+        event.preventDefault();
+        const window = windowManager?.getWindow();
+        if (window && isRendererReady) {
+            loadFileAssociation(filePath, window);
+        } else {
+            pendingFileToOpen = filePath;
+        }
+    });
+
+    const store = new Store();
+
+    // Increase V8 heap size of the main process
+    if (process.arch === 'x64') {
+        const memoryLimit = 1024 * 8; // 8GB
+        app.commandLine.appendSwitch(
+            '--js-flags',
+            `--max-old-space-size=${memoryLimit}`,
+        );
+    }
+
+    if (process.platform === 'linux') {
+        app.commandLine.appendSwitch('--no-sandbox');
+    }
+
+    // Create the user data directory if it does not exist
+    const userData = app.getPath('userData');
+    mkdirp.sync(userData);
+    // Extra logging
+    logPath = path.join(app.getPath('userData'), 'logs/grbl.log');
+    grblLog.transports.file.resolvePath = () => logPath;
+
+    const loadFileAssociation = async (filePath, window) => {
         try {
-          res = await launchServer();
-        } catch (error) {
-          const isBindingError =
+            const fileMetadata = await parseAndReturnGCode({ filePath });
+            window.webContents.send('returned-upload-dialog-data', {
+                data: fileMetadata.result,
+                size: fileMetadata.size,
+                name: fileMetadata.name,
+                path: fileMetadata.fullPath,
+            });
+        } catch (err) {
+            log.error(`Error loading file association: ${err}`);
+        }
+    };
+
+    app.whenReady().then(async () => {
+        try {
+            await session.defaultSession.clearCache();
+
+            windowManager = new WindowManager();
+            // Create and show splash before server starts
+            const splashScreen = windowManager.createSplashScreen({
+                width: 600,
+                height: 400,
+                show: false,
+                frame: false,
+                transparent: true,
+                backgroundColor: '#00000000',
+            });
+            splashScreen.loadFile(
+                path.join(__dirname, 'app/assets/Splashscreen.webp'),
+            );
+            splashScreen.webContents.on('did-finish-load', () => {
+                splashScreen.show();
+            });
+
+            splashScreen.on('show', () => {
+                splashScreen.focus();
+            });
+
+            let url = '';
+            let kiosk = false;
+
+            if (externalRendererUrl) {
+                url = externalRendererUrl;
+                try {
+                    const parsedUrl = new URL(url);
+                    hostInformation = {
+                        address: parsedUrl.hostname,
+                        port:
+              Number(parsedUrl.port) ||
+              (parsedUrl.protocol === 'https:' ? 443 : 80),
+                    };
+                } catch (error) {
+                    hostInformation = {};
+                }
+                log.info(`Using external renderer URL in development: ${url}`);
+            } else if (process.env.NODE_ENV === 'development') {
+                const errorMessage =
+          'ELECTRON_RENDERER_URL is required in development mode';
+                log.error(errorMessage);
+                await dialog.showMessageBox({
+                    type: 'error',
+                    title: 'Development Startup Error',
+                    message: errorMessage,
+                });
+                app.exit(1);
+                return;
+            } else {
+                let res;
+                try {
+                    res = await launchServer();
+                } catch (error) {
+                    const isBindingError =
             error.errData?.bindingErr ||
             /EADDR|address not available|address already in use/i.test(
-              error.message,
+                error.message,
             );
 
-          if (isBindingError) {
-            log.warn(
-              "Remote mode binding failed — remote config has been reset.",
-            );
-            dialog.showMessageBoxSync(null, {
-              title: "Remote Mode Configuration Error",
-              message:
-                "gSender could not connect to the configured remote address.",
-              detail:
-                "Remote mode has been disabled and the configuration has been reset. Please restart gSender.",
-            });
-          } else {
-            log.error("Unexpected server startup error:", error);
-            dialog.showMessageBoxSync(null, {
-              title: "Server Startup Error",
-              message:
-                "gSender encountered an unexpected error while starting.",
-              detail: String(error.message),
-            });
-          }
-          app.exit(-1);
-          return;
-        }
+                    if (isBindingError) {
+                        log.warn(
+                            'Remote mode binding failed — remote config has been reset.',
+                        );
+                        dialog.showMessageBoxSync(null, {
+                            title: 'Remote Mode Configuration Error',
+                            message:
+                'gSender could not connect to the configured remote address.',
+                            detail:
+                'Remote mode has been disabled and the configuration has been reset. Please restart gSender.',
+                        });
+                    } else {
+                        log.error('Unexpected server startup error:', error);
+                        dialog.showMessageBoxSync(null, {
+                            title: 'Server Startup Error',
+                            message:
+                'gSender encountered an unexpected error while starting.',
+                            detail: String(error.message),
+                        });
+                    }
+                    app.exit(-1);
+                    return;
+                }
 
-        const { address, port, kiosk: resolvedKiosk } = { ...res };
-        kiosk = resolvedKiosk;
-        log.info(`Returned - http://${address}:${port}`);
-        hostInformation = {
-          address,
-          port,
-        };
-        if (!(address && port)) {
-          log.error(
-            "Unable to start the server at " +
+                const { address, port, kiosk: resolvedKiosk } = { ...res };
+                kiosk = resolvedKiosk;
+                log.info(`Returned - http://${address}:${port}`);
+                hostInformation = {
+                    address,
+                    port,
+                };
+                if (!(address && port)) {
+                    log.error(
+                        'Unable to start the server at ' +
               chalk.cyan(`http://${address}:${port}`),
-          );
-          return;
-        }
+                    );
+                    return;
+                }
 
-        url = `http://${address}:${port}`;
-      }
-      // The bounds is a rectangle object with the following properties:
-      // * `x` Number - The x coordinate of the origin of the rectangle.
-      // * `y` Number - The y coordinate of the origin of the rectangle.
-      // * `width` Number - The width of the rectangle.
-      // * `height` Number - The height of the rectangle.
-      // resolution used to be 1024x768
-      const bounds = {
-        minWidth: 1044,
-        minHeight: 768,
-        ...store.get("bounds"),
-      };
-      const options = {
-        ...bounds,
-        title: `gSender ${pkg.version}`,
-        kiosk,
-      };
-      const window = await windowManager.openWindow(url, options, splashScreen);
+                url = `http://${address}:${port}`;
+            }
+            // The bounds is a rectangle object with the following properties:
+            // * `x` Number - The x coordinate of the origin of the rectangle.
+            // * `y` Number - The y coordinate of the origin of the rectangle.
+            // * `width` Number - The width of the rectangle.
+            // * `height` Number - The height of the rectangle.
+            // resolution used to be 1024x768
+            const bounds = {
+                minWidth: 1044,
+                minHeight: 768,
+                ...store.get('bounds'),
+            };
+            const options = {
+                ...bounds,
+                title: `gSender ${pkg.version}`,
+                kiosk,
+            };
+            const window = await windowManager.openWindow(url, options, splashScreen);
 
-      window.on("ready-to-show", () => {
-        const savedScaleFactor = Number(store.get("displayScaleFactor", 1.0));
+            window.on('ready-to-show', () => {
+                const savedScaleFactor = Number(store.get('displayScaleFactor', 1.0));
 
-        window.webContents.setZoomFactor(savedScaleFactor);
-      });
+                window.webContents.setZoomFactor(savedScaleFactor);
+            });
 
-      // Check argv for file path on Windows/Linux cold start
-      if (process.platform !== "darwin") {
-        const filePath = process.argv.find((arg) =>
-          /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
-        );
-        if (filePath) {
-          pendingFileToOpen = filePath;
-        }
-      }
-
-      ipcMain.on("file-association-ready", () => {
-        isRendererReady = true;
-        if (pendingFileToOpen) {
-          loadFileAssociation(pendingFileToOpen, window);
-          pendingFileToOpen = null;
-        }
-      });
-
-      // Power saver - display sleep higher precedence over app suspension
-      powerSaveBlocker.start("prevent-display-sleep");
-      powerMonitor.on("lock-screen", () => {
-        powerSaveBlocker.start("prevent-display-sleep");
-      });
-      powerMonitor.on("suspend", () => {
-        powerSaveBlocker.start("prevent-app-suspension");
-        log.info("Prevented suspension");
-      });
-
-      // Save window size and position
-      window.on("close", () => {
-        store.set("bounds", window.getBounds());
-      });
-
-      // Include release notes
-      //autoUpdater.fullChangelog = true;
-
-      if (process.platform === "win32") {
-        autoUpdater.on("update-available", (info) => {
-          setTimeout(() => {
-            window.webContents.send("update_available", info);
-          }, 8000);
-        });
-
-        autoUpdater.on("error", (err) => {
-          window.webContents.send("updated_error", err);
-          log.error(err);
-        });
-
-        autoUpdater.on("download-progress", (info) => {
-          window.webContents.send("update_download_progress", info.percent);
-        });
-
-        ipcMain.once("restart_app", async () => {
-          await autoUpdater.downloadUpdate();
-          autoUpdater.quitAndInstall(false, false);
-        });
-      }
-
-      ipcMain.on("load-recent-file", async (msg, recentFile) => {
-        try {
-          const fileMetadata = await parseAndReturnGCode(recentFile);
-          window.webContents.send("loaded-recent-file", fileMetadata);
-        } catch (err) {
-          log.error(err);
-          window.webContents.send("remove-recent-file", {
-            err: err.message,
-            path: recentFile.filePath,
-          });
-        }
-      });
-
-      ipcMain.on("logError:electron", (channel, error) => {
-        if ("type" in error) {
-          log.transports.file.level = "error";
-        }
-
-        if (error.type.includes("GRBL_HAL")) {
-          error.type === "GRBL_HAL_ERROR"
-            ? grblLog.error(
-                `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-              )
-            : grblLog.error(
-                `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
-              );
-        } else {
-          error.type === "GRBL_ERROR"
-            ? grblLog.error(
-                `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-              )
-            : grblLog.error(
-                `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
-              );
-        }
-      });
-
-      ipcMain.handle("copy-to-clipboard", (_channel, text) => {
-        if (!text) {
-          return { success: false, error: "No text to copy" };
-        }
-
-        clipboard.writeText(text);
-
-        return { success: true };
-      });
-
-      ipcMain.handle("grblLog:fetch", async (channel) => {
-        const data = await getGRBLLog(logPath);
-        return data;
-      });
-
-      ipcMain.handle("check-remote-status", (channel) => {
-        log.debug(hostInformation);
-        return hostInformation;
-      });
-
-      /**
-       * gSender config events - move electron store changes out of renderer process
-       */
-      ipcMain.on("open-upload-dialog", async () => {
-        try {
-          let additionalOptions = {};
-          let gSenderWindow = windowManager.getWindow();
-
-          if (prevDirectory) {
-            additionalOptions.defaultPath = prevDirectory;
-          }
-          const file = await dialog.showOpenDialog(gSenderWindow, {
-            properties: ["openFile"],
-            filters: [
-              {
-                name: "G-Code Files",
-                extensions: ["gcode", "gc", "nc", "tap", "cnc"],
-              },
-              { name: "All Files", extensions: ["*"] },
-            ],
-          });
-
-          if (!file) {
-            return;
-          }
-          if (file.canceled) {
-            return;
-          }
-
-          const FULL_FILE_PATH = file.filePaths[0];
-          const getFileInformation = (file) => {
-            const { base, dir } = path.parse(file);
-            return [dir, base];
-          };
-
-          const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
-
-          prevDirectory = filePath; // set previous directory
-
-          fs.readFile(FULL_FILE_PATH, "utf8", (err, data) => {
-            if (err) {
-              log.error(`Error in readFile: ${err}`);
-              return;
+            // Check argv for file path on Windows/Linux cold start
+            if (process.platform !== 'darwin') {
+                const filePath = process.argv.find((arg) => /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),);
+                if (filePath) {
+                    pendingFileToOpen = filePath;
+                }
             }
 
-            const { size } = fs.statSync(FULL_FILE_PATH);
-            window.webContents.send("returned-upload-dialog-data", {
-              data,
-              size,
-              name: fileName,
-              path: FULL_FILE_PATH,
+            ipcMain.on('file-association-ready', () => {
+                isRendererReady = true;
+                if (pendingFileToOpen) {
+                    loadFileAssociation(pendingFileToOpen, window);
+                    pendingFileToOpen = null;
+                }
             });
-          });
-        } catch (e) {
-          log.error(`Caught error in listener - ${e}`);
-        }
-      });
 
-      ipcMain.on("open-new-window", (msg, route) => {
-        const factor = screen.getPrimaryDisplay().scaleFactor;
-        const childOptions = {
-          width: 550 / factor,
-          height: 460 / factor,
-          minWidth: 550 / factor,
-          minHeight: 460 / factor,
-          useContentSize: true,
-          title: "gSender",
-          parent: window,
-        };
-        // Hash router URL should look like '{url}/#/widget/:id'
-        const address = `${url}/#${route}`;
-        const shouldMaximize = false;
-        const isChild = true;
+            // Power saver - display sleep higher precedence over app suspension
+            powerSaveBlocker.start('prevent-display-sleep');
+            powerMonitor.on('lock-screen', () => {
+                powerSaveBlocker.start('prevent-display-sleep');
+            });
+            powerMonitor.on('suspend', () => {
+                powerSaveBlocker.start('prevent-app-suspension');
+                log.info('Prevented suspension');
+            });
 
-        windowManager.openWindow(
-          address,
-          childOptions,
-          null,
-          shouldMaximize,
-          isChild,
-        );
-      });
+            // Save window size and position
+            window.on('close', () => {
+                store.set('bounds', window.getBounds());
+            });
 
-      ipcMain.on("reconnect-main", (event, options) => {
-        let shouldReconnect = false;
-        try {
-          if (event && event.sender && event.sender.browserWindowOptions) {
-            shouldReconnect =
+            // Include release notes
+            //autoUpdater.fullChangelog = true;
+
+            if (process.platform === 'win32') {
+                autoUpdater.on('update-available', (info) => {
+                    setTimeout(() => {
+                        window.webContents.send('update_available', info);
+                    }, 8000);
+                });
+
+                autoUpdater.on('error', (err) => {
+                    window.webContents.send('updated_error', err);
+                    log.error(err);
+                });
+
+                autoUpdater.on('download-progress', (info) => {
+                    window.webContents.send('update_download_progress', info.percent);
+                });
+
+                ipcMain.once('restart_app', async () => {
+                    await autoUpdater.downloadUpdate();
+                    autoUpdater.quitAndInstall(false, false);
+                });
+            }
+
+            ipcMain.on('load-recent-file', async (msg, recentFile) => {
+                try {
+                    const fileMetadata = await parseAndReturnGCode(recentFile);
+                    window.webContents.send('loaded-recent-file', fileMetadata);
+                } catch (err) {
+                    log.error(err);
+                    window.webContents.send('remove-recent-file', {
+                        err: err.message,
+                        path: recentFile.filePath,
+                    });
+                }
+            });
+
+            ipcMain.on('logError:electron', (channel, error) => {
+                if ('type' in error) {
+                    log.transports.file.level = 'error';
+                }
+
+                if (error.type.includes('GRBL_HAL')) {
+                    error.type === 'GRBL_HAL_ERROR'
+                        ? grblLog.error(
+                            `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+                        )
+                        : grblLog.error(
+                            `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
+                        );
+                } else {
+                    error.type === 'GRBL_ERROR'
+                        ? grblLog.error(
+                            `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+                        )
+                        : grblLog.error(
+                            `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
+                        );
+                }
+            });
+
+            ipcMain.handle('copy-to-clipboard', (_channel, text) => {
+                if (!text) {
+                    return { success: false, error: 'No text to copy' };
+                }
+
+                clipboard.writeText(text);
+
+                return { success: true };
+            });
+
+            ipcMain.handle('grblLog:fetch', async (channel) => {
+                const data = await getGRBLLog(logPath);
+                return data;
+            });
+
+            ipcMain.handle('check-remote-status', (channel) => {
+                log.debug(hostInformation);
+                return hostInformation;
+            });
+
+            /**
+       * gSender config events - move electron store changes out of renderer process
+       */
+            ipcMain.on('open-upload-dialog', async () => {
+                try {
+                    let additionalOptions = {};
+                    let gSenderWindow = windowManager.getWindow();
+
+                    if (prevDirectory) {
+                        additionalOptions.defaultPath = prevDirectory;
+                    }
+                    const file = await dialog.showOpenDialog(gSenderWindow, {
+                        properties: ['openFile'],
+                        filters: [
+                            {
+                                name: 'G-Code Files',
+                                extensions: ['gcode', 'gc', 'nc', 'tap', 'cnc'],
+                            },
+                            { name: 'All Files', extensions: ['*'] },
+                        ],
+                    });
+
+                    if (!file) {
+                        return;
+                    }
+                    if (file.canceled) {
+                        return;
+                    }
+
+                    const FULL_FILE_PATH = file.filePaths[0];
+                    const getFileInformation = (file) => {
+                        const { base, dir } = path.parse(file);
+                        return [dir, base];
+                    };
+
+                    const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
+
+                    prevDirectory = filePath; // set previous directory
+
+                    fs.readFile(FULL_FILE_PATH, 'utf8', (err, data) => {
+                        if (err) {
+                            log.error(`Error in readFile: ${err}`);
+                            return;
+                        }
+
+                        const { size } = fs.statSync(FULL_FILE_PATH);
+                        window.webContents.send('returned-upload-dialog-data', {
+                            data,
+                            size,
+                            name: fileName,
+                            path: FULL_FILE_PATH,
+                        });
+                    });
+                } catch (e) {
+                    log.error(`Caught error in listener - ${e}`);
+                }
+            });
+
+            ipcMain.on('open-new-window', (msg, route) => {
+                const factor = screen.getPrimaryDisplay().scaleFactor;
+                const childOptions = {
+                    width: 550 / factor,
+                    height: 460 / factor,
+                    minWidth: 550 / factor,
+                    minHeight: 460 / factor,
+                    useContentSize: true,
+                    title: 'gSender',
+                    parent: window,
+                };
+                // Hash router URL should look like '{url}/#/widget/:id'
+                const address = `${url}/#${route}`;
+                const shouldMaximize = false;
+                const isChild = true;
+
+                windowManager.openWindow(
+                    address,
+                    childOptions,
+                    null,
+                    shouldMaximize,
+                    isChild,
+                );
+            });
+
+            ipcMain.on('reconnect-main', (event, options) => {
+                let shouldReconnect = false;
+                try {
+                    if (event && event.sender && event.sender.browserWindowOptions) {
+                        shouldReconnect =
               !event.sender.browserWindowOptions.parent &&
               windowManager.childWindows.length > 0;
-          }
+                    }
+                } catch (err) {
+                    log.error(err);
+                }
+                if (shouldReconnect) {
+                    windowManager.childWindows.forEach((window) => {
+                        window.webContents.send('reconnect', options);
+                    });
+                }
+            });
+
+            ipcMain.on('get-data', (event, widget) => {
+                window.webContents.send('get-data-' + widget);
+            });
+
+            ipcMain.on('receive-data', (event, msg) => {
+                const { widget, data } = msg;
+                windowManager.childWindows.forEach((window) => {
+                    window.webContents.send('recieve-data-' + widget, data);
+                });
+            });
+
+            ipcMain.on('save-display-scale', (_event, scaleFactor) => {
+                const value = Number(scaleFactor) || 1.0;
+
+                store.set('displayScaleFactor', value);
+                window.webContents.setZoomFactor(value);
+            });
+
+            //Handle app restart with remote settings
+            ipcMain.on('remoteMode-restart', (event, headlessSettings) => {
+                app.relaunch(); // flags are handled in server/index.js
+                app.exit(0);
+            });
         } catch (err) {
-          log.error(err);
+            log.error(err);
+            log.err(err.name);
+            await dialog.showMessageBox({
+                message: err,
+            });
         }
-        if (shouldReconnect) {
-          windowManager.childWindows.forEach((window) => {
-            window.webContents.send("reconnect", options);
-          });
+        //Check for available updates at end to avoid try-catch failing to load events
+        if (process.platform === 'win32') {
+            const internetConnectivity = await isOnline();
+            if (internetConnectivity) {
+                autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
+                // There may be situations where something is blocking the update check outside of internet connectivity
+                // This sets a 4 second timeout on the await.
+                try {
+                    asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
+                } catch (e) {
+                    log.info(
+                        'Unable to check for app updates, likely no internet connection.',
+                    );
+                }
+            }
         }
-      });
-
-      ipcMain.on("get-data", (event, widget) => {
-        window.webContents.send("get-data-" + widget);
-      });
-
-      ipcMain.on("receive-data", (event, msg) => {
-        const { widget, data } = msg;
-        windowManager.childWindows.forEach((window) => {
-          window.webContents.send("recieve-data-" + widget, data);
-        });
-      });
-
-      ipcMain.on("save-display-scale", (_event, scaleFactor) => {
-        const value = Number(scaleFactor) || 1.0;
-
-        store.set("displayScaleFactor", value);
-        window.webContents.setZoomFactor(value);
-      });
-
-      //Handle app restart with remote settings
-      ipcMain.on("remoteMode-restart", (event, headlessSettings) => {
-        app.relaunch(); // flags are handled in server/index.js
-        app.exit(0);
-      });
-    } catch (err) {
-      log.error(err);
-      log.err(err.name);
-      await dialog.showMessageBox({
-        message: err,
-      });
-    }
-    //Check for available updates at end to avoid try-catch failing to load events
-    if (process.platform === "win32") {
-      const internetConnectivity = await isOnline();
-      if (internetConnectivity) {
-        autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
-        // There may be situations where something is blocking the update check outside of internet connectivity
-        // This sets a 4 second timeout on the await.
-        try {
-          asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
-        } catch (e) {
-          log.info(
-            "Unable to check for app updates, likely no internet connection.",
-          );
-        }
-      }
-    }
-  });
+    });
 };
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -22,536 +22,528 @@
  */
 
 import {
-  app,
-  ipcMain,
-  dialog,
-  powerSaveBlocker,
-  powerMonitor,
-  screen,
-  session,
-  clipboard,
-} from "electron";
-import { autoUpdater } from "electron-updater";
-import Store from "electron-store";
-import chalk from "chalk";
-import mkdirp from "mkdirp";
-import isOnline from "is-online";
-import log from "electron-log";
-import path from "path";
-import fs from "fs";
-import * as Sentry from "@sentry/electron/main";
-import WindowManager from "./electron-app/WindowManager";
-import launchServer from "./server-cli";
-import pkg from "./package.json";
-import { parseAndReturnGCode } from "./electron-app/RecentFiles";
-import { asyncCallWithTimeout } from "./electron-app/AsyncTimeout";
-import { getGRBLLog } from "./electron-app/grblLogs";
+    app,
+    ipcMain,
+    dialog,
+    powerSaveBlocker,
+    powerMonitor,
+    screen,
+    session,
+    clipboard,
+} from 'electron';
+import { autoUpdater } from 'electron-updater';
+import Store from 'electron-store';
+import chalk from 'chalk';
+import mkdirp from 'mkdirp';
+import isOnline from 'is-online';
+import log from 'electron-log';
+import path from 'path';
+import fs from 'fs';
+import * as Sentry from '@sentry/electron/main';
+import WindowManager from './electron-app/WindowManager';
+import launchServer from './server-cli';
+import pkg from './package.json';
+import { parseAndReturnGCode } from './electron-app/RecentFiles';
+import { asyncCallWithTimeout } from './electron-app/AsyncTimeout';
+import { getGRBLLog } from './electron-app/grblLogs';
 
 // Hot reload in development
-if (process.env.NODE_ENV === "development") {
-  try {
-    require("electron-reloader")(module, {
-      debug: false,
-      watchRenderer: false, // Vite handles frontend
-      ignore: [/node_modules/, /output\/app/, /\.map$/],
-    });
-  } catch (err) {
-    // electron-reloader not available, continue without it
-  }
+if (process.env.NODE_ENV === 'development') {
+    try {
+        require('electron-reloader')(module, {
+            debug: false,
+            watchRenderer: false, // Vite handles frontend
+            ignore: [
+                /node_modules/,
+                /output\/app/,
+                /\.map$/,
+            ],
+        });
+    } catch (err) {
+        // electron-reloader not available, continue without it
+    }
 }
 
 let windowManager = null;
 let hostInformation = {};
-let grblLog = log.create("grbl");
+let grblLog = log.create('grbl');
 let logPath;
-const externalRendererUrl =
-  process.env.NODE_ENV === "development"
+const externalRendererUrl = process.env.NODE_ENV === 'development'
     ? process.env.ELECTRON_RENDERER_URL
-    : "";
+    : '';
 
-if (process.env.NODE_ENV === "production") {
-  Sentry.init({
-    dsn: "https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560",
-    release: pkg.version,
-  });
+if (process.env.NODE_ENV === 'production') {
+    Sentry.init({
+        dsn: 'https://eeb4899f0415aa6bc9de477a7faeb720@o558751.ingest.us.sentry.io/4509479105986560',
+        release: pkg.version,
+    });
 }
 
 const main = () => {
-  // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
-  const gotSingleInstanceLock = app.requestSingleInstanceLock();
-  const shouldQuitImmediately = !gotSingleInstanceLock;
+    // https://github.com/electron/electron/blob/master/docs/api/app.md#apprequestsingleinstancelock
+    const gotSingleInstanceLock = app.requestSingleInstanceLock();
+    const shouldQuitImmediately = !gotSingleInstanceLock;
 
-  // Initialize remote main
-  require("@electron/remote/main").initialize();
+    // Initialize remote main
+    require('@electron/remote/main').initialize();
 
-  let prevDirectory = "";
-  let pendingFileToOpen = null;
-  let isRendererReady = false;
+    let prevDirectory = '';
+    let pendingFileToOpen = null;
+    let isRendererReady = false;
 
-  if (shouldQuitImmediately) {
-    app.quit();
-    return;
-  }
-
-  app.on("second-instance", (event, commandLine, workingDirectory) => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (!windowManager) {
-      return;
-    }
-
-    const window = windowManager.getWindow();
-    if (window) {
-      if (window.isMinimized()) {
-        window.restore();
-      }
-      window.focus();
-      const filePath = commandLine.find((arg) =>
-        /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
-      );
-      if (filePath) {
-        loadFileAssociation(filePath, window);
-      }
-    }
-  });
-
-  app.on("open-file", (event, filePath) => {
-    event.preventDefault();
-    const window = windowManager?.getWindow();
-    if (window && isRendererReady) {
-      loadFileAssociation(filePath, window);
-    } else {
-      pendingFileToOpen = filePath;
-    }
-  });
-
-  const store = new Store();
-
-  // Increase V8 heap size of the main process
-  if (process.arch === "x64") {
-    const memoryLimit = 1024 * 8; // 8GB
-    app.commandLine.appendSwitch(
-      "--js-flags",
-      `--max-old-space-size=${memoryLimit}`,
-    );
-  }
-
-  if (process.platform === "linux") {
-    app.commandLine.appendSwitch("--no-sandbox");
-  }
-
-  // Create the user data directory if it does not exist
-  const userData = app.getPath("userData");
-  mkdirp.sync(userData);
-  // Extra logging
-  logPath = path.join(app.getPath("userData"), "logs/grbl.log");
-  grblLog.transports.file.resolvePath = () => logPath;
-
-  const loadFileAssociation = async (filePath, window) => {
-    try {
-      const fileMetadata = await parseAndReturnGCode({ filePath });
-      window.webContents.send("returned-upload-dialog-data", {
-        data: fileMetadata.result,
-        size: fileMetadata.size,
-        name: fileMetadata.name,
-        path: fileMetadata.fullPath,
-      });
-    } catch (err) {
-      log.error(`Error loading file association: ${err}`);
-    }
-  };
-
-  app.whenReady().then(async () => {
-    try {
-      await session.defaultSession.clearCache();
-
-      windowManager = new WindowManager();
-      // Create and show splash before server starts
-      const splashScreen = windowManager.createSplashScreen({
-        width: 600,
-        height: 400,
-        show: false,
-        frame: false,
-        transparent: true,
-        backgroundColor: "#00000000",
-      });
-      splashScreen.loadFile(
-        path.join(__dirname, "app/assets/Splashscreen.webp"),
-      );
-      splashScreen.webContents.on("did-finish-load", () => {
-        splashScreen.show();
-      });
-
-      splashScreen.on("show", () => {
-        splashScreen.focus();
-      });
-
-      let url = "";
-      let kiosk = false;
-
-      if (externalRendererUrl) {
-        url = externalRendererUrl;
-        try {
-          const parsedUrl = new URL(url);
-          hostInformation = {
-            address: parsedUrl.hostname,
-            port:
-              Number(parsedUrl.port) ||
-              (parsedUrl.protocol === "https:" ? 443 : 80),
-          };
-        } catch (error) {
-          hostInformation = {};
-        }
-        log.info(`Using external renderer URL in development: ${url}`);
-      } else if (process.env.NODE_ENV === "development") {
-        const errorMessage =
-          "ELECTRON_RENDERER_URL is required in development mode";
-        log.error(errorMessage);
-        await dialog.showMessageBox({
-          type: "error",
-          title: "Development Startup Error",
-          message: errorMessage,
-        });
-        app.exit(1);
+    if (shouldQuitImmediately) {
+        app.quit();
         return;
-      } else {
-        let res;
-        try {
-          res = await launchServer();
-        } catch (error) {
-          const isBindingError =
-            error.errData?.bindingErr ||
-            /EADDR|address not available|address already in use/i.test(
-              error.message,
+    }
+
+    app.on('second-instance', (event, commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+        if (!windowManager) {
+            return;
+        }
+
+        const window = windowManager.getWindow();
+        if (window) {
+            if (window.isMinimized()) {
+                window.restore();
+            }
+            window.focus();
+            const filePath = commandLine.find(arg =>
+                /\.(gcode|gc|nc|tap|cnc)$/i.test(arg)
             );
-
-          if (isBindingError) {
-            log.warn(
-              "Remote mode binding failed — remote config has been reset.",
-            );
-            dialog.showMessageBoxSync(null, {
-              title: "Remote Mode Configuration Error",
-              message:
-                "gSender could not connect to the configured remote address.",
-              detail:
-                "Remote mode has been disabled and the configuration has been reset. Please restart gSender.",
-            });
-          } else {
-            log.error("Unexpected server startup error:", error);
-            dialog.showMessageBoxSync(null, {
-              title: "Server Startup Error",
-              message:
-                "gSender encountered an unexpected error while starting.",
-              detail: String(error.message),
-            });
-          }
-          app.exit(-1);
-          return;
+            if (filePath) {
+                loadFileAssociation(filePath, window);
+            }
         }
+    });
 
-        const { address, port, kiosk: resolvedKiosk } = { ...res };
-        kiosk = resolvedKiosk;
-        log.info(`Returned - http://${address}:${port}`);
-        hostInformation = {
-          address,
-          port,
-        };
-        if (!(address && port)) {
-          log.error(
-            "Unable to start the server at " +
-              chalk.cyan(`http://${address}:${port}`),
-          );
-          return;
-        }
-
-        url = `http://${address}:${port}`;
-      }
-      // The bounds is a rectangle object with the following properties:
-      // * `x` Number - The x coordinate of the origin of the rectangle.
-      // * `y` Number - The y coordinate of the origin of the rectangle.
-      // * `width` Number - The width of the rectangle.
-      // * `height` Number - The height of the rectangle.
-      // resolution used to be 1024x768
-      const bounds = {
-        minWidth: 1044,
-        minHeight: 768,
-        ...store.get("bounds"),
-      };
-      const options = {
-        ...bounds,
-        title: `gSender ${pkg.version}`,
-        kiosk,
-      };
-      const window = await windowManager.openWindow(url, options, splashScreen);
-
-      window.on("ready-to-show", () => {
-        const savedScaleFactor = Number(store.get("displayScaleFactor", 1.0));
-
-        window.webContents.setZoomFactor(savedScaleFactor);
-      });
-
-      // Check argv for file path on Windows/Linux cold start
-      if (process.platform !== "darwin") {
-        const filePath = process.argv.find((arg) =>
-          /\.(gcode|gc|nc|tap|cnc)$/i.test(arg),
-        );
-        if (filePath) {
-          pendingFileToOpen = filePath;
-        }
-      }
-
-      ipcMain.on("file-association-ready", () => {
-        isRendererReady = true;
-        if (pendingFileToOpen) {
-          loadFileAssociation(pendingFileToOpen, window);
-          pendingFileToOpen = null;
-        }
-      });
-
-      // Power saver - display sleep higher precedence over app suspension
-      powerSaveBlocker.start("prevent-display-sleep");
-      powerMonitor.on("lock-screen", () => {
-        powerSaveBlocker.start("prevent-display-sleep");
-      });
-      powerMonitor.on("suspend", () => {
-        powerSaveBlocker.start("prevent-app-suspension");
-        log.info("Prevented suspension");
-      });
-
-      // Save window size and position
-      window.on("close", () => {
-        store.set("bounds", window.getBounds());
-      });
-
-      // Include release notes
-      //autoUpdater.fullChangelog = true;
-
-      if (process.platform === "win32") {
-        autoUpdater.on("update-available", (info) => {
-          setTimeout(() => {
-            window.webContents.send("update_available", info);
-          }, 8000);
-        });
-
-        autoUpdater.on("error", (err) => {
-          window.webContents.send("updated_error", err);
-          log.error(err);
-        });
-
-        autoUpdater.on("download-progress", (info) => {
-          window.webContents.send("update_download_progress", info.percent);
-        });
-
-        ipcMain.once("restart_app", async () => {
-          await autoUpdater.downloadUpdate();
-          autoUpdater.quitAndInstall(false, false);
-        });
-      }
-
-      ipcMain.on("load-recent-file", async (msg, recentFile) => {
-        try {
-          const fileMetadata = await parseAndReturnGCode(recentFile);
-          window.webContents.send("loaded-recent-file", fileMetadata);
-        } catch (err) {
-          log.error(err);
-          window.webContents.send("remove-recent-file", {
-            err: err.message,
-            path: recentFile.filePath,
-          });
-        }
-      });
-
-      ipcMain.on("logError:electron", (channel, error) => {
-        if ("type" in error) {
-          log.transports.file.level = "error";
-        }
-
-        if (error.type.includes("GRBL_HAL")) {
-          error.type === "GRBL_HAL_ERROR"
-            ? grblLog.error(
-                `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-              )
-            : grblLog.error(
-                `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
-              );
+    app.on('open-file', (event, filePath) => {
+        event.preventDefault();
+        const window = windowManager?.getWindow();
+        if (window && isRendererReady) {
+            loadFileAssociation(filePath, window);
         } else {
-          error.type === "GRBL_ERROR"
-            ? grblLog.error(
-                `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
-              )
-            : grblLog.error(
-                `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
-              );
+            pendingFileToOpen = filePath;
         }
-      });
+    });
 
-      ipcMain.handle("copy-to-clipboard", (_channel, text) => {
-        if (!text) {
-          return { success: false, error: "No text to copy" };
-        }
+    const store = new Store();
 
-        clipboard.writeText(text);
+    // Increase V8 heap size of the main process
+    if (process.arch === 'x64') {
+        const memoryLimit = 1024 * 8; // 8GB
+        app.commandLine.appendSwitch(
+            '--js-flags',
+            `--max-old-space-size=${memoryLimit}`,
+        );
+    }
 
-        return { success: true };
-      });
+    if (process.platform === 'linux') {
+        app.commandLine.appendSwitch('--no-sandbox');
+    }
 
-      ipcMain.handle("grblLog:fetch", async (channel) => {
-        const data = await getGRBLLog(logPath);
-        return data;
-      });
+    // Create the user data directory if it does not exist
+    const userData = app.getPath('userData');
+    mkdirp.sync(userData);
+    // Extra logging
+    logPath = path.join(app.getPath('userData'), 'logs/grbl.log');
+    grblLog.transports.file.resolvePath = () => logPath;
 
-      ipcMain.handle("check-remote-status", (channel) => {
-        log.debug(hostInformation);
-        return hostInformation;
-      });
-
-      /**
-       * gSender config events - move electron store changes out of renderer process
-       */
-      ipcMain.on("open-upload-dialog", async () => {
+    const loadFileAssociation = async (filePath, window) => {
         try {
-          let additionalOptions = {};
-          let gSenderWindow = windowManager.getWindow();
+            const fileMetadata = await parseAndReturnGCode({ filePath });
+            window.webContents.send('returned-upload-dialog-data', {
+                data: fileMetadata.result,
+                size: fileMetadata.size,
+                name: fileMetadata.name,
+                path: fileMetadata.fullPath,
+            });
+        } catch (err) {
+            log.error(`Error loading file association: ${err}`);
+        }
+    };
 
-          if (prevDirectory) {
-            additionalOptions.defaultPath = prevDirectory;
-          }
-          const file = await dialog.showOpenDialog(gSenderWindow, {
-            properties: ["openFile"],
-            filters: [
-              {
-                name: "G-Code Files",
-                extensions: ["gcode", "gc", "nc", "tap", "cnc"],
-              },
-              { name: "All Files", extensions: ["*"] },
-            ],
-          });
+    app.whenReady().then(async () => {
+        try {
+            await session.defaultSession.clearCache();
 
-          if (!file) {
-            return;
-          }
-          if (file.canceled) {
-            return;
-          }
+            windowManager = new WindowManager();
+            // Create and show splash before server starts
+            const splashScreen = windowManager.createSplashScreen({
+                width: 600,
+                height: 400,
+                show: false,
+                frame: false,
+                transparent: true,
+                backgroundColor: '#00000000',
+            });
+            splashScreen.loadFile(
+                path.join(__dirname, 'app/assets/Splashscreen.webp'),
+            );
+            splashScreen.webContents.on('did-finish-load', () => {
+                splashScreen.show();
+            });
 
-          const FULL_FILE_PATH = file.filePaths[0];
-          const getFileInformation = (file) => {
-            const { base, dir } = path.parse(file);
-            return [dir, base];
-          };
+            splashScreen.on('show', () => {
+                splashScreen.focus();
+            });
 
-          const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
+            let url = '';
+            let kiosk = false;
 
-          prevDirectory = filePath; // set previous directory
+            if (externalRendererUrl) {
+                url = externalRendererUrl;
+                try {
+                    const parsedUrl = new URL(url);
+                    hostInformation = {
+                        address: parsedUrl.hostname,
+                        port: Number(parsedUrl.port) || (parsedUrl.protocol === 'https:' ? 443 : 80),
+                    };
+                } catch (error) {
+                    hostInformation = {};
+                }
+                log.info(`Using external renderer URL in development: ${url}`);
+            } else if (process.env.NODE_ENV === 'development') {
+                const errorMessage = 'ELECTRON_RENDERER_URL is required in development mode';
+                log.error(errorMessage);
+                await dialog.showMessageBox({
+                    type: 'error',
+                    title: 'Development Startup Error',
+                    message: errorMessage,
+                });
+                app.exit(1);
+                return;
+            } else {
+                let res;
+                try {
+                    res = await launchServer();
+                } catch (error) {
+                    const isBindingError = error.errData?.bindingErr ||
+                        /EADDR|address not available|address already in use/i.test(error.message);
 
-          fs.readFile(FULL_FILE_PATH, "utf8", (err, data) => {
-            if (err) {
-              log.error(`Error in readFile: ${err}`);
-              return;
+                    if (isBindingError) {
+                        log.warn('Remote mode binding failed — remote config has been reset.');
+                        dialog.showMessageBoxSync(null, {
+                            title: 'Remote Mode Configuration Error',
+                            message: 'gSender could not connect to the configured remote address.',
+                            detail: 'Remote mode has been disabled and the configuration has been reset. Please restart gSender.',
+                        });
+                    } else {
+                        log.error('Unexpected server startup error:', error);
+                        dialog.showMessageBoxSync(null, {
+                            title: 'Server Startup Error',
+                            message: 'gSender encountered an unexpected error while starting.',
+                            detail: String(error.message),
+                        });
+                    }
+                    app.exit(-1);
+                    return;
+                }
+
+                const { address, port, kiosk: resolvedKiosk } = { ...res };
+                kiosk = resolvedKiosk;
+                log.info(`Returned - http://${address}:${port}`);
+                hostInformation = {
+                    address,
+                    port,
+                };
+                if (!(address && port)) {
+                    log.error(
+                        'Unable to start the server at ' +
+                chalk.cyan(`http://${address}:${port}`),
+                    );
+                    return;
+                }
+
+                url = `http://${address}:${port}`;
+            }
+            // The bounds is a rectangle object with the following properties:
+            // * `x` Number - The x coordinate of the origin of the rectangle.
+            // * `y` Number - The y coordinate of the origin of the rectangle.
+            // * `width` Number - The width of the rectangle.
+            // * `height` Number - The height of the rectangle.
+            // resolution used to be 1024x768
+            const bounds = {
+                minWidth: 1044,
+                minHeight: 768,
+                ...store.get('bounds'),
+            };
+            const options = {
+                ...bounds,
+                title: `gSender ${pkg.version}`,
+                kiosk,
+            };
+            const window = await windowManager.openWindow(url, options, splashScreen);
+
+            window.on("ready-to-show", () => {
+                const savedScaleFactor = Number(store.get("displayScaleFactor", 1.0));
+
+                window.webContents.setZoomFactor(savedScaleFactor);
+            });
+
+            // Check argv for file path on Windows/Linux cold start
+            if (process.platform !== 'darwin') {
+                const filePath = process.argv.find(arg =>
+                    /\.(gcode|gc|nc|tap|cnc)$/i.test(arg)
+                );
+                if (filePath) {
+                    pendingFileToOpen = filePath;
+                }
             }
 
-            const { size } = fs.statSync(FULL_FILE_PATH);
-            window.webContents.send("returned-upload-dialog-data", {
-              data,
-              size,
-              name: fileName,
-              path: FULL_FILE_PATH,
+            ipcMain.on('file-association-ready', () => {
+                isRendererReady = true;
+                if (pendingFileToOpen) {
+                    loadFileAssociation(pendingFileToOpen, window);
+                    pendingFileToOpen = null;
+                }
             });
-          });
-        } catch (e) {
-          log.error(`Caught error in listener - ${e}`);
-        }
-      });
 
-      ipcMain.on("open-new-window", (msg, route) => {
-        const factor = screen.getPrimaryDisplay().scaleFactor;
-        const childOptions = {
-          width: 550 / factor,
-          height: 460 / factor,
-          minWidth: 550 / factor,
-          minHeight: 460 / factor,
-          useContentSize: true,
-          title: "gSender",
-          parent: window,
-        };
-        // Hash router URL should look like '{url}/#/widget/:id'
-        const address = `${url}/#${route}`;
-        const shouldMaximize = false;
-        const isChild = true;
+            // Power saver - display sleep higher precedence over app suspension
+            powerSaveBlocker.start('prevent-display-sleep');
+            powerMonitor.on('lock-screen', () => {
+                powerSaveBlocker.start('prevent-display-sleep');
+            });
+            powerMonitor.on('suspend', () => {
+                powerSaveBlocker.start('prevent-app-suspension');
+                log.info('Prevented suspension');
+            });
 
-        windowManager.openWindow(
-          address,
-          childOptions,
-          null,
-          shouldMaximize,
-          isChild,
-        );
-      });
+            // Save window size and position
+            window.on('close', () => {
+                store.set('bounds', window.getBounds());
+            });
 
-      ipcMain.on("reconnect-main", (event, options) => {
-        let shouldReconnect = false;
-        try {
-          if (event && event.sender && event.sender.browserWindowOptions) {
-            shouldReconnect =
+            // Include release notes
+            //autoUpdater.fullChangelog = true;
+
+            if (process.platform === 'win32') {
+                autoUpdater.on('update-available', (info) => {
+                    setTimeout(() => {
+                        window.webContents.send('update_available', info);
+                    }, 8000);
+                });
+
+                autoUpdater.on('error', (err) => {
+                    window.webContents.send('updated_error', err);
+                    log.error((err));
+                });
+
+                autoUpdater.on('download-progress', (info) => {
+                    window.webContents.send('update_download_progress', info.percent);
+                });
+
+                ipcMain.once('restart_app', async () => {
+                    await autoUpdater.downloadUpdate();
+                    autoUpdater.quitAndInstall(false, false);
+                });
+            }
+
+            ipcMain.on('load-recent-file', async (msg, recentFile) => {
+                try {
+                    const fileMetadata = await parseAndReturnGCode(recentFile);
+                    window.webContents.send('loaded-recent-file', fileMetadata);
+                } catch (err) {
+                    log.error(err);
+                    window.webContents.send('remove-recent-file', {
+                        err: err.message,
+                        path: recentFile.filePath,
+                    });
+                }
+            });
+
+            ipcMain.on('logError:electron', (channel, error) => {
+                if ('type' in error) {
+                    log.transports.file.level = 'error';
+                }
+
+                if (error.type.includes('GRBL_HAL')) {
+                    error.type === 'GRBL_HAL_ERROR'
+                        ? grblLog.error(
+                            `GRBL_HAL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+                        )
+                        : grblLog.error(
+                            `GRBL_HAL_ALARM:Alarm ${error.code} - ${error.description}`,
+                        );
+                } else {
+                    error.type === 'GRBL_ERROR'
+                        ? grblLog.error(
+                            `GRBL_ERROR:Error ${error.code} - ${error.description} Line ${error.lineNumber}: "${error.line.trim()}" Origin- ${error.origin.trim()}`,
+                        )
+                        : grblLog.error(
+                            `GRBL_ALARM:Alarm ${error.code} - ${error.description}`,
+                        );
+                }
+            });
+
+            ipcMain.handle('copy-to-clipboard', (_channel, text) => {
+                if (!text) {
+                    return { success: false, error: 'No text to copy' };
+                }
+
+                clipboard.writeText(text);
+
+                return { success: true };
+            });
+
+            ipcMain.handle('grblLog:fetch', async (channel) => {
+                const data = await getGRBLLog(logPath);
+                return data;
+            });
+
+            ipcMain.handle('check-remote-status', (channel) => {
+                log.debug(hostInformation);
+                return hostInformation;
+            });
+
+            /**
+       * gSender config events - move electron store changes out of renderer process
+       */
+            ipcMain.on('open-upload-dialog', async () => {
+                try {
+                    let additionalOptions = {};
+                    let gSenderWindow = windowManager.getWindow();
+
+                    if (prevDirectory) {
+                        additionalOptions.defaultPath = prevDirectory;
+                    }
+                    const file = await dialog.showOpenDialog(gSenderWindow, {
+                        properties: ['openFile'],
+                        filters: [
+                            {
+                                name: 'G-Code Files',
+                                extensions: ['gcode', 'gc', 'nc', 'tap', 'cnc'],
+                            },
+                            { name: 'All Files', extensions: ['*'] },
+                        ],
+                    });
+
+                    if (!file) {
+                        return;
+                    }
+                    if (file.canceled) {
+                        return;
+                    }
+
+                    const FULL_FILE_PATH = file.filePaths[0];
+                    const getFileInformation = (file) => {
+                        const { base, dir } = path.parse(file);
+                        return [dir, base];
+                    };
+
+                    const [filePath, fileName] = getFileInformation(FULL_FILE_PATH);
+
+                    prevDirectory = filePath; // set previous directory
+
+                    fs.readFile(FULL_FILE_PATH, 'utf8', (err, data) => {
+                        if (err) {
+                            log.error(`Error in readFile: ${err}`);
+                            return;
+                        }
+
+                        const { size } = fs.statSync(FULL_FILE_PATH);
+                        window.webContents.send('returned-upload-dialog-data', {
+                            data,
+                            size,
+                            name: fileName,
+                            path: FULL_FILE_PATH,
+                        });
+                    });
+                } catch (e) {
+                    log.error(`Caught error in listener - ${e}`);
+                }
+            });
+
+            ipcMain.on('open-new-window', (msg, route) => {
+                const factor = screen.getPrimaryDisplay().scaleFactor;
+                const childOptions = {
+                    width: 550 / factor,
+                    height: 460 / factor,
+                    minWidth: 550 / factor,
+                    minHeight: 460 / factor,
+                    useContentSize: true,
+                    title: 'gSender',
+                    parent: window,
+                };
+                // Hash router URL should look like '{url}/#/widget/:id'
+                const address = `${url}/#${route}`;
+                const shouldMaximize = false;
+                const isChild = true;
+
+                windowManager.openWindow(
+                    address,
+                    childOptions,
+                    null,
+                    shouldMaximize,
+                    isChild,
+                );
+            });
+
+            ipcMain.on('reconnect-main', (event, options) => {
+                let shouldReconnect = false;
+                try {
+                    if (event && event.sender && event.sender.browserWindowOptions) {
+                        shouldReconnect =
               !event.sender.browserWindowOptions.parent &&
               windowManager.childWindows.length > 0;
-          }
+                    }
+                } catch (err) {
+                    log.error(err);
+                }
+                if (shouldReconnect) {
+                    windowManager.childWindows.forEach((window) => {
+                        window.webContents.send('reconnect', options);
+                    });
+                }
+            });
+
+            ipcMain.on('get-data', (event, widget) => {
+                window.webContents.send('get-data-' + widget);
+            });
+
+            ipcMain.on('receive-data', (event, msg) => {
+                const { widget, data } = msg;
+                windowManager.childWindows.forEach((window) => {
+                    window.webContents.send('recieve-data-' + widget, data);
+                });
+            });
+
+            ipcMain.on("save-display-scale", (_event, scaleFactor) => {
+                const value = Number(scaleFactor) || 1.0;
+
+                store.set("displayScaleFactor", value);
+                window.webContents.setZoomFactor(value);
+            });
+
+            //Handle app restart with remote settings
+            ipcMain.on('remoteMode-restart', (event, headlessSettings) => {
+                app.relaunch(); // flags are handled in server/index.js
+                app.exit(0);
+            });
         } catch (err) {
-          log.error(err);
+            log.error(err);
+            log.err(err.name);
+            await dialog.showMessageBox({
+                message: err,
+            });
         }
-        if (shouldReconnect) {
-          windowManager.childWindows.forEach((window) => {
-            window.webContents.send("reconnect", options);
-          });
+        //Check for available updates at end to avoid try-catch failing to load events
+        if (process.platform === 'win32') {
+            const internetConnectivity = await isOnline();
+            if (internetConnectivity) {
+                autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
+                // There may be situations where something is blocking the update check outside of internet connectivity
+                // This sets a 4 second timeout on the await.
+                try {
+                    asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
+                } catch (e) {
+                    log.info(
+                        'Unable to check for app updates, likely no internet connection.',
+                    );
+                }
+            }
         }
-      });
-
-      ipcMain.on("get-data", (event, widget) => {
-        window.webContents.send("get-data-" + widget);
-      });
-
-      ipcMain.on("receive-data", (event, msg) => {
-        const { widget, data } = msg;
-        windowManager.childWindows.forEach((window) => {
-          window.webContents.send("recieve-data-" + widget, data);
-        });
-      });
-
-      ipcMain.on("save-display-scale", (_event, scaleFactor) => {
-        const value = Number(scaleFactor) || 1.0;
-
-        store.set("displayScaleFactor", value);
-        window.webContents.setZoomFactor(value);
-      });
-
-      //Handle app restart with remote settings
-      ipcMain.on("remoteMode-restart", (event, headlessSettings) => {
-        app.relaunch(); // flags are handled in server/index.js
-        app.exit(0);
-      });
-    } catch (err) {
-      log.error(err);
-      log.err(err.name);
-      await dialog.showMessageBox({
-        message: err,
-      });
-    }
-    //Check for available updates at end to avoid try-catch failing to load events
-    if (process.platform === "win32") {
-      const internetConnectivity = await isOnline();
-      if (internetConnectivity) {
-        autoUpdater.autoDownload = false; // We don't want to force update but will prompt until it is updated
-        // There may be situations where something is blocking the update check outside of internet connectivity
-        // This sets a 4 second timeout on the await.
-        try {
-          asyncCallWithTimeout(autoUpdater.checkForUpdates(), 5000);
-        } catch (e) {
-          log.info(
-            "Unable to check for app updates, likely no internet connection.",
-          );
-        }
-      }
-    }
-  });
+    });
 };
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -139,14 +139,6 @@ const main = () => {
     app.commandLine.appendSwitch("--no-sandbox");
   }
 
-  const savedScaleFactor = Number(store.get("displayScaleFactor", 0));
-  if (savedScaleFactor > 0 && savedScaleFactor <= 5) {
-    app.commandLine.appendSwitch(
-      "force-device-scale-factor",
-      String(savedScaleFactor),
-    );
-  }
-
   // Create the user data directory if it does not exist
   const userData = app.getPath("userData");
   mkdirp.sync(userData);
@@ -290,6 +282,12 @@ const main = () => {
         kiosk,
       };
       const window = await windowManager.openWindow(url, options, splashScreen);
+
+      window.on("ready-to-show", () => {
+        const savedScaleFactor = Number(store.get("displayScaleFactor", 1.0));
+
+        window.webContents.setZoomFactor(savedScaleFactor);
+      });
 
       // Check argv for file path on Windows/Linux cold start
       if (process.platform !== "darwin") {
@@ -518,15 +516,11 @@ const main = () => {
         });
       });
 
-      // Persist display scale factor chosen in settings so it can be
-      // applied via force-device-scale-factor on the next launch.
       ipcMain.on("save-display-scale", (_event, scaleFactor) => {
-        const value = Number(scaleFactor);
-        if (value > 0) {
-          store.set("displayScaleFactor", value);
-        } else {
-          store.delete("displayScaleFactor");
-        }
+        const value = Number(scaleFactor) || 1.0;
+
+        store.set("displayScaleFactor", value);
+        window.webContents.setZoomFactor(value);
       });
 
       //Handle app restart with remote settings


### PR DESCRIPTION
I share this CNC with a few older guys and some of them struggle to navigate the windows file picker dialog because it's so small. We can increase Window's scale factor, but that also increases the size of gsender's UI which isn't necessary since it's already easy to navigate.

This PR allows for scaling of the app's UI independent of the OS' scale. This would allow for our use case (increasing Window's scaling but keeping gsender the same size) but also the inverse of increasing gsender's size without changing the OS' scale. I've chosen scaling numbers like 50%, 67%, and 75% since those are the reciprocal of a 2x, 1.5x, and 1.25x OS scaling factor respectively.

I've only tested on MacOS but it should work across all platforms.  Note that this is Electron-only since browsers can use their inbuilt scaling features if needed