### PR TITLE
Add "Move To Here" click-to-move in the visualizer

### DIFF
--- a/src/app/src/features/DRO/utils/SafeMove.ts
+++ b/src/app/src/features/DRO/utils/SafeMove.ts
@@ -1,0 +1,53 @@
+import controller from 'app/lib/controller';
+import store from 'app/store';
+import get from 'lodash/get';
+
+/**
+ * Build the gcode lines required to retract Z to the user's configured safe
+ * height before performing a rapid XY move.
+ *
+ * Mirrors the retract logic used by "Go To Location" so the two features stay
+ * consistent:
+ *  - When homing is enabled, retract in machine space (G53) but only if the
+ *    spindle is currently below the safe height.
+ *  - When homing is disabled, retract incrementally (G91). Callers are
+ *    responsible for re-establishing their desired modal state afterwards.
+ *
+ * Returns an empty array when no retract height is configured.
+ */
+export function getSafeRetractCode(): string[] {
+    const code: string[] = [];
+    const retractHeight = Number(store.get('workspace.safeRetractHeight', -1));
+
+    if (retractHeight === 0) {
+        return code;
+    }
+
+    const settings = get(controller.settings, 'settings', {});
+    const homingEnabled = Number(get(settings, '$22', 0)) !== 0;
+
+    if (homingEnabled) {
+        const currentZ = Number(get(controller, 'state.status.mpos.z', 0));
+        const retract = Math.abs(retractHeight) * -1;
+        if (currentZ < retract) {
+            code.push(`G53 G0 Z${retract}`);
+        }
+    } else {
+        code.push('G91');
+        code.push(`G0Z${retractHeight}`);
+    }
+
+    return code;
+}
+
+/**
+ * Build a "retract to safe Z, then rapid to absolute work XY" gcode sequence.
+ *
+ * The spindle is left parked at the safe height over the target — it is never
+ * plunged back down. Coordinates are absolute work coordinates in millimetres.
+ */
+export function getSafeXYMoveCode(x: number, y: number): string[] {
+    const code = getSafeRetractCode();
+    code.push('G90', `G0 X${x} Y${y}`);
+    return code;
+}

--- a/src/app/src/features/Visualizer/PrimaryVisualizer.tsx
+++ b/src/app/src/features/Visualizer/PrimaryVisualizer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, ReactNode } from 'react';
 import PropTypes from 'prop-types';
-import { FrownIcon } from 'lucide-react';
+import { FrownIcon, Crosshair } from 'lucide-react';
 import pubsub from 'pubsub-js';
 
 import * as WebGL from 'app/lib/three/WebGL';
