### PR TITLE
Use explorer.exe to launch gSender de-elevated from installer

### DIFF
--- a/electron-build/installer.nsh
+++ b/electron-build/installer.nsh
@@ -42,8 +42,20 @@ FunctionEnd
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW showNewCheckbox
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE checkboxLeave
 # run after closing installer checkbox
-!define MUI_FINISHPAGE_RUN "${PRODUCT_NAME}.exe"
+# NOTE: the installer runs elevated (perMachine), so launching the exe
+# directly would make gSender inherit the admin token. Use
+# StdUtils.ExecShellAsUser to relaunch with the normal (non-elevated)
+# user token so gSender does not run as administrator.
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_FUNCTION RunAsUser
 !define MUI_FINISHPAGE_RUN_TEXT "Run gSender"
+
+Function RunAsUser
+    # Launch via explorer.exe so the app inherits explorer's normal
+    # (medium-integrity) token instead of the installer's admin token.
+    # This avoids needing the StdUtils plugin, which is not bundled.
+    Exec '"$WINDIR\explorer.exe" "$INSTDIR\${PRODUCT_NAME}.exe"'
+FunctionEnd
 # insert finish page
 !insertmacro MUI_PAGE_FINISH
 


### PR DESCRIPTION
The NSIS installer runs elevated (perMachine), so the finish-page "Run gSender" option launched the app with the installer's admin token, triggering a UAC prompt / running as administrator. Launch via explorer.exe instead.

Better UX - bugged me that I'd go to open a file and it was in some random folder (not the last folder from my user session)