### PR TITLE
[FEAT] Add macro editor modal to automations settings page

### DIFF
--- a/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
+++ b/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
@@ -87,6 +87,7 @@ export function EventInput({ eventType }: EventInputProps): React.ReactElement {
                     dialogDescription="Enter the G-code commands to run for this event."
                     showNameField={false}
                     showDescriptionField={false}
+                    allowEmptyContent
                     submitLabel="Save"
                     onSubmit={({ content }) => {
                         saveCommands(content).catch(() => {

--- a/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
+++ b/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
@@ -9,12 +9,22 @@ interface EventInputProps {
     eventType: string;
 }
 
+interface EventData {
+    id: string;
+    event: string;
+    trigger: string;
+    commands: string;
+    enabled: boolean;
+    mtime: number;
+}
+
 export function EventInput({ eventType }: EventInputProps): React.ReactElement {
-    const [eventData, setEventData] = useState<any>({});
+    const [eventData, setEventData] = useState<EventData | null>(null);
     const [eventCommands, setCommands] = useState('');
     const [isEditing, setIsEditing] = useState(false);
 
     async function toggleEvent() {
+        if (!eventData) return;
         const event = { ...eventData };
 
         try {
@@ -30,7 +40,7 @@ export function EventInput({ eventType }: EventInputProps): React.ReactElement {
     }
 
     async function saveCommands(commands: string) {
-        if (eventData.hasOwnProperty('id')) {
+        if (eventData?.id) {
             await api.events.update(eventType, { commands });
             setCommands(commands);
         } else {
@@ -51,9 +61,11 @@ export function EventInput({ eventType }: EventInputProps): React.ReactElement {
             const response = await api.events.fetch();
             const { records: jsonRecords } = response.data;
             const recordMap = new Map(Object.entries(jsonRecords));
-            const event = recordMap.get(eventType);
+            const event = recordMap.get(eventType) as EventData | undefined;
+
             if (event) {
-                const { commands } = event as any;
+                console.log({ event });
+                const { commands } = event;
                 setEventData(event);
                 commands && setCommands(commands);
             }
@@ -89,7 +101,10 @@ export function EventInput({ eventType }: EventInputProps): React.ReactElement {
             )}
             <div className="flex flex-row justify-between items-center">
                 <span>Enabled:</span>
-                <Switch checked={eventData.enabled} onChange={toggleEvent} />
+                <Switch
+                    checked={eventData?.enabled ?? false}
+                    onChange={toggleEvent}
+                />
             </div>
             <textarea
                 readOnly

--- a/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
+++ b/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
@@ -64,7 +64,6 @@ export function EventInput({ eventType }: EventInputProps): React.ReactElement {
             const event = recordMap.get(eventType) as EventData | undefined;
 
             if (event) {
-                console.log({ event });
                 const { commands } = event;
                 setEventData(event);
                 commands && setCommands(commands);

--- a/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
+++ b/src/app/src/features/Config/components/SettingInputs/EventInput.tsx
@@ -1,21 +1,20 @@
 import { useEffect, useState } from 'react';
+import React from 'react';
 import { toast } from 'app/lib/toaster';
 import api from 'app/api';
 import { Switch } from 'app/components/shadcn/Switch';
+import MacroForm from 'app/features/Macros/MacroForm';
 
 interface EventInputProps {
     eventType: string;
 }
 
-export function EventInput({ eventType }: EventInputProps): JSX.Element {
-    const [eventData, setEventData] = useState({});
+export function EventInput({ eventType }: EventInputProps): React.ReactElement {
+    const [eventData, setEventData] = useState<any>({});
     const [eventCommands, setCommands] = useState('');
+    const [isEditing, setIsEditing] = useState(false);
 
-    function onChange(e) {
-        setCommands(e.target.value);
-    }
-
-    async function toggleEvent(e) {
+    async function toggleEvent() {
         const event = { ...eventData };
 
         try {
@@ -26,21 +25,20 @@ export function EventInput({ eventType }: EventInputProps): JSX.Element {
                 enabled: event.enabled,
             });
         } catch (e) {
-            console.assert(e);
+            console.error(e);
         }
     }
 
-    async function onSave(e) {
-        e.preventDefault();
+    async function saveCommands(commands: string) {
         if (eventData.hasOwnProperty('id')) {
-            await api.events.update(eventType, {
-                commands: eventCommands,
-            });
+            await api.events.update(eventType, { commands });
+            setCommands(commands);
         } else {
             const res = await api.events.create({
                 event: eventType,
                 trigger: 'gcode',
-                commands: eventCommands,
+                commands,
+                enabled: false,
             });
             const { record } = res.data;
             setEventData(record);
@@ -55,14 +53,13 @@ export function EventInput({ eventType }: EventInputProps): JSX.Element {
             const recordMap = new Map(Object.entries(jsonRecords));
             const event = recordMap.get(eventType);
             if (event) {
-                const { commands } = event;
+                const { commands } = event as any;
                 setEventData(event);
-                //setEventData(recordMap.get(eventType));
                 commands && setCommands(commands);
             }
         };
 
-        fetchCall().catch((e) => {
+        fetchCall().catch(() => {
             toast.error(`Unable to fetch event data ${eventType}`, {
                 position: 'bottom-right',
             });
@@ -71,21 +68,41 @@ export function EventInput({ eventType }: EventInputProps): JSX.Element {
 
     return (
         <div className="flex flex-col w-full gap-2">
+            {isEditing && (
+                <MacroForm
+                    macroContent={eventCommands}
+                    title="Edit Event"
+                    dialogDescription="Enter the G-code commands to run for this event."
+                    showNameField={false}
+                    showDescriptionField={false}
+                    submitLabel="Save"
+                    onSubmit={({ content }) => {
+                        saveCommands(content).catch(() => {
+                            toast.error('Unable to save event commands', {
+                                position: 'bottom-right',
+                            });
+                        });
+                        setIsEditing(false);
+                    }}
+                    onCancel={() => setIsEditing(false)}
+                />
+            )}
             <div className="flex flex-row justify-between items-center">
                 <span>Enabled:</span>
                 <Switch checked={eventData.enabled} onChange={toggleEvent} />
             </div>
             <textarea
-                rows={8}
-                value={eventCommands}
-                onChange={onChange}
-                className="ring-1 ring-gray-300 rounded-md font-mono block w-full p-2 text-sm text-robin-500 bg-white resize-none focus:outline-none dark:bg-dark dark:text-white"
+                readOnly
+                tabIndex={-1}
+                rows={4}
+                value={eventCommands || '; No commands set'}
+                className="ring-1 ring-gray-300 rounded-md font-mono block w-full p-2 text-sm bg-gray-50 text-gray-500 resize-none pointer-events-none dark:bg-dark-lighter dark:text-gray-400 dark:ring-gray-600"
             />
             <button
                 className="bg-white shadow p-2 text-sm rounded border border-blue-500 text-gray-700 hover:bg-gray-100 dark:bg-dark dark:text-white dark:hover:bg-dark-lighter"
-                onClick={onSave}
+                onClick={() => setIsEditing(true)}
             >
-                Save Event
+                Edit Event
             </button>
         </div>
     );

--- a/src/app/src/features/Macros/MacroForm.tsx
+++ b/src/app/src/features/Macros/MacroForm.tsx
@@ -30,6 +30,11 @@ interface MacroFormProps {
         description: string;
     }) => void;
     onCancel: () => void;
+    title: string;
+    dialogDescription?: string;
+    showNameField?: boolean;
+    showDescriptionField?: boolean;
+    submitLabel: string;
 }
 
 interface MacroState {
@@ -50,6 +55,11 @@ const MacroForm = ({
     macroDescription = '',
     onSubmit,
     onCancel,
+    title,
+    dialogDescription,
+    showNameField = true,
+    showDescriptionField = true,
+    submitLabel,
 }: MacroFormProps) => {
     const [macroState, setMacroState] = useState<MacroState>({
         name: macroName,
@@ -70,7 +80,7 @@ const MacroForm = ({
 
     const validateForm = (): boolean => {
         const { name, content } = macroState;
-        return name.trim() !== '' && content.trim() !== '';
+        return (showNameField ? name.trim() !== '' : true) && content.trim() !== '';
     };
 
     const options = MACRO_VARIABLES.reduce((acc: any[], v: any) => {
@@ -108,15 +118,14 @@ const MacroForm = ({
                 >
                     <DialogHeader>
                         <DialogTitle>
-                            {id ? 'Edit Macro' : 'Add Macro'}
+                            {title}
                         </DialogTitle>
                     </DialogHeader>
-                    <DialogDescription className="mt-1 text-sm text-gray-500">
-                        Macros are a way to store and reuse commands. They can
-                        be used to speed up repetitive tasks and make your CNC
-                        more efficient.
+                    <DialogDescription className="mt-1 mb-4 text-sm text-gray-500">
+                        {dialogDescription ?? 'Macros are a way to store and reuse commands. They can be used to speed up repetitive tasks and make your CNC more efficient.'}
                     </DialogDescription>
-                    <div className="flex flex-col gap-2 my-4">
+                    {showNameField && (
+                    <div className="flex flex-col gap-2 mb-4">
                         <label>Name</label>
                         <Input
                             ref={nameRef}
@@ -128,6 +137,7 @@ const MacroForm = ({
                             required
                         />
                     </div>
+                    )}
                     <div className="flex flex-col gap-2 mb-4">
                         <div className="flex flex-row gap-2 items-center justify-between">
                             <label>G-code</label>
@@ -205,6 +215,7 @@ const MacroForm = ({
                             />
                         </Tooltip>
                     </div>
+                    {showDescriptionField && (
                     <div className="flex flex-col gap-2 mb-4">
                         <label>Macro Description</label>
                         <textarea
@@ -218,6 +229,7 @@ const MacroForm = ({
                             title=""
                         />
                     </div>
+                    )}
                     <DialogFooter>
                         <Button
                             color="primary"
@@ -235,7 +247,7 @@ const MacroForm = ({
                             }}
                             data-testid="add-macro-button"
                         >
-                            {id ? 'Update Macro' : 'Add New Macro'}
+                            {submitLabel}
                         </Button>
                         <Button onClick={onCancel}>Cancel</Button>
                     </DialogFooter>

--- a/src/app/src/features/Macros/MacroForm.tsx
+++ b/src/app/src/features/Macros/MacroForm.tsx
@@ -35,6 +35,7 @@ interface MacroFormProps {
     showNameField?: boolean;
     showDescriptionField?: boolean;
     submitLabel: string;
+    allowEmptyContent?: boolean;
 }
 
 interface MacroState {
@@ -60,6 +61,7 @@ const MacroForm = ({
     showNameField = true,
     showDescriptionField = true,
     submitLabel,
+    allowEmptyContent = false,
 }: MacroFormProps) => {
     const [macroState, setMacroState] = useState<MacroState>({
         name: macroName,
@@ -80,7 +82,10 @@ const MacroForm = ({
 
     const validateForm = (): boolean => {
         const { name, content } = macroState;
-        return (showNameField ? name.trim() !== '' : true) && content.trim() !== '';
+        return (
+            (showNameField ? name.trim() !== '' : true) &&
+            (allowEmptyContent || content.trim() !== '')
+        );
     };
 
     const options = MACRO_VARIABLES.reduce((acc: any[], v: any) => {
@@ -117,26 +122,25 @@ const MacroForm = ({
                     }}
                 >
                     <DialogHeader>
-                        <DialogTitle>
-                            {title}
-                        </DialogTitle>
+                        <DialogTitle>{title}</DialogTitle>
                     </DialogHeader>
                     <DialogDescription className="mt-1 mb-4 text-sm text-gray-500">
-                        {dialogDescription ?? 'Macros are a way to store and reuse commands. They can be used to speed up repetitive tasks and make your CNC more efficient.'}
+                        {dialogDescription ??
+                            'Macros are a way to store and reuse commands. They can be used to speed up repetitive tasks and make your CNC more efficient.'}
                     </DialogDescription>
                     {showNameField && (
-                    <div className="flex flex-col gap-2 mb-4">
-                        <label>Name</label>
-                        <Input
-                            ref={nameRef}
-                            maxLength={MAX_CHARACTERS}
-                            type="text"
-                            name="name"
-                            value={macroState.name}
-                            onChange={handleInputChange}
-                            required
-                        />
-                    </div>
+                        <div className="flex flex-col gap-2 mb-4">
+                            <label>Name</label>
+                            <Input
+                                ref={nameRef}
+                                maxLength={MAX_CHARACTERS}
+                                type="text"
+                                name="name"
+                                value={macroState.name}
+                                onChange={handleInputChange}
+                                required
+                            />
+                        </div>
                     )}
                     <div className="flex flex-col gap-2 mb-4">
                         <div className="flex flex-row gap-2 items-center justify-between">
@@ -216,19 +220,19 @@ const MacroForm = ({
                         </Tooltip>
                     </div>
                     {showDescriptionField && (
-                    <div className="flex flex-col gap-2 mb-4">
-                        <label>Macro Description</label>
-                        <textarea
-                            ref={descriptionRef}
-                            rows={4}
-                            maxLength={MAX_CHARACTERS}
-                            className="border border-gray-300 rounded-md p-2 dark:text-white dark:bg-dark dark:border-gray-500"
-                            name="description"
-                            value={macroState.description}
-                            onChange={handleInputChange}
-                            title=""
-                        />
-                    </div>
+                        <div className="flex flex-col gap-2 mb-4">
+                            <label>Macro Description</label>
+                            <textarea
+                                ref={descriptionRef}
+                                rows={4}
+                                maxLength={MAX_CHARACTERS}
+                                className="border border-gray-300 rounded-md p-2 dark:text-white dark:bg-dark dark:border-gray-500"
+                                name="description"
+                                value={macroState.description}
+                                onChange={handleInputChange}
+                                title=""
+                            />
+                        </div>
                     )}
                     <DialogFooter>
                         <Button

--- a/src/app/src/features/Macros/index.tsx
+++ b/src/app/src/features/Macros/index.tsx
@@ -438,6 +438,8 @@ const MacroWidget = ({
                     macroName={editMacro?.name}
                     macroContent={editMacro?.content}
                     macroDescription={editMacro?.description}
+                    title={modal.name === MODAL_EDIT_MACRO ? 'Edit Macro' : 'Add Macro'}
+                    submitLabel={modal.name === MODAL_EDIT_MACRO ? 'Update Macro' : 'Add New Macro'}
                 />
             )}
 


### PR DESCRIPTION
**What's new?**

Adds the macro editor modal to the automations settings page. Includes a readonly view of the gcode for that event so you can see the gcode at a glance

**Screenshots**

<img width="637" height="472" alt="Screenshot 2026-04-20 at 9 20 32 AM" src="https://github.com/user-attachments/assets/df9bc5e7-7696-4703-90b0-c6d6b578b5d9" />
<img width="907" height="630" alt="Screenshot 2026-04-20 at 9 23 17 AM" src="https://github.com/user-attachments/assets/881618b9-181c-4520-9f19-81f1cf2a5a8f" />
