### PR TITLE
Fix/windows build on linux

### DIFF
--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -137,8 +137,6 @@ if [[ " $* " == *" --windows "* ]] || [[ " $* " == *" --win "* ]]; then
         *)
             if ! command -v wine >/dev/null 2>&1; then
                 echo "✗ Building a Windows installer on $(uname -s) requires 'wine' (used by electron-builder to generate the NSIS uninstaller)." >&2
-                echo "  Install it, e.g. on Debian/Ubuntu:" >&2
-                echo "    sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y wine wine32:i386" >&2
                 exit 1
             fi
             ;;

--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -111,6 +111,40 @@ CSC_IDENTITY_AUTO_DISCOVERY_VALUE=false
 if [ -n "$CSC_LINK" ] || [ -n "$CSC_NAME" ]; then
     CSC_IDENTITY_AUTO_DISCOVERY_VALUE=true
 fi
+
+# Extra args appended to the electron-builder invocation.
+EXTRA_ARGS=()
+
+# Windows-specific handling (building a Windows target, e.g. on a dev machine).
+if [[ " $* " == *" --windows "* ]] || [[ " $* " == *" --win "* ]]; then
+    # Skip Windows code signing unless DigiCert KeyLocker credentials are present.
+    # These are only set on release (tag) builds in CI; locally / on PR builds they
+    # are absent, in which case electron-builder would otherwise try to invoke
+    # signtool.exe (via wine on non-Windows hosts) and fail. signExecutable=false
+    # still applies the icon/version metadata, it only skips the signature.
+    # See WindowsSigner.js for the credentials contract.
+    if [ -z "$SM_KEYPAIR_ALIAS" ] || [ -z "$SM_CLIENT_CERT_FILE" ]; then
+        echo "ℹ Windows signing credentials (SM_KEYPAIR_ALIAS / SM_CLIENT_CERT_FILE) not set — skipping code signing for this build"
+        EXTRA_ARGS+=("-c.win.signExecutable=false")
+    fi
+
+    # Building an NSIS installer on a non-Windows host requires wine to generate
+    # the uninstaller stub. Fail early with a clear message instead of a cryptic
+    # "spawn wine ENOENT" deep inside electron-builder. Skip the check on native
+    # Windows (Git Bash / MSYS), where wine is neither present nor needed.
+    case "$(uname -s)" in
+        MINGW* | MSYS* | CYGWIN*) ;; # native Windows host, no wine needed
+        *)
+            if ! command -v wine >/dev/null 2>&1; then
+                echo "✗ Building a Windows installer on $(uname -s) requires 'wine' (used by electron-builder to generate the NSIS uninstaller)." >&2
+                echo "  Install it, e.g. on Debian/Ubuntu:" >&2
+                echo "    sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y wine wine32:i386" >&2
+                exit 1
+            fi
+            ;;
+    esac
+fi
+
 cross-env USE_HARD_LINKS=false \
     CSC_IDENTITY_AUTO_DISCOVERY=$CSC_IDENTITY_AUTO_DISCOVERY_VALUE \
-    yarn electron-builder -- "$@"
+    yarn electron-builder -- "$@" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
Fix Windows packaging on non-Windows hosts
Building the Windows target on a Linux dev host failed for two
reasons unrelated to the app itself:

1. electron-builder tried to code-sign the executables, invoking
   signtool.exe through wine. With no DigiCert KeyLocker credentials
   present (the local/PR case) this produced a confusing failure.

2. Generating the NSIS uninstaller requires wine on non-Windows hosts;
   when wine was missing the build died with a cryptic
   "spawn wine ENOENT" deep inside electron-builder.

This adds, in scripts/electron-builder.sh:

- Skip Windows code signing (-c.win.signExecutable=false) unless the
  SM_KEYPAIR_ALIAS and SM_CLIENT_CERT_FILE credentials are set. These
  are only set on release (tag) builds in CI, so signed release builds
  are unchanged; local and PR builds simply produce an unsigned package
  instead of failing. signExecutable=false still applies the icon and
  version metadata.

- A clear, actionable error when building a Windows installer on a
  non-Windows host without wine installed, instead of the raw ENOENT.

CI impact: none. The Windows job runs on windows-latest (no wine), and
on tag builds both SM_ credentials are present so signing proceeds as
before; on non-tag builds the artifact was already unsigned.