### PR TITLE
Fix CI

### DIFF
--- a/scripts/electron-builder.sh
+++ b/scripts/electron-builder.sh
@@ -144,9 +144,6 @@ else
     EXTRA_ARGS+=("-c.mac.identity=null")
 fi
 
-# Extra args appended to the electron-builder invocation.
-EXTRA_ARGS=()
-
 # Windows-specific handling (building a Windows target, e.g. on a dev machine).
 if [[ " $* " == *" --windows "* ]] || [[ " $* " == *" --win "* ]]; then
     # Skip Windows code signing unless DigiCert KeyLocker credentials are present.


### PR DESCRIPTION
[scripts/electron-builder.sh](https://github.com/gcormier/gsender/blob/features/fix-ci-extraargs-reset/scripts/electron-builder.sh) has two EXTRA_ARGS=() declarations from two independant PR's.