### PR TITLE
Feature/toolhead outline

### DIFF
--- a/src/app/src/features/Visualizer/Visualizer.jsx
+++ b/src/app/src/features/Visualizer/Visualizer.jsx
@@ -1851,6 +1851,13 @@ class Visualizer extends Component {
                         const object = new THREE.Object3D();
                         object.add(mesh);
 
+                        // Black edge outline so the spinning tool reads as a
+                        // rotating fluted bit instead of a featureless grey blob.
+                        const outline = this.createToolOutline(geometry);
+                        if (outline) {
+                            object.add(outline);
+                        }
+
                         // unload the old one
                         this.group.remove(this.cuttingTool);
 
@@ -2241,6 +2248,13 @@ class Visualizer extends Component {
                     const object = new THREE.Object3D();
                     object.add(mesh);
 
+                    // Black edge outline so the spinning tool reads as a
+                    // rotating fluted bit instead of a featureless grey blob.
+                    const outline = this.createToolOutline(geometry);
+                    if (outline) {
+                        object.add(outline);
+                    }
+
                     this.group.remove(this.cuttingTool);
 
                     this.cuttingTool = object;
@@ -2435,6 +2449,28 @@ class Visualizer extends Component {
         const delta = 1 / fps;
         const degrees = 360 * ((delta * Math.PI) / 180); // Rotates 360 degrees per second
         this.cuttingTool.rotateZ(-((rpm / 60) * degrees)); // rotate in clockwise direction
+    }
+
+    // Build a black edge "outline" of the tool model — the geometric edges of
+    // the bit (its flutes and silhouette) drawn as black lines on top of the
+    // mesh. Added as a child of the rotating cuttingTool so the outlined flutes
+    // sweep as it spins, instead of the bit reading as a featureless grey blob.
+    // EdgesGeometry keeps only edges whose adjacent faces meet more sharply than
+    // thresholdAngleDeg, so smooth round areas stay clean and the flute creases
+    // stand out. Lower the threshold to catch more edges, raise it for fewer.
+    createToolOutline(geometry, { thresholdAngleDeg = 30 } = {}) {
+        if (
+            !geometry ||
+            !geometry.getAttribute ||
+            !geometry.getAttribute('position')
+        ) {
+            return null;
+        }
+        const edges = new THREE.EdgesGeometry(geometry, thresholdAngleDeg);
+        const material = new THREE.LineBasicMaterial({ color: 0x000000 });
+        const lines = new THREE.LineSegments(edges, material);
+        lines.name = 'CuttingToolOutline';
+        return lines;
     }
 
     // Update cutting tool position

--- a/src/app/src/features/Visualizer/Visualizer.jsx
+++ b/src/app/src/features/Visualizer/Visualizer.jsx
@@ -63,7 +63,12 @@ import _ from 'lodash';
 import store from 'app/store';
 
 import controller from '../../lib/controller';
-import { getBoundingBox, loadSTL, loadTexture } from './helpers';
+import {
+    getBoundingBox,
+    loadSTL,
+    loadTexture,
+    createToolOutline,
+} from './helpers';
 import Viewport from './Viewport';
 import CoordinateAxes from './CoordinateAxes';
 import Cuboid from './Cuboid';
@@ -1853,7 +1858,7 @@ class Visualizer extends Component {
 
                         // Black edge outline so the spinning tool reads as a
                         // rotating fluted bit instead of a featureless grey blob.
-                        const outline = this.createToolOutline(geometry);
+                        const outline = createToolOutline(geometry);
                         if (outline) {
                             object.add(outline);
                         }
@@ -2250,7 +2255,7 @@ class Visualizer extends Component {
 
                     // Black edge outline so the spinning tool reads as a
                     // rotating fluted bit instead of a featureless grey blob.
-                    const outline = this.createToolOutline(geometry);
+                    const outline = createToolOutline(geometry);
                     if (outline) {
                         object.add(outline);
                     }
@@ -2449,28 +2454,6 @@ class Visualizer extends Component {
         const delta = 1 / fps;
         const degrees = 360 * ((delta * Math.PI) / 180); // Rotates 360 degrees per second
         this.cuttingTool.rotateZ(-((rpm / 60) * degrees)); // rotate in clockwise direction
-    }
-
-    // Build a black edge "outline" of the tool model — the geometric edges of
-    // the bit (its flutes and silhouette) drawn as black lines on top of the
-    // mesh. Added as a child of the rotating cuttingTool so the outlined flutes
-    // sweep as it spins, instead of the bit reading as a featureless grey blob.
-    // EdgesGeometry keeps only edges whose adjacent faces meet more sharply than
-    // thresholdAngleDeg, so smooth round areas stay clean and the flute creases
-    // stand out. Lower the threshold to catch more edges, raise it for fewer.
-    createToolOutline(geometry, { thresholdAngleDeg = 30 } = {}) {
-        if (
-            !geometry ||
-            !geometry.getAttribute ||
-            !geometry.getAttribute('position')
-        ) {
-            return null;
-        }
-        const edges = new THREE.EdgesGeometry(geometry, thresholdAngleDeg);
-        const material = new THREE.LineBasicMaterial({ color: 0x000000 });
-        const lines = new THREE.LineSegments(edges, material);
-        lines.name = 'CuttingToolOutline';
-        return lines;
     }
 
     // Update cutting tool position

--- a/src/app/src/features/Visualizer/helpers.js
+++ b/src/app/src/features/Visualizer/helpers.js
@@ -52,4 +52,26 @@ const loadTexture = (url) =>
         new THREE.TextureLoader().load(url, resolve);
     });
 
-export { getBoundingBox, loadSTL, loadTexture };
+// Build a black edge "outline" of the tool model — the geometric edges of
+// the bit (its flutes and silhouette) drawn as black lines on top of the
+// mesh. Added as a child of the rotating cuttingTool so the outlined flutes
+// sweep as it spins, instead of the bit reading as a featureless grey blob.
+// EdgesGeometry keeps only edges whose adjacent faces meet more sharply than
+// thresholdAngleDeg, so smooth round areas stay clean and the flute creases
+// stand out. Lower the threshold to catch more edges, raise it for fewer.
+const createToolOutline = (geometry, { thresholdAngleDeg = 30 } = {}) => {
+    if (
+        !geometry ||
+        !geometry.getAttribute ||
+        !geometry.getAttribute('position')
+    ) {
+        return null;
+    }
+    const edges = new THREE.EdgesGeometry(geometry, thresholdAngleDeg);
+    const material = new THREE.LineBasicMaterial({ color: 0x000000 });
+    const lines = new THREE.LineSegments(edges, material);
+    lines.name = 'CuttingToolOutline';
+    return lines;
+};
+
+export { getBoundingBox, loadSTL, loadTexture, createToolOutline };

--- a/src/app/src/features/Visualizer/tests/toolOutline.test.js
+++ b/src/app/src/features/Visualizer/tests/toolOutline.test.js
@@ -1,0 +1,58 @@
+/*
+ * Unit tests for createToolOutline (the cutting-tool flute outline added in
+ * "Outline the cutting tool's flutes so rotation is visible").
+ *
+ * The outline builder is a pure THREE helper: given the tool mesh geometry it
+ * returns a black LineSegments of the geometry's sharp edges (so the spinning
+ * bit reads as a fluted tool rather than a featureless grey blob), or null for
+ * unusable input. three is real (not mocked).
+ */
+
+import * as THREE from 'three';
+import { createToolOutline } from '../helpers';
+
+describe('createToolOutline', () => {
+    describe('guards against unusable geometry', () => {
+        it('returns null when geometry is missing', () => {
+            expect(createToolOutline(undefined)).toBeNull();
+            expect(createToolOutline(null)).toBeNull();
+        });
+
+        it('returns null when the object has no getAttribute', () => {
+            expect(createToolOutline({})).toBeNull();
+        });
+
+        it('returns null when there is no position attribute', () => {
+            // A geometry with getAttribute but no 'position' (e.g. empty).
+            expect(createToolOutline(new THREE.BufferGeometry())).toBeNull();
+        });
+    });
+
+    describe('builds the outline for a valid mesh geometry', () => {
+        it('returns a named black LineSegments of edges', () => {
+            const outline = createToolOutline(new THREE.BoxGeometry(1, 1, 1));
+
+            expect(outline).toBeInstanceOf(THREE.LineSegments);
+            expect(outline.geometry).toBeInstanceOf(THREE.EdgesGeometry);
+            expect(outline.name).toBe('CuttingToolOutline');
+            // Black material so the edges read as a dark outline.
+            expect(outline.material).toBeInstanceOf(THREE.LineBasicMaterial);
+            expect(outline.material.color.getHex()).toBe(0x000000);
+            // A cube has its 12 right-angle edges kept (12 edges * 2 vertices).
+            expect(
+                outline.geometry.getAttribute('position').count,
+            ).toBeGreaterThan(0);
+        });
+
+        it('honors thresholdAngleDeg — a higher threshold keeps fewer edges', () => {
+            const box = new THREE.BoxGeometry(1, 1, 1);
+            const def = createToolOutline(box); // default 30deg
+            // The cube's faces meet at 90deg; a 100deg threshold keeps no edges.
+            const sparse = createToolOutline(box, { thresholdAngleDeg: 100 });
+
+            const defCount = def.geometry.getAttribute('position').count;
+            const sparseCount = sparse.geometry.getAttribute('position').count;
+            expect(defCount).toBeGreaterThan(sparseCount);
+        });
+    });
+});


### PR DESCRIPTION
Build a black edge "outline" of the tool model — the geometric edges of
the bit (its flutes and silhouette) drawn as black lines on top of the
mesh. Added as a child of the rotating cuttingTool so the outlined flutes
sweep as it spins, instead of the bit reading as a featureless grey blob.
EdgesGeometry keeps only edges whose adjacent faces meet more sharply than
thresholdAngleDeg, so smooth round areas stay clean and the flute creases
stand out. Lower the threshold to catch more edges, raise it for fewer.