### PR TITLE
Add camera "follow tool" mode to the 3D visualizer

### DIFF
--- a/src/app/src/features/Visualizer/PrimaryVisualizer.tsx
+++ b/src/app/src/features/Visualizer/PrimaryVisualizer.tsx
@@ -11,7 +11,7 @@ import Rendering from './Rendering';
 import SoftLimitsWarningArea from './SoftLimitsWarningArea';
 import CameraDisplay from './CameraDisplay/CameraDisplay';
 import { WorkspaceSelector } from 'app/features/WorkspaceSelector/index.tsx';
-import { FaFeatherAlt } from 'react-icons/fa';
+import { FaFeatherAlt, FaCrosshairs } from 'react-icons/fa';
 import cx from 'classnames';
 import { Tooltip } from 'app/components/Tooltip';
 import GcodeEditor from './GcodeEditor';
@@ -101,6 +101,7 @@ const PrimaryVisualizer = ({
                         <VisualizerWrapper
                             show={showVisualizer}
                             cameraPosition={cameraPosition}
+                            followTool={state.followTool}
                             ref={visualizerRef}
                             state={state}
                             actions={actions}
@@ -128,6 +129,19 @@ const PrimaryVisualizer = ({
                                     })}
                                     onClick={() =>
                                         actions.handleLiteModeToggle()
+                                    }
+                                />
+                            </button>
+                        </Tooltip>
+                        <Tooltip content="Follow tool with camera">
+                            <button className="bg-gray-600 bg-opacity-50 rounded-full p-3.5">
+                                <FaCrosshairs
+                                    className={cx('cursor-pointer', {
+                                        'text-gray-400': !state.followTool,
+                                        'text-green-400': state.followTool,
+                                    })}
+                                    onClick={() =>
+                                        actions.camera.toggleFollowTool()
                                     }
                                 />
                             </button>

--- a/src/app/src/features/Visualizer/Visualizer.jsx
+++ b/src/app/src/features/Visualizer/Visualizer.jsx
@@ -22,6 +22,12 @@
  */
 
 import { store as reduxStore } from 'app/store/redux';
+import {
+    isFollowEnabled as _isFollowEnabled,
+    getToolScenePosition as _getToolScenePosition,
+    startCameraFollow as _startCameraFollow,
+    stopCameraFollow as _stopCameraFollow,
+} from './cameraFollowHelpers';
 import gsap from 'gsap';
 import { connect } from 'react-redux';
 import _get from 'lodash/get';
@@ -120,6 +126,7 @@ class Visualizer extends Component {
             'Right',
             'Free',
         ]),
+        followTool: PropTypes.bool,
         state: PropTypes.object,
         isSecondary: PropTypes.bool,
     };
@@ -129,6 +136,9 @@ class Visualizer extends Component {
     pubsubTokens = [];
 
     outlineRunning = false;
+
+    // requestAnimationFrame handle for the smooth camera-follow loop (null = idle)
+    cameraFollowRAF = null;
 
     isAgitated = false;
 
@@ -603,6 +613,12 @@ class Visualizer extends Component {
                     prevProps.workPosition,
                     this.props.workPosition,
                 );
+                // Keep the camera following the tool while "follow tool" is on.
+                // Driven here (per position update) rather than via the gsap
+                // onUpdate inside updateCuttingToolPosition, which early-returns
+                // when the tool STL model hasn't loaded. startCameraFollow eases
+                // the camera toward the new position and self-gates when off.
+                this.startCameraFollow();
             }
         }
 
