### PR TITLE
[FEAT] Add shutdown button for host computer in top bar

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -332,6 +332,14 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         min: 0,
                         max: 4,
                     },
+                    {
+                        label: 'Show power button',
+                        key: 'workspace.showPowerButton',
+                        description:
+                            'Show a power button in the top bar to shut down the host computer',
+                        type: 'boolean',
+                        hidden: () => !isElectron(),
+                    },
                 ],
             },
             {
@@ -1319,7 +1327,7 @@ export const SettingsMenu: SettingsMenuSection[] = [
                     },
                     {
                         type: 'eeprom',
-                        eID: '$394'
+                        eID: '$394',
                     },
                     {
                         label: 'Spindle on delay',

--- a/src/app/src/features/PowerButton/index.tsx
+++ b/src/app/src/features/PowerButton/index.tsx
@@ -1,0 +1,41 @@
+import isElectron from 'is-electron';
+import { GrPowerShutdown } from 'react-icons/gr';
+import { Confirm } from 'app/components/ConfirmationDialog/ConfirmationDialogLib.ts';
+import Tooltip from 'app/components/Tooltip';
+import { useWorkspaceState } from 'app/hooks/useWorkspaceState';
+
+const PowerButton = () => {
+    const { showPowerButton } = useWorkspaceState();
+
+    if (!isElectron() || !showPowerButton) {
+        return null;
+    }
+
+    const handleClick = () => {
+        Confirm({
+            title: 'Shut Down Computer',
+            content:
+                'Are you sure you want to shut down this computer? This will close gSender and power off the host machine.',
+            confirmLabel: 'Shut Down',
+            cancelLabel: 'Cancel',
+            onConfirm: () => {
+                // @ts-ignore
+                window.ipcRenderer.send('shutdown-host');
+            },
+        });
+    };
+
+    return (
+        <Tooltip content="Shut Down Computer">
+            <button
+                className="flex flex-col gap-0.5 self-center content-center items-center justify-center text-sm text-gray-500 ml-4"
+                onClick={handleClick}
+                aria-label="Shut down host computer"
+            >
+                <GrPowerShutdown className="w-7 h-7 text-red-500 hover:text-red-700" />
+            </button>
+        </Tooltip>
+    );
+};
+
+export default PowerButton;

--- a/src/app/src/features/StatusIcons/index.tsx
+++ b/src/app/src/features/StatusIcons/index.tsx
@@ -12,6 +12,7 @@ import RemoteIndicator from 'app/features/RemoteMode/components/RemoteIndicator.
 import Tooltip from 'app/components/Tooltip';
 
 import NotificationsArea from 'app/features/NotificationsArea';
+import PowerButton from 'app/features/PowerButton';
 
 const StatusIcons = () => {
     const [gamepadConnected, setGamePadConnected] = useState(false);
@@ -102,6 +103,8 @@ const StatusIcons = () => {
             />
 
             <NotificationsArea />
+
+            <PowerButton />
         </div>
     );
 };

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -175,6 +175,7 @@ const defaultState: State = {
         notifications: [],
         toastDuration: 0,
         enableDarkMode: false,
+        showPowerButton: false,
         accessibility: {
             statusAnnouncements: false,
             jobProgressAnnouncements: false,

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -103,6 +103,7 @@ export interface Workspace {
     notifications: Notification[];
     toastDuration: number;
     enableDarkMode: boolean;
+    showPowerButton: boolean;
     accessibility: {
         statusAnnouncements: boolean;
         jobProgressAnnouncements: boolean;

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import {
     session,
     clipboard,
 } from 'electron';
+import { exec } from 'child_process';
 import { autoUpdater } from 'electron-updater';
 import Store from 'electron-store';
 import chalk from 'chalk';
@@ -513,6 +514,23 @@ const main = () => {
 
                 store.set("displayScaleFactor", value);
                 window.webContents.setZoomFactor(value);
+            });
+
+            ipcMain.on('shutdown-host', () => {
+                let command;
+                if (process.platform === 'win32') {
+                    command = 'shutdown /s /t 0';
+                } else if (process.platform === 'darwin') {
+                    command = 'osascript -e \'tell app "System Events" to shut down\'';
+                } else {
+                    // Linux, including Raspberry Pi
+                    command = 'shutdown -h now';
+                }
+                exec(command, (err) => {
+                    if (err) {
+                        log.error(`Failed to shut down host: ${err.message}`);
+                    }
+                });
             });
 
             //Handle app restart with remote settings


### PR DESCRIPTION
This one is really hyper specific to my needs so I totally understand if this doesn't make the cut! Here's the short version of why I wanted this:

- We have an AltMill 4x4 that's used by multiple people. Most of them are older and not super computer savvy
- We use the gControl Panel Computer in portrait mode. Because of the above tech literacy issue, we hide a lot of the Windows UI so all the guys can see is gSender
- We've had to disable the silver power button on the gControl since Windows no longer allows showing a confirmation prompt before shutdown. Our only options when pressing the silver power button are to shutdown immediately without prompting or to ignore the input entirely. We chose the latter since guys were accidentally turning off the computer when trying to insert a USB stick

Because of those factors, it would be really great to have a way to shut down the host computer via gSender. Again, I totally get that this is a very specific use case so feel free to tell me "no" 😉 