### PR TITLE
Add run-progress toolpath coloring to the 3D visualizer

### DIFF
--- a/src/app/src/features/Visualizer/GCodeVisualizer.js
+++ b/src/app/src/features/Visualizer/GCodeVisualizer.js
@@ -34,6 +34,14 @@ const STATES = {
     DONE: 2,
 };
 
+// Lead color: buffered toolpath just ahead of the toolhead, between the
+// executed (grey) path and the rest of the buffered (yellow) path.
+const PROGRESS_LEAD_COLOR = '#ff8000'; // orange
+
+// Max distance (mm) from the toolhead to the nearest in-flight segment for the
+// split to track it; beyond this (jogging off the path) the split freezes.
+const PROGRESS_NEAR_MM = 2;
+
 class GCodeVisualizer {
     constructor(theme) {
         this.group = new THREE.Object3D();
@@ -58,6 +66,18 @@ class GCodeVisualizer {
         // Hide processed lines
         this.hideProcessedLines = false;
 
+        // Run-progress painter state: grey edge already painted (incremental),
+        // previous acked edge (for rewind restore), and the cached arc-length
+        // table for sizing the orange lead.
+        this._progGreyEndV = 0;
+        this._progAheadEndV = 0;
+        this._cumLen = null;
+        // Crisp-split position (segment + 0..1 param), kept monotonic so it
+        // never slides backward within a segment; reset when the segment changes.
+        this._progSplitSegFloor = -1;
+        this._progSplitSegFwd = -1;
+        this._progSplitT = 0;
+
         return this;
     }
 
@@ -66,6 +86,8 @@ class GCodeVisualizer {
         this.frames = frames;
         this.isLaser = isLaser;
         this.isRotaryFile = false;
+        // New geometry: drop the cached arc-length table so it rebuilds lazily.
+        this._cumLen = null;
         const baseColors =
             savedColors && savedColors.length === colorArray.length
                 ? savedColors
@@ -113,6 +135,135 @@ class GCodeVisualizer {
             return;
         }
         this.originalColors = new Float32Array(colorAttr.array);
+    }
+
+    // The in-buffer / planned color (theme PLANNED_PART, yellow by default).
+    _plannedColor() {
+        return new THREE.Color(this.theme.get(PLANNED_PART));
+    }
+
+    // Overlay line for a crisp grey/lead boundary at the toolhead. The main
+    // toolpath is one vertex-colored Line, so the tool's segment can only show a
+    // gradient; this short overlay (depthTest off, drawn on top) redraws that
+    // segment with a temp vertex at the machine position for a sharp split.
+    _ensureProgressSplitLine() {
+        if (this._progSplitLine) return;
+        // 4 vertices: A, split, split, B. Duplicating the split vertex lets the
+        // executed half and the ahead half carry solid colors with no gradient
+        // between them.
+        this._progSplitPositions = new Float32Array(4 * 3);
+        this._progSplitColors = new Float32Array(4 * 4);
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute(
+            'position',
+            new THREE.BufferAttribute(this._progSplitPositions, 3),
+        );
+        geom.setAttribute(
+            'color',
+            new THREE.BufferAttribute(this._progSplitColors, 4),
+        );
+        const mat = new THREE.LineBasicMaterial({
+            vertexColors: true,
+            transparent: true,
+            opacity: 0.9,
+            depthTest: false,
+        });
+        const line = new THREE.Line(geom, mat);
+        line.name = 'progressSplitOverlay';
+        line.renderOrder = 500;
+        line.frustumCulled = false;
+        line.visible = false;
+        this._progSplitGeometry = geom;
+        this._progSplitMaterial = mat;
+        this._progSplitLine = line;
+        this.group.add(line);
+    }
+
+    _hideProgressSplit() {
+        if (this._progSplitLine) this._progSplitLine.visible = false;
+    }
+
+    // Lazily build + cache cumulative arc length per vertex; differencing two
+    // entries gives mm of path travel (used to size the orange lead).
+    _ensureCumLen() {
+        if (this._cumLen) return this._cumLen;
+        const pos = this.vertices && this.vertices.array;
+        const n = this.vertices ? this.vertices.count : 0;
+        if (!pos || !n) return null;
+        const cum = new Float64Array(n);
+        let acc = 0;
+        for (let v = 1; v < n; v++) {
+            const dx = pos[v * 3] - pos[(v - 1) * 3];
+            const dy = pos[v * 3 + 1] - pos[(v - 1) * 3 + 1];
+            const dz = pos[v * 3 + 2] - pos[(v - 1) * 3 + 2];
+            acc += Math.sqrt(dx * dx + dy * dy + dz * dz);
+            cum[v] = acc;
+        }
+        this._cumLen = cum;
+        return cum;
+    }
+
+    // Draw the overlay on [vFloor, vFwd] with the split at the projection of the
+    // machine position; grey* colors the executed half, aheadColor the rest.
+    _updateProgressSplit(vFloor, vFwd, cutterPos, greyColor, greyAlpha, aheadColor) {
+        this._ensureProgressSplitLine();
+        const srcPos = this.vertices && this.vertices.array;
+        if (!srcPos || !cutterPos || vFwd <= vFloor) {
+            this._hideProgressSplit();
+            return;
+        }
+        const ax = srcPos[vFloor * 3];
+        const ay = srcPos[vFloor * 3 + 1];
+        const az = srcPos[vFloor * 3 + 2];
+        const bx = srcPos[vFwd * 3];
+        const by = srcPos[vFwd * 3 + 1];
+        const bz = srcPos[vFwd * 3 + 2];
+        const ex = bx - ax;
+        const ey = by - ay;
+        const ez = bz - az;
+        const len2 = ex * ex + ey * ey + ez * ez;
+        if (len2 === 0) {
+            this._hideProgressSplit();
+            return;
+        }
+        let t =
+            ((cutterPos.x - ax) * ex +
+                (cutterPos.y - ay) * ey +
+                (cutterPos.z - az) * ez) /
+            len2;
+        if (t < 0) t = 0;
+        else if (t > 1) t = 1;
+        // Monotonic split: never slide the boundary backward within a segment
+        // (reset when the segment changes).
+        if (
+            this._progSplitSegFloor === vFloor &&
+            this._progSplitSegFwd === vFwd
+        ) {
+            if (t < this._progSplitT) t = this._progSplitT;
+        } else {
+            this._progSplitSegFloor = vFloor;
+            this._progSplitSegFwd = vFwd;
+        }
+        this._progSplitT = t;
+        const sx = ax + t * ex;
+        const sy = ay + t * ey;
+        const sz = az + t * ez;
+
+        const p = this._progSplitPositions;
+        p[0] = ax; p[1] = ay; p[2] = az;
+        p[3] = sx; p[4] = sy; p[5] = sz;
+        p[6] = sx; p[7] = sy; p[8] = sz;
+        p[9] = bx; p[10] = by; p[11] = bz;
+
+        const c = this._progSplitColors;
+        c[0] = greyColor.r; c[1] = greyColor.g; c[2] = greyColor.b; c[3] = greyAlpha;
+        c[4] = greyColor.r; c[5] = greyColor.g; c[6] = greyColor.b; c[7] = greyAlpha;
+        c[8] = aheadColor.r; c[9] = aheadColor.g; c[10] = aheadColor.b; c[11] = 1;
+        c[12] = aheadColor.r; c[13] = aheadColor.g; c[14] = aheadColor.b; c[15] = 1;
+
+        this._progSplitGeometry.getAttribute('position').needsUpdate = true;
+        this._progSplitGeometry.getAttribute('color').needsUpdate = true;
+        this._progSplitLine.visible = true;
     }
 
     setFrameIndex(frameIndex) {
@@ -229,6 +380,11 @@ class GCodeVisualizer {
             this.plannedColorArray = [];
             this.plannedV1 = null;
             this.plannedState = STATES.START;
+            // Pull the run-progress painter's edges back to the rewound
+            // position so it re-paints orange/yellow forward from here (the
+            // [v2, v1) restore below clears the abandoned ahead band).
+            this._progGreyEndV = Math.min(this._progGreyEndV || 0, v2);
+            this._progAheadEndV = Math.min(this._progAheadEndV || 0, v2);
             // --rotary
             this.frameDifferences = Array(16).fill(-1);
             this.oldV1s = Array(16).fill(-1);
@@ -252,141 +408,288 @@ class GCodeVisualizer {
             workpiece.geometry.attributes.color.needsUpdate = true;
         }
 
+        // Per-frame hide backstop (greyOutLines needs a sender status; this
+        // doesn't). Rotary files have no run-progress bands, so hide to the
+        // received edge; otherwise stop at the grey/lead boundary maintained
+        // by greyOutLines so the orange lead and yellow buffer stay visible.
+        if (this.hideProcessedLines && v2 > 0) {
+            if (this.isRotaryFile) {
+                this._hideProcessedVertices(v2);
+            } else {
+                const greyEdge = Math.min(this._progGreyEndV || 0, v2);
+                if (greyEdge > 0) {
+                    this._hideProcessedVertices(greyEdge);
+                }
+            }
+        }
+
         this.frameIndex = frameIndex;
     }
 
-    greyOutLines(currentLineRunning) {
+    // Paint run-progress coloring: GREY behind the toolhead, ORANGE for a short
+    // look-ahead lead, YELLOW for the rest of the buffered range. currentLineRunning
+    // (wall-clock progress line) is only a fallback when cutterPos (machine
+    // position) is null.
+    greyOutLines(currentLineRunning, cutterPos) {
         currentLineRunning = Math.min(
             currentLineRunning,
             this.frames.length - 1,
         );
         currentLineRunning = Math.max(currentLineRunning, 0);
-        const v1FrameIndex =
-            currentLineRunning - 2 >= 0 ? currentLineRunning - 2 : 0;
-        const v2FrameIndex =
-            currentLineRunning - 2 >= 0 ? currentLineRunning - 1 : 0;
-        // fill from the last frame index to the current one - 2
-        // if start from line (this.plannedv1 - 0), start at 0
-        const v1 =
-            this.frames[
-                this.plannedV1 === undefined
-                    ? 0
-                    : this.oldFrameIndex || v1FrameIndex
-            ];
-        const v2 = this.frames[v2FrameIndex];
 
-        // Handle hiding processed lines if enabled
-        if (this.hideProcessedLines && v2 > 0) {
-            this._hideProcessedVertices(v2);
+        // Rotary files color the toolpath in setFrameIndex; nothing to paint
+        // here (mirrors the stock branch, which was guarded by !isRotaryFile).
+        if (this.isRotaryFile) {
+            this._hideProgressSplit();
+            this.oldFrameIndex = Math.max(0, currentLineRunning - 1);
+            return;
         }
 
-        if (v1 < v2 && !this.isRotaryFile) {
-            this._ensureOriginalColorsSnapshot();
-            const workpiece = this.group.children[0];
-            const colorAttr = workpiece.geometry.getAttribute('color');
-            const offsetIndex = v1 * 4;
-            const opacity = this.isLaser ? 1 : 0.3;
-            // grey
-            const runColor = new THREE.Color(SECONDARY_COLOR);
-            const greyArray = [...runColor.toArray(), opacity];
-            // yellow
-            const yellowColor = new THREE.Color(this.theme.get(PLANNED_PART));
-            const yellowArray = [...yellowColor.toArray(), 1];
-            // color arrays
-            const runColorArray = Array.from(
-                { length: v2 - v1 },
-                () => greyArray,
-            ).flat(); // grey, a couple movements before where our bit currently is
-            const bufferColorArray = Array.from(
-                { length: this.plannedV1 - this.frames[v2FrameIndex + 1] },
-                () => yellowArray,
-            ).flat(); // yellow, everything in between run lines and last planned line
+        const workpiece = this.group.children[0];
+        if (!workpiece) {
+            this._hideProgressSplit();
+            return;
+        }
+        const colorAttr = workpiece.geometry.getAttribute('color');
+        if (!colorAttr) {
+            this._hideProgressSplit();
+            return;
+        }
+        this._ensureOriginalColorsSnapshot();
 
-            let isOverflowing = false;
-            let lengthLeft = null;
-            if (this.plannedColorArray) {
-                // calculate length we have left to fill
-                lengthLeft = this.frames[this.frames.length - 1] - v1;
-                // calculate whether the grey + yellow will overflow the buffer
-                isOverflowing =
-                    runColorArray.length / 4 +
-                        bufferColorArray.length / 4 +
-                        this.plannedColorArray.length / 4 >
-                    lengthLeft;
+        const arr = colorAttr.array;
+        const totalV = this.vertices.count || arr.length / 4;
+
+        // vReceived: forward edge of what the controller has acked (the end of
+        // the yellow band). frameIndex was set to `received` by setFrameIndex.
+        const vReceived = Math.min(
+            Number(this.frames[this.frameIndex]) || 0,
+            totalV,
+        );
+        // Estimate boundary: gSender's wall-clock per-line countdown. Used only
+        // as the fallback floor when there's no reported machine position.
+        const estLine = Math.max(0, currentLineRunning - 1);
+        const vEstRaw = Math.min(Number(this.frames[estLine]) || 0, totalV);
+
+        // vCutter: grey/orange split = floor vertex at/behind the toolhead.
+        // Found by a NEAREST-SEGMENT scan over [floor, received): point-to-
+        // SEGMENT distance (not nearest-vertex) keeps it on the tool's own
+        // segment on back-and-forth paths, since a parallel pass is a stepover
+        // away. Scanning from the floor self-heals; the result is clamped
+        // monotonic so the grey edge never retreats.
+        const greyEnd = Math.min(this._progGreyEndV || 0, totalV);
+        const srcPos = this.vertices.array;
+        let vCutter = greyEnd;
+        // Whether the toolhead is close enough to an in-flight segment for the
+        // split to track it (false while jogging off the path → freeze).
+        let cutterNear = true;
+        if (cutterPos && srcPos && vReceived > greyEnd) {
+            // Geometry duplicates every point, so i+1 is often a zero-length
+            // joint; nextDistinct skips to the next distinct vertex.
+            const sameXYZ = (i, j) =>
+                srcPos[i * 3] === srcPos[j * 3] &&
+                srcPos[i * 3 + 1] === srcPos[j * 3 + 1] &&
+                srcPos[i * 3 + 2] === srcPos[j * 3 + 2];
+            const nextDistinct = (i) => {
+                let j = i + 1;
+                while (j < vReceived && sameXYZ(j, i)) j++;
+                return j;
+            };
+            // Clamped squared distance from the tool to segment [p, q].
+            const segDistSq = (p, q) => {
+                const ax = srcPos[p * 3];
+                const ay = srcPos[p * 3 + 1];
+                const az = srcPos[p * 3 + 2];
+                const ex = srcPos[q * 3] - ax;
+                const ey = srcPos[q * 3 + 1] - ay;
+                const ez = srcPos[q * 3 + 2] - az;
+                const len2 = ex * ex + ey * ey + ez * ez;
+                let t =
+                    len2 > 0
+                        ? ((cutterPos.x - ax) * ex +
+                              (cutterPos.y - ay) * ey +
+                              (cutterPos.z - az) * ez) /
+                          len2
+                        : 0;
+                if (t < 0) t = 0;
+                else if (t > 1) t = 1;
+                const dx = ax + t * ex - cutterPos.x;
+                const dy = ay + t * ey - cutterPos.y;
+                const dz = az + t * ez - cutterPos.z;
+                return dx * dx + dy * dy + dz * dz;
+            };
+            let bestS = greyEnd;
+            let bestD = Infinity;
+            let p = greyEnd;
+            let guard = 0;
+            while (p < vReceived - 1 && guard++ < 100000) {
+                const q = nextDistinct(p); // real segment [p, q]
+                if (q >= vReceived) break;
+                const d = segDistSq(p, q);
+                if (d < bestD) {
+                    bestD = d;
+                    bestS = p;
+                }
+                p = q;
             }
-
-            // if we have reached the end, fill in the rest of the yellow
-            // we know its at the end if the amount to update overflows the buffer, or if the frameIndex is at the last frame
-            let updateCount = 0;
-            if (
-                this.plannedState !== STATES.DONE &&
-                (isOverflowing || this.frameIndex === this.frames.length - 1)
-            ) {
-                const newBufferColorArray = Array.from(
-                    {
-                        length:
-                            this.frames[this.frames.length - 1] -
-                            this.frames[v1FrameIndex + 1],
-                    },
-                    () => yellowArray,
-                ).flat();
-                colorAttr.set(
-                    [...runColorArray, ...newBufferColorArray],
-                    offsetIndex,
-                );
-                updateCount = runColorArray.length + newBufferColorArray.length;
-                this.plannedState = STATES.DONE;
-                // beginning lines, for regular start or start from line
-            } else if (this.plannedState === STATES.START) {
-                // this.frameIndex starts at 0, so the yellow line we just made includes every line before the current starting line.
-                // redo yellow with the starting index being the end of the grey
-                const plannedColor = new THREE.Color(
-                    this.theme.get(PLANNED_PART),
-                );
-
-                const defaultColorArray = [...plannedColor.toArray(), 1]; // yellow
-
-                const colorArray = Array.from(
-                    { length: this.frameIndex - v2FrameIndex + 1 },
-                    () => defaultColorArray,
-                ).flat();
-
-                colorAttr.set([...runColorArray, ...colorArray], offsetIndex);
-                updateCount = runColorArray.length + colorArray.length;
-                this.plannedState = STATES.RUNNING;
-                // if the end has alrdy been reached, only update grey
-            } else if (this.plannedState === STATES.DONE) {
-                colorAttr.set(runColorArray, offsetIndex);
-                updateCount = runColorArray.length;
-                // end not reached, update everything
+            // Only track when the toolhead is near the path; off-path (jogging)
+            // hold the last progress. bestD is a squared distance.
+            if (bestD <= PROGRESS_NEAR_MM * PROGRESS_NEAR_MM) {
+                vCutter = bestS;
             } else {
-                // set grey lines, planned lines that were previously calculated, and the buffer in between
-                colorAttr.set(
-                    [
-                        ...runColorArray,
-                        ...bufferColorArray,
-                        ...this.plannedColorArray,
-                    ],
-                    offsetIndex,
-                );
-                updateCount =
-                    runColorArray.length +
-                    bufferColorArray.length +
-                    this.plannedColorArray.length;
+                vCutter = greyEnd;
+                cutterNear = false;
             }
+        } else if (!cutterPos) {
+            // No machine position — fall back to the estimate boundary so grey
+            // ends at gSender's progress line and orange leads from there.
+            vCutter = Math.min(vEstRaw, vReceived);
+        }
+        vCutter = Math.max(greyEnd, Math.min(vCutter, vReceived));
+
+        const opacity = this.isLaser ? 1 : 0.3;
+        const grey = new THREE.Color(SECONDARY_COLOR);
+        // In laser mode the planned color is red, so orange lead blends in — use
+        // cyan for strong contrast against red.
+        const PROGRESS_LEAD_COLOR_LASER = '#00ffff'; // cyan
+        const progressLead = this.isLaser
+            ? new THREE.Color(PROGRESS_LEAD_COLOR_LASER)
+            : new THREE.Color(PROGRESS_LEAD_COLOR);
+        const yellow = this._plannedColor();
+        const src = this.originalColors;
+
+        // vFwd = next vertex with a position DISTINCT from vCutter (skip the
+        // duplicate joints), so the overlay has a real segment to split on and
+        // orange starts right at the marker. aheadColor is orange when there's
+        // any buffered lead, else yellow.
+        let vFwd = vCutter + 1;
+        while (
+            vFwd < vReceived &&
+            srcPos[vFwd * 3] === srcPos[vCutter * 3] &&
+            srcPos[vFwd * 3 + 1] === srcPos[vCutter * 3 + 1] &&
+            srcPos[vFwd * 3 + 2] === srcPos[vCutter * 3 + 2]
+        ) {
+            vFwd++;
+        }
+        const aheadColor = vReceived > vCutter ? progressLead : yellow;
+        // Lead end: walk ~LEAD_MM of path travel ahead (arc length, not
+        // vertex count), capped at received. [vFwd,vLeadEnd) lead color, rest yellow.
+        const LEAD_MM = 20;
+        const cumLen = this._ensureCumLen();
+        let vLeadEnd = vFwd;
+        if (cumLen) {
+            const baseLen = cumLen[Math.min(vCutter, totalV - 1)];
+            while (
+                vLeadEnd < vReceived &&
+                cumLen[Math.min(vLeadEnd, totalV - 1)] - baseLen < LEAD_MM
+            ) {
+                vLeadEnd++;
+            }
+        } else {
+            vLeadEnd = vReceived;
+        }
+        vLeadEnd = Math.max(vFwd, Math.min(vLeadEnd, vReceived));
+
+        const paint = (vStart, vEnd, c, a) => {
+            for (let v = Math.max(0, vStart); v < vEnd; v++) {
+                const off = v * 4;
+                arr[off] = c.r;
+                arr[off + 1] = c.g;
+                arr[off + 2] = c.b;
+                arr[off + 3] = a;
+            }
+        };
+        const restore = (vStart, vEnd) => {
+            if (!src) return;
+            for (let v = Math.max(0, vStart); v < vEnd; v++) {
+                const off = v * 4;
+                arr[off] = src[off];
+                arr[off + 1] = src[off + 1];
+                arr[off + 2] = src[off + 2];
+                arr[off + 3] = src[off + 3];
+            }
+        };
+
+        const hideProc = this.hideProcessedLines;
+        const prevAheadEnd = this._progAheadEndV || 0;
+        if (hideProc) {
+            // "Hide processed lines": only the EXECUTED span [0, vFwd) goes
+            // invisible (alpha 0 — the line material honors per-vertex alpha,
+            // so this hides reliably in both spindle and laser modes). The
+            // run-progress bands ahead of the toolhead stay visible: orange
+            // lead, then yellow for the rest of the buffered range. Painted in
+            // full every frame so the executed path can never show through;
+            // setHideProcessedLines() restores originals when hiding turns off.
+            paint(0, vFwd, grey, 0);
+            paint(vFwd, vLeadEnd, progressLead, 1);
+            paint(vLeadEnd, vReceived, yellow, 1);
+            if (prevAheadEnd > vReceived) {
+                restore(vReceived, prevAheadEnd);
+            }
+            // Crisp boundary under the marker: executed half invisible
+            // (alpha 0), ahead half still drawn so orange starts exactly at
+            // the toolhead.
+            if (cutterNear) {
+                this._updateProgressSplit(
+                    vCutter,
+                    vFwd,
+                    cutterPos,
+                    grey,
+                    0,
+                    aheadColor,
+                );
+            }
+        } else {
+            // GREY [greyEnd, vFwd): extend the executed range (incremental, so cost
+            // is bounded). The tool's segment is painted grey here and redrawn
+            // crisply by the overlay below.
+            paint(greyEnd, vFwd, grey, opacity);
+            // Orange/Purple lead [vFwd, vLeadEnd) ahead of the cutter (purple in laser
+            // mode for contrast against red toolpath). Beyond received the path keeps
+            // its planned color.
+            paint(vFwd, vLeadEnd, progressLead, 1);
+            paint(vLeadEnd, vReceived, yellow, 1);
+            // If the acked edge moved backward since last frame (rare — rewind is
+            // normally caught in setFrameIndex), restore the abandoned tail to its
+            // original motion colors.
+            if (prevAheadEnd > vReceived) {
+                restore(vReceived, prevAheadEnd);
+            }
+            // Redraw the crisp split under the marker — only when near the path;
+            // off-path (jogging) leave the overlay frozen at the last split.
+            if (cutterNear) {
+                this._updateProgressSplit(
+                    vCutter,
+                    vFwd,
+                    cutterPos,
+                    grey,
+                    opacity,
+                    aheadColor,
+                );
+            }
+        }
+
+        this._progGreyEndV = vCutter;
+        this._progAheadEndV = vReceived;
+        this.oldFrameIndex = Math.max(0, currentLineRunning - 1);
+
+        const updStart = hideProc ? 0 : Math.max(0, greyEnd);
+        const updEnd = Math.max(vReceived, prevAheadEnd);
+        if (updEnd > updStart) {
             colorAttr.addUpdateRange({
-                start: offsetIndex,
-                count: updateCount,
+                start: updStart * 4,
+                count: (updEnd - updStart) * 4,
             });
             colorAttr.needsUpdate = true;
         }
-
-        // set last frame index
-        this.oldFrameIndex = v2FrameIndex;
     }
 
     /**
-     * Hide processed vertices using drawRange
+     * Hide processed vertices [0, vertexIndex) by setting their per-vertex alpha to 0.
+     * Alpha is honored by the line material, so this reliably stops them rendering in
+     * BOTH spindle and laser modes (drawRange alone does not visually hide a THREE.Line).
+     * Runs every frame from setFrameIndex, so it's independent of run-progress / sender
+     * status. setHideProcessedLines() restores the original colors when hiding turns off.
      * @param {number} vertexIndex - The index up to which vertices should be hidden
      */
     _hideProcessedVertices(vertexIndex) {
@@ -396,8 +699,22 @@ class GCodeVisualizer {
         const totalVertices = this.vertices.count;
         const remainingCount = totalVertices - vertexIndex;
 
+        // Keep the drawRange too (cheap; helps where it does apply).
         if (remainingCount > 0) {
             this.geometry.setDrawRange(vertexIndex, remainingCount);
+        }
+
+        // Make the processed span invisible via alpha — the reliable, mode-independent hide.
+        this._ensureOriginalColorsSnapshot();
+        const colorAttr = workpiece.geometry.getAttribute('color');
+        if (colorAttr && colorAttr.array && vertexIndex > 0) {
+            const arr = colorAttr.array;
+            const end = Math.min(vertexIndex, totalVertices);
+            for (let v = 0; v < end; v++) {
+                arr[v * 4 + 3] = 0;
+            }
+            colorAttr.addUpdateRange({ start: 0, count: end * 4 });
+            colorAttr.needsUpdate = true;
         }
     }
 
@@ -406,12 +723,26 @@ class GCodeVisualizer {
      * @param {boolean} hide - Whether to hide processed lines
      */
     setHideProcessedLines(hide) {
+        const wasHiding = this.hideProcessedLines;
         this.hideProcessedLines = hide;
 
         if (!hide) {
             const workpiece = this.group.children[0];
             if (workpiece && this.geometry) {
                 this.geometry.setDrawRange(0, Infinity);
+            }
+            // Coming out of hiding (e.g. on job end): the executed span was painted with
+            // alpha 0 to hide it, so restore the toolpath's original colors — otherwise it
+            // would stay invisible. Also rewind the run-progress edges so a re-run repaints
+            // from the start.
+            if (wasHiding && this.originalColors && workpiece) {
+                const colorAttr = workpiece.geometry.getAttribute('color');
+                if (colorAttr && colorAttr.array) {
+                    colorAttr.array.set(this.originalColors);
+                    colorAttr.needsUpdate = true;
+                }
+                this._progGreyEndV = 0;
+                this._progAheadEndV = 0;
             }
         }
     }
@@ -426,6 +757,15 @@ class GCodeVisualizer {
     }
 
     unload() {
+        if (this._progSplitLine) {
+            this._progSplitMaterial?.dispose();
+            this._progSplitGeometry?.dispose();
+            this._progSplitLine = null;
+            this._progSplitMaterial = null;
+            this._progSplitGeometry = null;
+            this._progSplitPositions = null;
+            this._progSplitColors = null;
+        }
         this.geometry.dispose();
         this.group.clear();
 
@@ -441,6 +781,9 @@ class GCodeVisualizer {
         this.plannedColorArray = [];
         this.plannedV1 = null;
         this.plannedState = STATES.START;
+        this._progGreyEndV = 0;
+        this._progAheadEndV = 0;
+        this._cumLen = null;
         // --rotary
         this.frameDifferences = Array(16).fill(null);
         this.oldV1s = Array(16).fill(null);

--- a/src/app/src/features/Visualizer/Visualizer.jsx
+++ b/src/app/src/features/Visualizer/Visualizer.jsx
@@ -267,6 +267,19 @@ class Visualizer extends Component {
         }
     };
 
+    // The point the run-progress coloring anchors its grey/orange split at:
+    // the reported machine (work) position, coerced to numbers. The on-screen
+    // cutter is drawn at the same position, so the split tracks the marker.
+    // Returns null when no position is available.
+    _getDisplayedCutterPos(workPos) {
+        if (!workPos) return null;
+        return {
+            x: Number(workPos.x) || 0,
+            y: Number(workPos.y) || 0,
+            z: Number(workPos.z) || 0,
+        };
+    }
+
     constructor(props) {
         super(props);
 
@@ -408,12 +421,28 @@ class Visualizer extends Component {
 
         // Update visualizer's frame index
         if (this.visualizer) {
+            // Keep the "hide processed lines" flag in sync with the live setting on every
+            // update, so processed lines are reliably hidden whenever the option is on —
+            // independent of pubsub / job-state timing.
+            const hideProcessedLines = store.get(
+                'widgets.visualizer.hideProcessedLines',
+                false,
+            );
+            if (this.visualizer.hideProcessedLines !== hideProcessedLines) {
+                this.visualizer.setHideProcessedLines(hideProcessedLines);
+            }
             const frameIndex = this.props.receivedLines;
             this.visualizer.setFrameIndex(frameIndex);
-            // grey lines
+            // run-progress coloring (grey behind the toolhead, orange lead,
+            // yellow buffer). Anchored at the reported machine position so the
+            // grey/orange split sits under the on-screen cutter.
             if (this.props.senderStatus) {
+                const cutterPos = this._getDisplayedCutterPos(
+                    this.props.workPosition,
+                );
                 this.visualizer.greyOutLines(
                     this.props.senderStatus.currentLineRunning,
+                    cutterPos,
                 );
             }
         }
@@ -1072,9 +1101,14 @@ class Visualizer extends Component {
                 this.updateScene({ forceUpdate: true });
             }),
             pubsub.subscribe('job:end', () => {
-                // Reset hidden lines when job finishes
+                // Respect the "hide processed lines" setting when the job finishes: keep
+                // processed lines hidden if it's on, otherwise show them again.
                 if (this.visualizer) {
-                    this.visualizer.setHideProcessedLines(false);
+                    const hideProcessedLines = store.get(
+                        'widgets.visualizer.hideProcessedLines',
+                        false,
+                    );
+                    this.visualizer.setHideProcessedLines(hideProcessedLines);
                     this.updateScene({ forceUpdate: true });
                 }
             }),

--- a/src/app/src/features/Visualizer/tests/GCodeVisualizer.runprogress.test.js
+++ b/src/app/src/features/Visualizer/tests/GCodeVisualizer.runprogress.test.js
@@ -1,0 +1,229 @@
+/*
+ * Unit tests for the run-progress toolpath coloring added in
+ * "Add run-progress toolpath coloring to the 3D visualizer".
+ *
+ * These exercise the pure-geometry logic of GCodeVisualizer.greyOutLines():
+ *   - the three-zone painter (grey executed / orange lead / yellow buffered),
+ *   - the nearest-SEGMENT scan that locates the grey/orange split,
+ *   - the monotonic grey edge (never retreats within a run),
+ *   - the off-path freeze (jogging away from the path holds the last split),
+ * plus the cumulative arc-length table (_ensureCumLen) used to size the lead.
+ *
+ * three is real (jest does not mock it); only the redux store and the rotary
+ * detector are stubbed so the module can be imported without the app's wider
+ * dependency tree. Colors are compared against THREE.Color(<same input>) so the
+ * assertions are independent of three's color-management/sRGB conversion.
+ */
+
+import * as THREE from 'three';
+import { SECONDARY_COLOR } from '../constants';
+
+// Keep the import light + deterministic: no real redux store, always non-rotary.
+jest.mock('app/store/redux', () => ({ store: { getState: () => ({}) } }));
+jest.mock('../../../lib/rotary', () => ({ checkIfRotaryFile: () => false }));
+
+import GCodeVisualizer from '../GCodeVisualizer';
+
+// Colors the painter uses (mirrors the constants in GCodeVisualizer.js).
+const GREY = SECONDARY_COLOR; // '#6F7376'
+const ORANGE = '#ff8000'; // PROGRESS_LEAD_COLOR
+const YELLOW = '#dff204'; // theme PLANNED_PART value supplied below
+
+// A theme stub whose .get() returns the colors greyOutLines/render read.
+const theme = {
+    get: (key) =>
+        ({
+            'Cutting Coordinates Lines': '#ffffff',
+            'Planned Cutting Lines': YELLOW,
+        })[key],
+};
+
+// Build a straight polyline along +X at 1mm spacing (no duplicated joints), so
+// vertex i sits at x=i mm and cumulative arc length == vertex index.
+function makeStraightPath(n) {
+    const vertices = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+        vertices[i * 3] = i; // x = i
+    }
+    const frames = Array.from({ length: n }, (_, i) => i); // line i -> vertex i
+    // Initialise every vertex to a distinct SENTINEL color (pure blue), so a
+    // vertex left untouched (beyond the buffered range) is detectable and never
+    // collides with grey/orange/yellow.
+    const colors = new Float32Array(n * 4);
+    for (let i = 0; i < n; i++) {
+        colors[i * 4] = 0;
+        colors[i * 4 + 1] = 0;
+        colors[i * 4 + 2] = 1;
+        colors[i * 4 + 3] = 1;
+    }
+    return { vertices, frames, colors };
+}
+
+function renderStraight(gcv, n) {
+    const { vertices, frames, colors } = makeStraightPath(n);
+    gcv.render({ vertices, frames, isLaser: false }, colors);
+    return gcv.group.children[0].geometry.getAttribute('color').array;
+}
+
+// Assert vertex v's RGBA matches a THREE.Color built from `input` (+ alpha).
+function expectColor(arr, v, input, alpha) {
+    const c = new THREE.Color(input);
+    const o = v * 4;
+    expect(arr[o]).toBeCloseTo(c.r, 4);
+    expect(arr[o + 1]).toBeCloseTo(c.g, 4);
+    expect(arr[o + 2]).toBeCloseTo(c.b, 4);
+    if (alpha !== undefined) {
+        expect(arr[o + 3]).toBeCloseTo(alpha, 4);
+    }
+}
+
+function expectSentinel(arr, v) {
+    const o = v * 4;
+    expect(arr[o]).toBeCloseTo(0, 4);
+    expect(arr[o + 1]).toBeCloseTo(0, 4);
+    expect(arr[o + 2]).toBeCloseTo(1, 4);
+}
+
+describe('GCodeVisualizer run-progress coloring', () => {
+    describe('greyOutLines three-zone painter', () => {
+        it('paints grey behind the toolhead, an orange lead, then yellow up to the buffered edge', () => {
+            const gcv = new GCodeVisualizer(theme);
+            const arr = renderStraight(gcv, 100);
+            // Controller has acked up to vertex 60 (the yellow edge).
+            gcv.frameIndex = 60;
+            // Toolhead sitting on the path at x=30.
+            gcv.greyOutLines(1, { x: 30, y: 0, z: 0 });
+
+            // Grey executed zone [0, ~30): low alpha (0.3 in spindle mode).
+            expectColor(arr, 10, GREY, 0.3);
+            expectColor(arr, 25, GREY, 0.3);
+            // Orange lead zone (~20mm of path travel ahead of the tool).
+            expectColor(arr, 35, ORANGE, 1);
+            expectColor(arr, 45, ORANGE, 1);
+            // Yellow buffered zone up to the received edge at 60.
+            expectColor(arr, 52, YELLOW, 1);
+            expectColor(arr, 58, YELLOW, 1);
+            // Beyond the buffered edge the path keeps its planned color (untouched).
+            expectSentinel(arr, 70);
+            expectSentinel(arr, 90);
+
+            // The orange lead is ~20mm long (LEAD_MM), not the whole buffer.
+            expect(gcv._progGreyEndV).toBe(29);
+            expect(gcv._progAheadEndV).toBe(60);
+        });
+
+        it('uses the wall-clock estimate as the split when no machine position is given', () => {
+            const gcv = new GCodeVisualizer(theme);
+            const arr = renderStraight(gcv, 100);
+            gcv.frameIndex = 60;
+            // currentLineRunning = 21 -> estimate boundary at vertex 20.
+            gcv.greyOutLines(21, null);
+
+            // Grey ends at the estimate boundary; orange leads from there.
+            expectColor(arr, 10, GREY, 0.3);
+            expect(gcv._progGreyEndV).toBe(20);
+        });
+    });
+
+    describe('nearest-segment split is robust on back-and-forth paths', () => {
+        it('lands the split on the toolhead\'s own segment, not a spatially-near parallel pass', () => {
+            // Two stacked raster passes 0.5mm apart (well under PROGRESS_NEAR_MM=2):
+            //   pass 1: x 0..10 at y=0       (vertices 0..10)
+            //   pass 2: x 10..0 at y=0.5     (vertices 11..21)
+            // The tool is on pass 2; a nearest-VERTEX scan could wrongly pick the
+            // overlapping pass-1 vertex, but the nearest-SEGMENT scan keeps it on
+            // pass 2.
+            const n = 22;
+            const vertices = new Float32Array(n * 3);
+            for (let i = 0; i <= 10; i++) {
+                vertices[i * 3] = i; // pass 1: x=i, y=0
+            }
+            for (let k = 0; k <= 10; k++) {
+                const i = 11 + k;
+                vertices[i * 3] = 10 - k; // pass 2: x=10..0
+                vertices[i * 3 + 1] = 0.5; // y=0.5
+            }
+            const frames = Array.from({ length: n }, (_, i) => i);
+            const colors = new Float32Array(n * 4);
+            for (let i = 0; i < n; i++) colors[i * 4 + 3] = 1;
+
+            const gcv = new GCodeVisualizer(theme);
+            gcv.render({ vertices, frames, isLaser: false }, colors);
+            gcv.frameIndex = 21; // whole file buffered
+
+            // Tool partway along pass 2 (x≈4, y=0.5).
+            gcv.greyOutLines(1, { x: 4, y: 0.5, z: 0 });
+
+            // Split must be on pass 2 (vertex index >= 11), i.e. pass 1 is fully
+            // executed (grey) and we are mid pass-2.
+            expect(gcv._progGreyEndV).toBeGreaterThanOrEqual(11);
+        });
+    });
+
+    describe('monotonic grey edge', () => {
+        it('never retreats when the toolhead jitters slightly backward', () => {
+            const gcv = new GCodeVisualizer(theme);
+            renderStraight(gcv, 100);
+            gcv.frameIndex = 60;
+
+            gcv.greyOutLines(1, { x: 30, y: 0, z: 0 });
+            const afterA = gcv._progGreyEndV;
+
+            gcv.greyOutLines(1, { x: 35, y: 0, z: 0 });
+            const afterB = gcv._progGreyEndV;
+            expect(afterB).toBeGreaterThan(afterA); // advanced forward
+
+            // Tool jogs back 2mm but stays near the path.
+            gcv.greyOutLines(1, { x: 33, y: 0, z: 0 });
+            const afterC = gcv._progGreyEndV;
+            expect(afterC).toBe(afterB); // edge held, did NOT retreat
+        });
+    });
+
+    describe('off-path freeze', () => {
+        it('holds the split at the last cut point while the tool jogs off the path', () => {
+            const gcv = new GCodeVisualizer(theme);
+            renderStraight(gcv, 100);
+            gcv.frameIndex = 60;
+
+            gcv.greyOutLines(1, { x: 30, y: 0, z: 0 });
+            const onPath = gcv._progGreyEndV;
+            expect(onPath).toBe(29);
+
+            // Jog 50mm off the path (far past PROGRESS_NEAR_MM): split must freeze.
+            gcv.greyOutLines(1, { x: 70, y: 50, z: 0 });
+            expect(gcv._progGreyEndV).toBe(onPath);
+        });
+    });
+
+    describe('_ensureCumLen arc-length table', () => {
+        it('computes cumulative path length per vertex', () => {
+            const gcv = new GCodeVisualizer(theme);
+            // 3-4-5 right angle: (0,0,0) -> (3,0,0) -> (3,4,0)
+            const arr = new Float32Array([0, 0, 0, 3, 0, 0, 3, 4, 0]);
+            gcv.vertices = new THREE.BufferAttribute(arr, 3);
+
+            const cum = gcv._ensureCumLen();
+            expect(cum[0]).toBeCloseTo(0, 6);
+            expect(cum[1]).toBeCloseTo(3, 6); // +3
+            expect(cum[2]).toBeCloseTo(7, 6); // +4
+        });
+
+        it('caches the table and returns the same instance until geometry changes', () => {
+            const gcv = new GCodeVisualizer(theme);
+            const arr = new Float32Array([0, 0, 0, 1, 0, 0]);
+            gcv.vertices = new THREE.BufferAttribute(arr, 3);
+
+            const first = gcv._ensureCumLen();
+            const second = gcv._ensureCumLen();
+            expect(second).toBe(first); // cached
+
+            // render() loads new geometry and must drop the cache.
+            renderStraight(gcv, 5);
+            expect(gcv._cumLen).toBeNull();
+            const rebuilt = gcv._ensureCumLen();
+            expect(rebuilt).not.toBe(first);
+            expect(rebuilt[4]).toBeCloseTo(4, 6); // 5 vertices, 1mm spacing
+        });
+    });
+});


### PR DESCRIPTION
While a job runs, color the toolpath by execution state instead of a single grey/yellow split: GREY behind the real toolhead (executed), ORANGE for a short look-ahead lead hugging the tool (buffered, about to be cut), and YELLOW for the rest of the controller's buffered range. Beyond the buffer the path keeps its planned color, so a long file is never flooded.

GCodeVisualizer.js:
- greyOutLines(currentLineRunning, cutterPos) rewritten as a three-zone painter. The grey/orange split is found by a nearest-SEGMENT scan over the in-flight range using clamped point-to-segment distance to the machine position — robust on back-and-forth raster paths (the tool lies on its own segment, so it wins over a spatially-near parallel pass). The floor is monotonic so the executed edge never retreats; duplicated joint vertices are skipped.
- Crisp boundary overlay: a short depth-test-off line with a temp vertex at the machine position, so the grey/lead split is sharp under the marker rather than a gradient across the active segment.
- Orange lead sized by ~20mm of path travel via a cached cumulative arc-length table.
- The split only tracks while the toolhead is near the path; jogging off the path freezes it at the last cut point. Within a segment the split is monotonic and never slides backward (tool jitter / a small jog-back keeps the progress already made).
- setFrameIndex/render/unload reset the progress trackers and arc-length cache; unload disposes the overlay.

Visualizer.jsx:
- Pass the reported work position into greyOutLines so the split anchors at the on-screen cutter.