@@ -643,6 +659,17 @@ class Visualizer extends Component {
             if (this.props.cameraPosition === 'Right') {
                 this.toRightSideView();
             }
+        }
+
+        // Start/stop the smooth follow loop when "follow tool" is toggled.
+        const followNow =
+            this.props.followTool || this.props.state?.followTool;
+        const followPrev =
+            prevProps.followTool || prevProps.state?.followTool;
+        if (followNow && !followPrev) {
+            this.startCameraFollow();
+        } else if (!followNow && followPrev) {
+            this.stopCameraFollow();
         }
 
         if (activeState === GRBL_ACTIVE_STATE_CHECK && this.waitingForCheck) {
@@ -2088,6 +2115,10 @@ class Visualizer extends Component {
         if (this.controls) {
             this.controls.dispose();
         }
+        if (this.disposeFollowDragDetection) {
+            this.disposeFollowDragDetection();
+            this.disposeFollowDragDetection = null;
+        }
 
         // Update the scene
         this.updateScene();
@@ -2417,6 +2448,57 @@ class Visualizer extends Component {
             this.updateScene();
         });
 
+        // Turn off "follow tool" when the user actually DRAGS the view (pointer
+        // down + movement past a small threshold) — not on a plain click, and
+        // not on wheel-zoom (so the user can still zoom while following). The
+        // controls' own 'start' event fires for mousedown, wheel and touch
+        // alike and carries no movement info, so detect the drag here instead.
+        const DRAG_THRESHOLD_SQ = 16; // (4px)^2 before a press counts as a drag
+        let dragOrigin = null;
+        const onGrabStart = (event) => {
+            const p = event.touches ? event.touches[0] : event;
+            dragOrigin = p ? { x: p.clientX, y: p.clientY } : null;
+        };
+        const onGrabMove = (event) => {
+            if (!dragOrigin) {
+                return;
+            }
+            const p = event.touches ? event.touches[0] : event;
+            if (!p) {
+                return;
+            }
+            const dx = p.clientX - dragOrigin.x;
+            const dy = p.clientY - dragOrigin.y;
+            if (dx * dx + dy * dy >= DRAG_THRESHOLD_SQ) {
+                dragOrigin = null; // fire once per press
+                if (
+                    this.isFollowEnabled() &&
+                    this.props.actions?.camera?.toggleFollowTool
+                ) {
+                    this.props.actions.camera.toggleFollowTool();
+                }
+            }
+        };
+        const onGrabEnd = () => {
+            dragOrigin = null;
+        };
+        domElement.addEventListener('mousedown', onGrabStart);
+        domElement.addEventListener('mousemove', onGrabMove);
+        domElement.addEventListener('mouseup', onGrabEnd);
+        domElement.addEventListener('touchstart', onGrabStart, {
+            passive: true,
+        });
+        domElement.addEventListener('touchmove', onGrabMove, { passive: true });
+        domElement.addEventListener('touchend', onGrabEnd);
+        this.disposeFollowDragDetection = () => {
+            domElement.removeEventListener('mousedown', onGrabStart);
+            domElement.removeEventListener('mousemove', onGrabMove);
+            domElement.removeEventListener('mouseup', onGrabEnd);
+            domElement.removeEventListener('touchstart', onGrabStart);
+            domElement.removeEventListener('touchmove', onGrabMove);
+            domElement.removeEventListener('touchend', onGrabEnd);
+        };
+
         return controls;
     }
 
@@ -2622,6 +2704,22 @@ class Visualizer extends Component {
         this.controls.target.y = y;
         this.controls.target.z = z;
         this.controls.update();
+    }
+
+    isFollowEnabled() {
+        return _isFollowEnabled(this);
+    }
+
+    getToolScenePosition() {
+        return _getToolScenePosition(this);
+    }
+
+    startCameraFollow() {
+        _startCameraFollow(this);
+    }
+
+    stopCameraFollow() {
+        _stopCameraFollow(this);
     }
 
     // Make the controls look at the center position