@@ -132,6 +132,24 @@ const PrimaryVisualizer = ({
                                 />
                             </button>
                         </Tooltip>
+                        {state.isConnected && (
+                            <Tooltip content="Move To Here: press and hold a spot to move the spindle there">
+                                <button
+                                    className="bg-gray-600 bg-opacity-50 rounded-full p-3.5"
+                                    onClick={() =>
+                                        camera.toggleMoveToHere()
+                                    }
+                                >
+                                    <Crosshair
+                                        size={36}
+                                        className={cx('cursor-pointer', {
+                                            'text-gray-400': !state.moveToHere,
+                                            'text-green-400': state.moveToHere,
+                                        })}
+                                    />
+                                </button>
+                            </Tooltip>
+                        )}
                     </div>
 
                     <CameraDisplay

--- a/src/app/src/features/Visualizer/Visualizer.jsx
+++ b/src/app/src/features/Visualizer/Visualizer.jsx
@@ -45,6 +45,7 @@ import {
     GRBL,
     GRBLHAL,
     GRBL_ACTIVE_STATE_CHECK,
+    GRBL_ACTIVE_STATE_IDLE,
     LASER_MODE,
     OUTLINE_MODE_RAPIDLESS_SQUARE,
     LIGHTWEIGHT_OPTIONS,
@@ -63,6 +64,7 @@ import _ from 'lodash';
 import store from 'app/store';
 
 import controller from '../../lib/controller';
+import { getSafeXYMoveCode } from 'app/features/DRO/utils/SafeMove';
 import { getBoundingBox, loadSTL, loadTexture } from './helpers';
 import Viewport from './Viewport';
 import CoordinateAxes from './CoordinateAxes';
@@ -101,6 +103,10 @@ const ORTHOGRAPHIC_FAR = 7000;
 const CAMERA_DISTANCE = 1900; // Move the camera out a bit from the origin (0, 0, 0)
 const TRACKBALL_CONTROLS_MIN_DISTANCE = 1;
 const TRACKBALL_CONTROLS_MAX_DISTANCE = 7000;
+// "Move To Here": how long to hold before committing, and how far the pointer
+// may drift before the gesture is treated as a pan instead of a placement.
+const MOVE_TO_HERE_HOLD_MS = 500;
+const MOVE_TO_HERE_CANCEL_PX = 8;
 import { outlineResponse } from '../../workers/Outline.response';
 import { shouldVisualizeSVG } from '../../workers/Visualize.response';
 import { uploadGcodeFileToServer } from 'app/lib/fileupload';
@@ -182,6 +188,17 @@ class Visualizer extends Component {
     counter = 0;
 
     waitingForCheck = false;
+
+    // "Move To Here" placement mode state
+    moveToHereActive = false;
+
+    mthPointerId = null;
+
+    mthStart = null;
+
+    mthTimer = null;
+
+    mthIndicator = null;
 
     setRef = (node) => {
         this.node = node;
@@ -443,6 +460,11 @@ class Visualizer extends Component {
             needUpdateScene = true;
         }
 
+        // "Move To Here" placement mode
+        if (prevState.moveToHere !== state.moveToHere) {
+            this.setMoveToHereMode(state.moveToHere);
+        }
+
         // Whether to show coordinate system
         if (
             prevState.units !== state.units ||
@@ -687,6 +709,7 @@ class Visualizer extends Component {
 
     componentWillUnmount() {
         this.removeControllerEvents();
+        this.setMoveToHereMode(false);
         this.unsubscribe();
         this.removeResizeEventListener();
         window.removeEventListener('keydown', this.handleKeyDown);
@@ -2383,6 +2406,8 @@ class Visualizer extends Component {
         controls.panSpeed = 0.4;
         controls.noZoom = false;
         controls.noPan = false;
+        // Keep rotation locked if "Move To Here" is armed during a rebuild
+        controls.noRotate = this.moveToHereActive;
 
         controls.staticMoving = true;
         controls.dynamicDampingFactor = 0.3;
@@ -2409,7 +2434,11 @@ class Visualizer extends Component {
 
         controls.addEventListener('end', () => {
             shouldAnimate = false;
-            this.props.actions.camera.toFreeView();
+            // While "Move To Here" is armed the camera stays locked to the Top
+            // view, so don't switch to the free view on pan/zoom interactions.
+            if (!this.moveToHereActive) {
+                this.props.actions.camera.toFreeView();
+            }
             this.updateScene();
         });
 
@@ -2418,6 +2447,276 @@ class Visualizer extends Component {
         });
 
         return controls;
+    }
+
+    setMoveToHereMode(enabled) {
+        this.moveToHereActive = enabled;
+        const dom = this.renderer && this.renderer.domElement;
+
+        if (enabled) {
+            if (this.controls) {
+                this.controls.noRotate = true;
+            }
+            if (dom) {
+                dom.style.cursor = 'crosshair';
+                dom.addEventListener(
+                    'pointerdown',
+                    this.handleMoveToHerePointerDown,
+                );
+                window.addEventListener(
+                    'pointermove',
+                    this.handleMoveToHerePointerMove,
+                );
+                window.addEventListener(
+                    'pointerup',
+                    this.handleMoveToHerePointerUp,
+                );
+                window.addEventListener(
+                    'pointercancel',
+                    this.handleMoveToHerePointerUp,
+                );
+            }
+        } else {
+            if (this.controls) {
+                this.controls.noRotate = false;
+            }
+            if (dom) {
+                dom.style.cursor = '';
+                dom.removeEventListener(
+                    'pointerdown',
+                    this.handleMoveToHerePointerDown,
+                );
+            }
+            window.removeEventListener(
+                'pointermove',
+                this.handleMoveToHerePointerMove,
+            );
+            window.removeEventListener(
+                'pointerup',
+                this.handleMoveToHerePointerUp,
+            );
+            window.removeEventListener(
+                'pointercancel',
+                this.handleMoveToHerePointerUp,
+            );
+            this.cancelMoveToHereHold();
+        }
+    }
+
+    machineIsReadyToMove() {
+        const { activeState } = this.props.state;
+        return (
+            this.props.isConnected && activeState === GRBL_ACTIVE_STATE_IDLE
+        );
+    }
+
+    handleMoveToHerePointerDown = (e) => {
+        if (!this.moveToHereActive) {
+            return;
+        }
+        // Primary (left mouse / touch) button only
+        if (e.button !== undefined && e.button !== 0) {
+            return;
+        }
+        // Only track a single pointer at a time (ignore multi-touch gestures)
+        if (this.mthPointerId !== null) {
+            return;
+        }
+        if (!this.machineIsReadyToMove()) {
+            toast.info('Machine must be connected and idle to move', {
+                position: 'bottom-right',
+            });
+            return;
+        }
+
+        this.mthPointerId = e.pointerId;
+        this.mthStart = { x: e.clientX, y: e.clientY };
+        this.showMoveToHereIndicator(e.clientX, e.clientY);
+
+        const { clientX, clientY } = e;
+        this.mthTimer = setTimeout(() => {
+            this.commitMoveToHere(clientX, clientY);
+        }, MOVE_TO_HERE_HOLD_MS);
+    };
+
+    handleMoveToHerePointerMove = (e) => {
+        if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
+            return;
+        }
+        const dx = e.clientX - this.mthStart.x;
+        const dy = e.clientY - this.mthStart.y;
+        // Movement beyond the threshold means the user is panning, not placing
+        if (Math.hypot(dx, dy) > MOVE_TO_HERE_CANCEL_PX) {
+            this.cancelMoveToHereHold();
+        }
+    };
+
+    handleMoveToHerePointerUp = (e) => {
+        if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
+            return;
+        }
+        // Released before the hold completed - cancel the placement
+        this.cancelMoveToHereHold();
+    };
+
+    cancelMoveToHereHold() {
+        if (this.mthTimer) {
+            clearTimeout(this.mthTimer);
+            this.mthTimer = null;
+        }
+        this.removeMoveToHereIndicator();
+        this.mthPointerId = null;
+        this.mthStart = null;
+    }
+
+    commitMoveToHere(clientX, clientY) {
+        this.cancelMoveToHereHold();
+
+        if (!this.machineIsReadyToMove()) {
+            toast.info('Machine must be connected and idle to move', {
+                position: 'bottom-right',
+            });
+            this.props.actions.camera.disableMoveToHere();
+            return;
+        }
+
+        const target = this.getWorkCoordsFromClient(clientX, clientY);
+        if (!target) {
+            return;
+        }
+
+        const { units } = this.props.state;
+        const unitModal = units === METRIC_UNITS ? 'G21' : 'G20';
+        controller.command(
+            'gcode:safe',
+            getSafeXYMoveCode(target.x, target.y),
+            unitModal,
+        );
+
+        toast.success(
+            `Moving to X${target.x.toFixed(2)} Y${target.y.toFixed(2)}`,
+            { position: 'bottom-right' },
+        );
+
+        // Auto-disarm after a successful move
+        this.props.actions.camera.disableMoveToHere();
+    }
+
+    getWorkCoordsFromClient(clientX, clientY) {
+        if (!this.renderer || !this.camera || !this.cuttingTool) {
+            return null;
+        }
+
+        const rect = this.renderer.domElement.getBoundingClientRect();
+        const ndc = new THREE.Vector2(
+            ((clientX - rect.left) / rect.width) * 2 - 1,
+            -((clientY - rect.top) / rect.height) * 2 + 1,
+        );
+
+        const raycaster = new THREE.Raycaster();
+        raycaster.setFromCamera(ndc, this.camera);
+
+        // Measure the clicked point relative to the cutting tool, whose world
+        // position corresponds to the current work position. This sidesteps the
+        // scene's pivot/group offsets and works in whatever units the scene is
+        // drawn in.
+        const toolWorld = new THREE.Vector3();
+        this.cuttingTool.getWorldPosition(toolWorld);
+
+        const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), -toolWorld.z);
+        const hit = new THREE.Vector3();
+        if (!raycaster.ray.intersectPlane(plane, hit)) {
+            return null;
+        }
+
+        const deltaX = hit.x - toolWorld.x;
+        const deltaY = hit.y - toolWorld.y;
+        const workX = Number(this.workPosition.x) + deltaX;
+        const workY = Number(this.workPosition.y) + deltaY;
+
+        return {
+            x: Number(workX.toFixed(3)),
+            y: Number(workY.toFixed(3)),
+        };
+    }
+
+    showMoveToHereIndicator(clientX, clientY) {
+        this.removeMoveToHereIndicator();
+
+        const size = 48;
+        const r = size / 2 - 4;
+        const c = size / 2;
+        const circumference = 2 * Math.PI * r;
+        const ns = 'http://www.w3.org/2000/svg';
+
+        // Use fixed positioning relative to the viewport so the indicator lands
+        // exactly under the pointer regardless of ancestor positioning.
+        const wrapper = document.createElement('div');
+        wrapper.style.cssText = [
+            'position:fixed',
+            'pointer-events:none',
+            'z-index:9999',
+            `width:${size}px`,
+            `height:${size}px`,
+            'transform:translate(-50%,-50%)',
+            `left:${clientX}px`,
+            `top:${clientY}px`,
+        ].join(';');
+
+        const svg = document.createElementNS(ns, 'svg');
+        svg.setAttribute('width', size);
+        svg.setAttribute('height', size);
+
+        const bg = document.createElementNS(ns, 'circle');
+        bg.setAttribute('cx', c);
+        bg.setAttribute('cy', c);
+        bg.setAttribute('r', r);
+        bg.setAttribute('fill', 'rgba(0,0,0,0.35)');
+        bg.setAttribute('stroke', 'rgba(255,255,255,0.4)');
+        bg.setAttribute('stroke-width', '3');
+
+        const progress = document.createElementNS(ns, 'circle');
+        progress.setAttribute('cx', c);
+        progress.setAttribute('cy', c);
+        progress.setAttribute('r', r);
+        progress.setAttribute('fill', 'none');
+        progress.setAttribute('stroke', '#4ade80');
+        progress.setAttribute('stroke-width', '3');
+        progress.setAttribute('stroke-linecap', 'round');
+        progress.setAttribute('stroke-dasharray', `${circumference}`);
+        progress.setAttribute('stroke-dashoffset', `${circumference}`);
+        progress.setAttribute('transform', `rotate(-90 ${c} ${c})`);
+
+        const dot = document.createElementNS(ns, 'circle');
+        dot.setAttribute('cx', c);
+        dot.setAttribute('cy', c);
+        dot.setAttribute('r', '2');
+        dot.setAttribute('fill', '#4ade80');
+
+        svg.appendChild(bg);
+        svg.appendChild(progress);
+        svg.appendChild(dot);
+        wrapper.appendChild(svg);
+        document.body.appendChild(wrapper);
+
+        if (typeof progress.animate === 'function') {
+            progress.animate(
+                [
+                    { strokeDashoffset: circumference },
+                    { strokeDashoffset: 0 },
+                ],
+                { duration: MOVE_TO_HERE_HOLD_MS, fill: 'forwards' },
+            );
+        }
+
+        this.mthIndicator = wrapper;
+    }
+
+    removeMoveToHereIndicator() {
+        if (this.mthIndicator && this.mthIndicator.parentElement) {
+            this.mthIndicator.parentElement.removeChild(this.mthIndicator);
+        }
+        this.mthIndicator = null;
     }
 
     getRadiansFromDegrees(val) {

--- a/src/app/src/features/Visualizer/definitions.ts
+++ b/src/app/src/features/Visualizer/definitions.ts
@@ -142,6 +142,8 @@ export interface State {
     };
     cameraMode: CAMERA_MODES_T;
     cameraPosition: CAMERA_POSITIONS_T; // 'Top', '3D', 'Front', 'Left', 'Right'
+    moveToHere: boolean; // "Move To Here" placement mode is armed
+    isConnected?: boolean; // Injected at render from connection state
     isAgitated: boolean; // Defaults to false
     currentTheme: Map<string, string>;
     currentTab: number;
@@ -203,6 +205,8 @@ export interface Actions {
         toLeftSideView: () => void;
         toRightSideView: () => void;
         toFreeView: () => void;
+        toggleMoveToHere: () => void;
+        disableMoveToHere: () => void;
     };
     handleLiteModeToggle: () => void;
     lineWarning: {

--- a/src/app/src/features/Visualizer/index.tsx
+++ b/src/app/src/features/Visualizer/index.tsx
@@ -575,6 +575,23 @@ class Visualizer extends Component {
             toFreeView: () => {
                 this.setState({ cameraPosition: 'Free' });
             },
+            // Arm/disarm "Move To Here": clicking-and-holding in the viewport
+            // rapids the spindle to that spot. Arming locks the camera to the
+            // Top view so the click maps cleanly to the XY work plane.
+            toggleMoveToHere: () => {
+                this.setState((state) => {
+                    const moveToHere = !state.moveToHere;
+                    return {
+                        moveToHere,
+                        cameraPosition: moveToHere
+                            ? 'Top'
+                            : state.cameraPosition,
+                    };
+                });
+            },
+            disableMoveToHere: () => {
+                this.setState({ moveToHere: false });
+            },
         },
         handleLiteModeToggle: () => {
             const { liteMode, liteOption } = this.state;
@@ -899,6 +916,7 @@ class Visualizer extends Component {
             },
             cameraMode: this.config.get('cameraMode', CAMERA_MODE_PAN),
             cameraPosition: '3D', // 'Top', '3D', 'Front', 'Left', 'Right'
+            moveToHere: false, // "Move To Here" placement mode is armed
             isAgitated: false, // Defaults to false
             currentTheme: getVisualizerTheme(),
             currentTab: 0,

--- a/src/app/src/lib/three/oldCombinedCamera.js
+++ b/src/app/src/lib/three/oldCombinedCamera.js
@@ -83,6 +83,13 @@ class CombinedCamera extends THREE.Camera {
         this.cameraP.updateProjectionMatrix();
 
         this.projectionMatrix = this.cameraP.projectionMatrix;
+        this.projectionMatrixInverse = this.cameraP.projectionMatrixInverse;
+
+        // Expose the standard THREE camera type flags so that helpers such as
+        // THREE.Raycaster (which dispatches on these) treat this combined
+        // camera as the projection it is currently emulating.
+        this.isPerspectiveCamera = true;
+        this.isOrthographicCamera = false;
 
         this.inPerspectiveMode = true;
         this.inOrthographicMode = false;
@@ -117,6 +124,12 @@ class CombinedCamera extends THREE.Camera {
         this.near = this.cameraO.near;
         this.far = this.cameraO.far;
         this.projectionMatrix = this.cameraO.projectionMatrix;
+        this.projectionMatrixInverse = this.cameraO.projectionMatrixInverse;
+
+        // See note in toPerspective(): keep the THREE camera type flags in sync
+        // with the active projection so Raycaster/unproject behave correctly.
+        this.isPerspectiveCamera = false;
+        this.isOrthographicCamera = true;
 
         this.inPerspectiveMode = false;
         this.inOrthographicMode = true;


### PR DESCRIPTION
<img width="799" height="274" alt="image" src="https://github.com/user-attachments/assets/26c9a1f4-82db-4c26-ae1d-aa51d404fecd" />

Adds a "move to here" button. Intent to easily jog around based on the loaded file. My use case - find spots where I can safely drill some screws into my spoilboard to hold down a workpiece based on avoiding toolpaths :)

Goals were
1. Avoid accidental clicks
2. Touch and mouse friendly interaction

Note that the retract Z currently does not go back down. Personally I hate it any time my Z goes down without my consent (or running a job). Need feedback on Z behavior, as I know we also want to target machines without a homing sensor for gSender.