### PR TITLE
Probe type selection from within Probe tab

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -603,6 +603,13 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         ],
                     },
                     {
+                        label: 'Show touch plate switcher',
+                        key: 'widgets.probe.touchplateTypeSwitcher',
+                        description:
+                            'Show a button on Probe tab to allow switching between touch plate types.',
+                        type: 'boolean',
+                    },
+                    {
                         label: 'Tip diameter',
                         key: 'widgets.probe.tipDiameter3D',
                         description:

--- a/src/app/src/features/Probe/Probe.tsx
+++ b/src/app/src/features/Probe/Probe.tsx
@@ -26,6 +26,12 @@ import cx from 'classnames';
 
 import { Button as ShadcnButton } from 'app/components/shadcn/Button';
 import { Button } from 'app/components/Button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from 'app/components/shadcn/Dropdown';
 
 import { METRIC_UNITS, PROBING_CATEGORY } from '../../constants';
 import ProbeImage from './ProbeImage';
@@ -35,6 +41,7 @@ import { Actions, State } from './definitions';
 import useKeybinding from 'app/lib/useKeybinding';
 import useShuttleEvents from 'app/hooks/useShuttleEvents';
 import Tooltip from 'app/components/Tooltip';
+import { TOUCHPLATE_TYPES } from 'app/lib/constants';
 
 type ProbeProps = {
     state: State;
@@ -118,6 +125,7 @@ const Probe = ({ state, actions }: ProbeProps) => {
         availableProbeCommands,
         selectedProbeCommand,
         touchplate,
+        touchplateTypeSwitcher,
         direction,
     } = state;
 
@@ -130,7 +138,25 @@ const Probe = ({ state, actions }: ProbeProps) => {
             <div className="grid grid-cols-[5fr_3fr] w-full h-full max-xl:max-h-[144px]">
                 {/* <div className="w-full h-full m-auto grid gap-4">
                     <div className="h-full grid grid-rows[4fr_2fr] self-center gap-2"> */}
-                <div className="grid grid-rows-[1fr_1fr_1fr] gap-2 items-center justify-center">
+                <div className="grid grid-rows-[1fr_1fr_1fr] gap-1 items-center justify-center">
+                    { touchplateTypeSwitcher &&
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button className="h-full" aria-label="Change Probe Type">{touchplateType}</Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-56 bg-white">
+                                { Object.values(TOUCHPLATE_TYPES).map((tpt) =>
+                                    <DropdownMenuItem
+                                        key={tpt}
+                                        onClick={() => actions.changeTouchPlateType(tpt)}
+                                        className="flex items-center hover:bg-blue-100 transition-colors duration-200 cursor-pointer dark:hover:bg-dark-lighter"
+                                    >
+                                        {tpt}
+                                    </DropdownMenuItem>)
+                                }
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    }
                     <div className="flex w-full bg-white dark:bg-dark rounded-md border-solid border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-200 p-[2px]">
                         {availableProbeCommands.map((command, index) => (
                             <Tooltip

--- a/src/app/src/features/Probe/definitions.ts
+++ b/src/app/src/features/Probe/definitions.ts
@@ -114,6 +114,7 @@ export interface Probe {
     zProbeDistance: number;
     touchPlateHeight: number;
     probeType: string;
+    touchplateTypeSwitcher: boolean;
     probeAxis: string;
     direction: number;
     tipDiameter3D: number;
@@ -125,6 +126,7 @@ export interface Actions {
     setProbeConnectivity: (connectionMade: boolean) => void;
     onOpenChange: (isOpen: boolean) => void;
     changeProbeCommand: (value: string) => void;
+    changeTouchPlateType: (value: TOUCHPLATE_TYPES_T) => void;
     toggleUseTLO: () => void;
     handleProbeDepthChange: (event: Event) => void;
     handleProbeFeedrateChange: (event: Event) => void;
@@ -157,6 +159,7 @@ export interface State {
     availableProbeCommands: ProbeCommand[];
     selectedProbeCommand: number;
     touchplate: ProbeProfile;
+    touchplateTypeSwitcher: boolean;
     toolDiameter: number;
     availableTools: AvailableTool[];
     units: UNITS_EN;

--- a/src/app/src/features/Probe/index.tsx
+++ b/src/app/src/features/Probe/index.tsx
@@ -149,6 +149,9 @@ const ProbeWidget = () => {
     const [useSafeProbeOption, setUseSafeProbeOption] =
         useState<boolean>(false);
     const [selectedProbeCommand, setSelectedProbeCommand] = useState<number>(0);
+    const [touchplateTypeSwitcher, setTouchplateTypeSwitcher] = useState<boolean>(
+        config.get('touchplateTypeSwitcher')
+    );
     const [connectivityTest, setConnectivityTest] = useState<boolean>(
         config.get('connectivityTest'),
     );
@@ -252,6 +255,9 @@ const ProbeWidget = () => {
         },
         changeProbeCommand: (value: string): void => {
             setProbeCommand(value);
+        },
+        changeTouchPlateType: (value: TOUCHPLATE_TYPES_T): void => {
+            store.set('workspace.probeProfile.touchplateType', value);
         },
         toggleUseTLO: (): void => {
             setUseTLO(!useTLO);
@@ -567,6 +573,7 @@ const ProbeWidget = () => {
                 store.get('workspace.probeProfile.touchplateType'),
             );
             setTouchplate(store.get('workspace.probeProfile', {}));
+            setTouchplateTypeSwitcher(config.get('touchplateTypeSwitcher'));
             setProbeCommand(config.get('probeCommand', 'G38.2'));
             setUseTLO(config.get('useTLO'));
             setProbeDepth(config.get('probeDepth') || {});
@@ -599,6 +606,7 @@ const ProbeWidget = () => {
         availableProbeCommands: availableProbeCommands,
         selectedProbeCommand: selectedProbeCommand,
         touchplate: touchplate,
+        touchplateTypeSwitcher: touchplateTypeSwitcher,
         toolDiameter: toolDiameter,
         availableTools: availableTools,
         units: units,

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -321,6 +321,7 @@ const defaultState: State = {
             minimized: false,
             probeCommand: 'G38.2',
             connectivityTest: true,
+            touchplateTypeSwitcher: false,
             useTLO: false,
             probeDepth: 10,
             probeFeedrate: 75,


### PR DESCRIPTION
Adds a new setting under "Probe" to show a 'probe switcher in the main tab:
<br>
  
<img width="1226" height="444" alt="image" src="https://github.com/user-attachments/assets/567e06e5-5576-46ef-9bc9-400a8ac36c63" />
<br><br>

This lets you toggle probe type (e.g. I have a 3D Probe and Auto Zero wired in parallel) directly from the probing tab.  
  
| <img width="500" height="296" alt="image" src="https://github.com/user-attachments/assets/314f3057-d25c-4043-8e40-4a3c61f76dd2" />| <img width="505" height="295" alt="image" src="https://github.com/user-attachments/assets/e56c6480-424f-470f-9e83-961a0b7a1770" />| 
|--------|--------|

<br>
Attempts to resolve this forum suggestion: https://forum.sienci.com/t/probe-type-toggle-switch-in-ui/25143
<br>