--- a/src/app/src/features/Visualizer/VisualizerWrapper.jsx
+++ b/src/app/src/features/Visualizer/VisualizerWrapper.jsx
@@ -142,6 +142,7 @@ class VisualizerWrapper extends Component {
             state,
             show,
             cameraPosition,
+            followTool,
             actions,
             containerID,
             isSecondary,
@@ -160,6 +161,7 @@ class VisualizerWrapper extends Component {
                     <Visualizer
                         show={show && show3D}
                         cameraPosition={cameraPosition}
+                        followTool={followTool}
                         ref={(visualizerRef) => {
                             this.threeVisualizer = visualizerRef;
                             this.visualizer = visualizerRef;

--- a/src/app/src/features/Visualizer/cameraFollowHelpers.js
+++ b/src/app/src/features/Visualizer/cameraFollowHelpers.js
@@ -1,0 +1,102 @@
+/**
+ * Pure helpers for the "follow tool" camera behaviour.
+ *
+ * All functions accept a `ctx` object instead of using `this` so they can be
+ * tested without mounting a full Visualizer instance. The Visualizer class
+ * methods delegate here, passing `this` as the context.
+ *
+ * ctx shape (subset of Visualizer instance):
+ *   props          – React props ({ followTool?, state? })
+ *   cameraFollowRAF – number|null   rAF handle, mutated by start/stop
+ *   controls       – Three OrbitControls  (target: Vector3, update())
+ *   camera         – Three Camera         (position: Vector3)
+ *   cuttingTool    – Three Object3D|null  (position: Vector3)
+ *   pivotPoint     – { get(): { x, y, z } }
+ *   workPosition   – { x?, y?, z? }|null
+ *   updateScene    – (opts?) => void
+ */
+
+const SMOOTHING = 0.08; // fraction of remaining distance eased per frame
+const SETTLE_SQ = 1e-4; // stop easing once within ~0.01 units
+
+/**
+ * Returns true when the "follow tool" toggle is on, checking both the direct
+ * prop and the nested state object (the two paths used in Visualizer).
+ */
+export function isFollowEnabled(ctx) {
+    return !!(ctx.props.followTool || ctx.props.state?.followTool);
+}
+
+/**
+ * Returns the cutting tool's position in scene space.
+ * Prefers `cuttingTool.position` (when the STL model is loaded); falls back to
+ * `workPosition - pivotPoint` so following works before the model has loaded.
+ */
+export function getToolScenePosition(ctx) {
+    if (ctx.cuttingTool) {
+        const p = ctx.cuttingTool.position;
+        return { x: p.x, y: p.y, z: p.z };
+    }
+    const pivot = ctx.pivotPoint.get();
+    const wp = ctx.workPosition || {};
+    return {
+        x: (wp.x || 0) - pivot.x,
+        y: (wp.y || 0) - pivot.y,
+        z: (wp.z || 0) - pivot.z,
+    };
+}
+
+/**
+ * Starts a requestAnimationFrame loop that smoothly pans the orbit target
+ * toward the cutting tool. No-ops if follow is disabled or already running.
+ * Mutates ctx.cameraFollowRAF.
+ */
+export function startCameraFollow(ctx) {
+    if (ctx.cameraFollowRAF !== null || !isFollowEnabled(ctx)) {
+        return;
+    }
+
+    const tick = () => {
+        if (!isFollowEnabled(ctx) || !ctx.controls || !ctx.camera) {
+            ctx.cameraFollowRAF = null;
+            return;
+        }
+
+        const tool = getToolScenePosition(ctx);
+        const ex = tool.x - ctx.controls.target.x;
+        const ey = tool.y - ctx.controls.target.y;
+        const ez = tool.z - ctx.controls.target.z;
+
+        if (ex * ex + ey * ey + ez * ez < SETTLE_SQ) {
+            ctx.cameraFollowRAF = null;
+            return;
+        }
+
+        const mx = ex * SMOOTHING;
+        const my = ey * SMOOTHING;
+        const mz = ez * SMOOTHING;
+        ctx.camera.position.x += mx;
+        ctx.camera.position.y += my;
+        ctx.camera.position.z += mz;
+        ctx.controls.target.x += mx;
+        ctx.controls.target.y += my;
+        ctx.controls.target.z += mz;
+        ctx.controls.update();
+        ctx.updateScene({ forceUpdate: true });
+
+        ctx.cameraFollowRAF = requestAnimationFrame(tick);
+    };
+
+    ctx.cameraFollowRAF = requestAnimationFrame(tick);
+}
+
+/**
+ * Cancels the rAF loop started by startCameraFollow. Safe to call when idle.
+ * Mutates ctx.cameraFollowRAF.
+ */
+export function stopCameraFollow(ctx) {
+    if (ctx.cameraFollowRAF !== null) {
+        cancelAnimationFrame(ctx.cameraFollowRAF);
+        ctx.cameraFollowRAF = null;
+    }
+}

--- a/src/app/src/features/Visualizer/definitions.ts
+++ b/src/app/src/features/Visualizer/definitions.ts
@@ -141,6 +141,7 @@ export interface State {
         };
     };
     cameraMode: CAMERA_MODES_T;
+    followTool: boolean;
     cameraPosition: CAMERA_POSITIONS_T; // 'Top', '3D', 'Front', 'Left', 'Right'
     isAgitated: boolean; // Defaults to false
     currentTheme: Map<string, string>;
@@ -203,6 +204,7 @@ export interface Actions {
         toLeftSideView: () => void;
         toRightSideView: () => void;
         toFreeView: () => void;
+        toggleFollowTool: () => void;
     };
     handleLiteModeToggle: () => void;
     lineWarning: {

--- a/src/app/src/features/Visualizer/index.tsx
+++ b/src/app/src/features/Visualizer/index.tsx
@@ -575,6 +575,13 @@ class Visualizer extends Component {
             toFreeView: () => {
                 this.setState({ cameraPosition: 'Free' });
             },
+            toggleFollowTool: () => {
+                this.setState((state) => {
+                    const followTool = !state.followTool;
+                    this.config.set('followTool', followTool); // persist
+                    return { followTool };
+                });
+            },
         },
         handleLiteModeToggle: () => {
             const { liteMode, liteOption } = this.state;
@@ -898,6 +905,7 @@ class Visualizer extends Component {
                 },
             },
             cameraMode: this.config.get('cameraMode', CAMERA_MODE_PAN),
+            followTool: this.config.get('followTool', false),
             cameraPosition: '3D', // 'Top', '3D', 'Front', 'Left', 'Right'
             isAgitated: false, // Defaults to false
             currentTheme: getVisualizerTheme(),

--- a/src/app/src/features/Visualizer/tests/cameraFollow.test.js
+++ b/src/app/src/features/Visualizer/tests/cameraFollow.test.js
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for the camera "follow tool" feature added to Visualizer.jsx.
+ *
+ * Tests the three pure-logic helpers and the rAF lifecycle without mounting
+ * the full Visualizer (which requires Three.js, WebGL, and heavy mocks).
+ * We extract the methods onto a minimal stub that mirrors just the instance
+ * shape the methods read/write.
+ */
+
+// Pull in the methods under test directly from the source so we don't need
+// to instantiate the full React component.
+import {
+    isFollowEnabled,
+    getToolScenePosition,
+    startCameraFollow,
+    stopCameraFollow,
+} from '../cameraFollowHelpers';
+
+// ---------------------------------------------------------------------------
+// isFollowEnabled
+// ---------------------------------------------------------------------------
+describe('isFollowEnabled', () => {
+    it('returns false when props are empty', () => {
+        expect(isFollowEnabled({ props: {} })).toBe(false);
+    });
+
+    it('returns true when followTool prop is true', () => {
+        expect(isFollowEnabled({ props: { followTool: true } })).toBe(true);
+    });
+
+    it('returns false when followTool prop is false', () => {
+        expect(isFollowEnabled({ props: { followTool: false } })).toBe(false);
+    });
+
+    it('returns true when state.followTool is true', () => {
+        expect(
+            isFollowEnabled({ props: { state: { followTool: true } } }),
+        ).toBe(true);
+    });
+
+    it('returns false when state.followTool is false and prop is absent', () => {
+        expect(
+            isFollowEnabled({ props: { state: { followTool: false } } }),
+        ).toBe(false);
+    });
+
+    it('direct prop overrides state when both set', () => {
+        // Either truthy value switches follow on
+        expect(
+            isFollowEnabled({
+                props: { followTool: true, state: { followTool: false } },
+            }),
+        ).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getToolScenePosition
+// ---------------------------------------------------------------------------
+describe('getToolScenePosition', () => {
+    it('uses cuttingTool.position when the STL model is loaded', () => {
+        const ctx = {
+            cuttingTool: { position: { x: 10, y: 20, z: 30 } },
+            pivotPoint: { get: () => ({ x: 0, y: 0, z: 0 }) },
+            workPosition: { x: 5, y: 5, z: 5 },
+        };
+        expect(getToolScenePosition(ctx)).toEqual({ x: 10, y: 20, z: 30 });
+    });
+
+    it('falls back to workPosition - pivotPoint when cuttingTool is null', () => {
+        const ctx = {
+            cuttingTool: null,
+            pivotPoint: { get: () => ({ x: 1, y: 2, z: 3 }) },
+            workPosition: { x: 11, y: 12, z: 13 },
+        };
+        expect(getToolScenePosition(ctx)).toEqual({ x: 10, y: 10, z: 10 });
+    });
+
+    it('handles missing workPosition fields as zero', () => {
+        const ctx = {
+            cuttingTool: null,
+            pivotPoint: { get: () => ({ x: 5, y: 5, z: 5 }) },
+            workPosition: {},
+        };
+        expect(getToolScenePosition(ctx)).toEqual({ x: -5, y: -5, z: -5 });
+    });
+
+    it('handles null workPosition as all-zero', () => {
+        const ctx = {
+            cuttingTool: null,
+            pivotPoint: { get: () => ({ x: 2, y: 3, z: 4 }) },
+            workPosition: null,
+        };
+        expect(getToolScenePosition(ctx)).toEqual({ x: -2, y: -3, z: -4 });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// startCameraFollow / stopCameraFollow (rAF lifecycle)
+// ---------------------------------------------------------------------------
+describe('startCameraFollow / stopCameraFollow', () => {
+    let ctx;
+
+    beforeEach(() => {
+        // Minimal context that mirrors the Visualizer instance fields the
+        // follow methods read and write.
+        ctx = {
+            cameraFollowRAF: null,
+            props: { followTool: true },
+            controls: {
+                target: { x: 0, y: 0, z: 0 },
+                update: jest.fn(),
+            },
+            camera: {
+                position: { x: 0, y: 0, z: 0 },
+            },
+            cuttingTool: { position: { x: 5, y: 5, z: 5 } },
+            pivotPoint: { get: () => ({ x: 0, y: 0, z: 0 }) },
+            workPosition: { x: 5, y: 5, z: 5 },
+            updateScene: jest.fn(),
+        };
+
+        // Replace rAF with a synchronous stub that records calls.
+        jest
+            .spyOn(global, 'requestAnimationFrame')
+            .mockImplementation((cb) => {
+                const id = Math.random();
+                // Don't auto-invoke — tests control when a frame fires.
+                return id;
+            });
+        jest
+            .spyOn(global, 'cancelAnimationFrame')
+            .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('startCameraFollow schedules a rAF when follow is on and not already running', () => {
+        startCameraFollow(ctx);
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+        expect(ctx.cameraFollowRAF).not.toBeNull();
+    });
+
+    it('startCameraFollow is a no-op when follow is disabled', () => {
+        ctx.props = { followTool: false };
+        startCameraFollow(ctx);
+        expect(requestAnimationFrame).not.toHaveBeenCalled();
+        expect(ctx.cameraFollowRAF).toBeNull();
+    });
+
+    it('startCameraFollow is a no-op when a loop is already running', () => {
+        ctx.cameraFollowRAF = 42; // already running
+        startCameraFollow(ctx);
+        expect(requestAnimationFrame).not.toHaveBeenCalled();
+    });
+
+    it('stopCameraFollow cancels the rAF and nulls the handle', () => {
+        ctx.cameraFollowRAF = 99;
+        stopCameraFollow(ctx);
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(99);
+        expect(ctx.cameraFollowRAF).toBeNull();
+    });
+
+    it('stopCameraFollow is a no-op when no loop is running', () => {
+        ctx.cameraFollowRAF = null;
+        stopCameraFollow(ctx);
+        expect(cancelAnimationFrame).not.toHaveBeenCalled();
+    });
+
+    it('the tick loop stops itself when follow is toggled off mid-frame', () => {
+        // Use a manual rAF that lets us fire the callback on demand.
+        let pendingCb = null;
+        requestAnimationFrame.mockImplementation((cb) => {
+            pendingCb = cb;
+            return 7;
+        });
+
+        startCameraFollow(ctx);
+        expect(pendingCb).not.toBeNull();
+
+        // Disable follow before the first frame fires.
+        ctx.props = { followTool: false };
+        pendingCb(); // fire the tick
+
+        // Loop should have stopped itself without scheduling another frame.
+        expect(ctx.cameraFollowRAF).toBeNull();
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1); // only the initial schedule
+    });
+
+    it('the tick loop stops itself once the camera has caught up (distance < SETTLE)', () => {
+        let pendingCb = null;
+        requestAnimationFrame.mockImplementation((cb) => {
+            pendingCb = cb;
+            return 8;
+        });
+
+        // Tool and orbit target at the same position → distance is 0.
+        ctx.controls.target = { x: 5, y: 5, z: 5 };
+        ctx.camera.position = { x: 0, y: 0, z: 0 };
+
+        startCameraFollow(ctx);
+        pendingCb();
+
+        expect(ctx.cameraFollowRAF).toBeNull();
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
A crosshair toggle (next to lite-mode) pan-follows the toolhead, keeping it centered while preserving the user's viewing angle and zoom. It eases smoothly toward the tool each animation frame (rAF loop, decoupled from the choppy status-report rate) and turns itself off when the user drags the view.

- index.tsx: followTool state (persisted via WidgetConfig) + camera.toggleFollowTool
- Visualizer.jsx: startCameraFollow() rAF easing loop; follow target = workPosition - pivotPoint so it works even when the tool STL model is null; drag-only disable via canvas pointer listeners (click/zoom keep following)
- definitions.ts / PrimaryVisualizer.tsx / VisualizerWrapper.jsx: types, the crosshair toggle button, and prop threading