### PR TITLE
Fix/ci skip publish on forks

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,4 @@
 publish:
   provider: github
-  token: 00688e734b107cea78d68847eb2b1bde7bf1f16f
 
 

--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -111,6 +111,22 @@ CSC_IDENTITY_AUTO_DISCOVERY_VALUE=false
 if [ -n "$CSC_LINK" ] || [ -n "$CSC_NAME" ]; then
     CSC_IDENTITY_AUTO_DISCOVERY_VALUE=true
 fi
+
+# Extra args appended to the electron-builder invocation.
+EXTRA_ARGS=()
+
+# Only publish when a GitHub token is available. On the upstream repo's CI the
+# token is provided via the CI_TOKEN secret (exposed as GITHUB_TOKEN/GH_TOKEN);
+# forks and local builds have no such secret, so the env var is empty. Without
+# this guard electron-builder still tries to publish to the upstream releases
+# API (resolved from package.json "repository") and fails with 401 Unauthorized.
+# The explicit release/upload steps in .github/workflows/CI.yml handle the actual
+# distribution, so skipping the in-build publish here is safe.
+if [ -z "$GH_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
+    echo "ℹ No GH_TOKEN/GITHUB_TOKEN set — skipping electron-builder publish (--publish never)"
+    EXTRA_ARGS+=("--publish" "never")
+fi
+
 cross-env USE_HARD_LINKS=false \
     CSC_IDENTITY_AUTO_DISCOVERY=$CSC_IDENTITY_AUTO_DISCOVERY_VALUE \
-    yarn electron-builder -- "$@"
+    yarn electron-builder -- "$@" "${EXTRA_ARGS[@]}"

--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -107,25 +107,41 @@ fi
 
 # Run electron-builder with optimizations
 echo "Building with electron-builder..."
-CSC_IDENTITY_AUTO_DISCOVERY_VALUE=false
-if [ -n "$CSC_LINK" ] || [ -n "$CSC_NAME" ]; then
-    CSC_IDENTITY_AUTO_DISCOVERY_VALUE=true
-fi
 
 # Extra args appended to the electron-builder invocation.
 EXTRA_ARGS=()
 
-# electron-builder implicitly publishes when it detects CI, targeting the repo
-# in package.json "repository" (Sienci-Labs/gsender). On forks and local builds
-# that fails with 401 Unauthorized against the upstream releases API. Only allow
-# publishing when actually building on that upstream repo; otherwise force
-# --publish never. GitHub Actions sets GITHUB_REPOSITORY to "owner/repo"; it is
-# unset for local builds, which also correctly resolves to "never".
+# Determine whether we're building on the upstream repo. Publishing and code
+# signing both target Sienci-Labs/gsender (publish repo is taken from
+# package.json "repository") and require secrets that only exist there. On forks
+# and local builds those operations fail (401 on publish; signing errors with no
+# certificate), so they must be disabled. GitHub Actions sets GITHUB_REPOSITORY
+# to "owner/repo"; it is unset locally, which correctly resolves to "not upstream".
 PUBLISH_REPO=$(node -e "const u=(require('$__dirname/../package.json').repository||{}).url||'';const m=u.match(/github\.com[/:]+([^/]+\/[^/.]+)/i);process.stdout.write(m?m[1].toLowerCase():'')")
 CURRENT_REPO=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
-if [ -z "$CURRENT_REPO" ] || [ "$CURRENT_REPO" != "$PUBLISH_REPO" ]; then
-    echo "ℹ Not building on the upstream publish repo (${PUBLISH_REPO}) — skipping electron-builder publish (--publish never)"
+ON_UPSTREAM=false
+if [ -n "$CURRENT_REPO" ] && [ "$CURRENT_REPO" = "$PUBLISH_REPO" ]; then
+    ON_UPSTREAM=true
+fi
+
+# Publishing: electron-builder publishes implicitly on CI detection. Only allow
+# it on the upstream repo; otherwise force --publish never.
+if [ "$ON_UPSTREAM" != true ]; then
+    echo "ℹ Not building on the upstream repo (${PUBLISH_REPO}) — skipping electron-builder publish (--publish never)"
     EXTRA_ARGS+=("--publish" "never")
+fi
+
+# macOS code signing: only sign when on the upstream repo AND a signing
+# certificate is available (CSC_LINK / CSC_NAME). Otherwise disable signing
+# entirely — setting mac.identity=null skips it (electron-builder would
+# otherwise attempt to sign and fail with "not a file" when no cert is present).
+# Notarization is gated separately in notarize.js on the APPLE_* credentials.
+CSC_IDENTITY_AUTO_DISCOVERY_VALUE=false
+if [ "$ON_UPSTREAM" = true ] && { [ -n "$CSC_LINK" ] || [ -n "$CSC_NAME" ]; }; then
+    CSC_IDENTITY_AUTO_DISCOVERY_VALUE=true
+else
+    echo "ℹ No macOS signing certificate / not on upstream repo — disabling code signing (mac.identity=null)"
+    EXTRA_ARGS+=("-c.mac.identity=null")
 fi
 
 cross-env USE_HARD_LINKS=false \

--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -115,15 +115,16 @@ fi
 # Extra args appended to the electron-builder invocation.
 EXTRA_ARGS=()
 
-# Only publish when a GitHub token is available. On the upstream repo's CI the
-# token is provided via the CI_TOKEN secret (exposed as GITHUB_TOKEN/GH_TOKEN);
-# forks and local builds have no such secret, so the env var is empty. Without
-# this guard electron-builder still tries to publish to the upstream releases
-# API (resolved from package.json "repository") and fails with 401 Unauthorized.
-# The explicit release/upload steps in .github/workflows/CI.yml handle the actual
-# distribution, so skipping the in-build publish here is safe.
-if [ -z "$GH_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
-    echo "ℹ No GH_TOKEN/GITHUB_TOKEN set — skipping electron-builder publish (--publish never)"
+# electron-builder implicitly publishes when it detects CI, targeting the repo
+# in package.json "repository" (Sienci-Labs/gsender). On forks and local builds
+# that fails with 401 Unauthorized against the upstream releases API. Only allow
+# publishing when actually building on that upstream repo; otherwise force
+# --publish never. GitHub Actions sets GITHUB_REPOSITORY to "owner/repo"; it is
+# unset for local builds, which also correctly resolves to "never".
+PUBLISH_REPO=$(node -e "const u=(require('$__dirname/../package.json').repository||{}).url||'';const m=u.match(/github\.com[/:]+([^/]+\/[^/.]+)/i);process.stdout.write(m?m[1].toLowerCase():'')")
+CURRENT_REPO=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+if [ -z "$CURRENT_REPO" ] || [ "$CURRENT_REPO" != "$PUBLISH_REPO" ]; then
+    echo "ℹ Not building on the upstream publish repo (${PUBLISH_REPO}) — skipping electron-builder publish (--publish never)"
     EXTRA_ARGS+=("--publish" "never")
 fi
 


### PR DESCRIPTION
  CI fails on forks (and would fail locally) because the build step performs two operations that only work on the Sienci repo:

  1. Publishing - electron-builder publishes implicitly on CI detection, targeting Sienci-Labs/gsender (resolved from package.json repository). Forks have no valid token → 401 Unauthorized.
  2. macOS signing - electron-builder attempts to sign the app even with no certificate → cryptic ⨯ ... not a file error.

  Changes (scripts/electron-builder.sh): determine once whether the build is running on the upstream repo via GITHUB_REPOSITORY, then gate both operations:
  - Publish only on the upstream repo; otherwise --publish never.
  - Sign only on the upstream repo and when a cert is present (CSC_LINK/CSC_NAME); otherwise -c.mac.identity=null.
  - Local builds (no GITHUB_REPOSITORY) also skip both.

  Also removed a hardcoded GitHub token committed in electron-builder.yml.

  Production behavior is unchanged - on Sienci-Labs/gsender with secrets present, builds publish and sign as before. But now my own local fork feature branches/etc will successfully compile and have an artifact to download.