### PR TITLE
Refactor "Move To Here" for the gviewer-based visualizer

### DIFF
--- a/src/app/src/features/DRO/utils/SafeMove.ts
+++ b/src/app/src/features/DRO/utils/SafeMove.ts
@@ -1,0 +1,53 @@
+import controller from 'app/lib/controller';
+import store from 'app/store';
+import get from 'lodash/get';
+
+/**
+ * Build the gcode lines required to retract Z to the user's configured safe
+ * height before performing a rapid XY move.
+ *
+ * Mirrors the retract logic used by "Go To Location" so the two features stay
+ * consistent:
+ *  - When homing is enabled, retract in machine space (G53) but only if the
+ *    spindle is currently below the safe height.
+ *  - When homing is disabled, retract incrementally (G91). Callers are
+ *    responsible for re-establishing their desired modal state afterwards.
+ *
+ * Returns an empty array when no retract height is configured.
+ */
+export function getSafeRetractCode(): string[] {
+    const code: string[] = [];
+    const retractHeight = Number(store.get('workspace.safeRetractHeight', -1));
+
+    if (retractHeight === 0) {
+        return code;
+    }
+
+    const settings = get(controller.settings, 'settings', {});
+    const homingEnabled = Number(get(settings, '$22', 0)) !== 0;
+
+    if (homingEnabled) {
+        const currentZ = Number(get(controller, 'state.status.mpos.z', 0));
+        const retract = Math.abs(retractHeight) * -1;
+        if (currentZ < retract) {
+            code.push(`G53 G0 Z${retract}`);
+        }
+    } else {
+        code.push('G91');
+        code.push(`G0Z${retractHeight}`);
+    }
+
+    return code;
+}
+
+/**
+ * Build a "retract to safe Z, then rapid to absolute work XY" gcode sequence.
+ *
+ * The spindle is left parked at the safe height over the target — it is never
+ * plunged back down. Coordinates are absolute work coordinates in millimetres.
+ */
+export function getSafeXYMoveCode(x: number, y: number): string[] {
+    const code = getSafeRetractCode();
+    code.push('G90', `G0 X${x} Y${y}`);
+    return code;
+}

--- a/src/app/src/features/Visualizer/GcodeViewer.tsx
+++ b/src/app/src/features/Visualizer/GcodeViewer.tsx
@@ -55,6 +55,7 @@ import {
 	FLEXOKI_DARK_THEME,
 	GRBL,
 	GRBL_ACTIVE_STATE_CHECK,
+	GRBL_ACTIVE_STATE_IDLE,
 	GRBL_ACTIVE_STATE_RUN,
 	GRBLHAL,
 	GRUVBOX_LIGHT_THEME,
@@ -84,7 +85,13 @@ const THEME_NAME_TO_PRESET: Record<string, GCodeViewerThemePresetName> = {
 const LIGHT_LIKE_PRESETS = new Set<GCodeViewerThemePresetName>(["light", "gruvbox-light", "ayu-light"]);
 
 import { outlineResponse } from "../../workers/Outline.response";
+import { getSafeXYMoveCode } from "app/features/DRO/utils/SafeMove";
 import type { Actions, CAMERA_POSITIONS_T, State } from "./definitions";
+
+// "Move To Here": how long to hold before committing, and how far the pointer
+// may drift before the gesture is treated as a pan instead of a placement.
+const MOVE_TO_HERE_HOLD_MS = 500;
+const MOVE_TO_HERE_CANCEL_PX = 8;
 
 // Maps gSender's camera positions onto gviewer ViewCube presets.
 const VIEW_MAP: Partial<Record<string, GCodeViewerCameraView>> = {
@@ -151,6 +158,17 @@ class GcodeViewer extends Component<Props> {
 
 	lastSpinning: boolean | null = null;
 
+	// "Move To Here" placement-mode state.
+	moveToHereActive = false;
+
+	mthPointerId: number | null = null;
+
+	mthStart: { x: number; y: number } | null = null;
+
+	mthTimer: ReturnType<typeof setTimeout> | null = null;
+
+	mthIndicator: HTMLDivElement | null = null;
+
 	componentDidMount() {
 		this.createViewer();
 		this.subscribe();
@@ -165,6 +183,7 @@ class GcodeViewer extends Component<Props> {
 	componentWillUnmount() {
 		this.unsubscribe();
 		this.reduxUnsub?.();
+		this.setMoveToHereMode(false);
 		this.viewer3d?.dispose();
 		this.viewerSvg?.dispose();
 		this.viewer3d = null;
@@ -174,6 +193,11 @@ class GcodeViewer extends Component<Props> {
 	componentDidUpdate(prevProps: Props) {
 		if (prevProps.cameraPosition !== this.props.cameraPosition) {
 			this.snapToView();
+		}
+
+		// "Move To Here" placement mode armed/disarmed.
+		if (prevProps.state.moveToHere !== this.props.state.moveToHere) {
+			this.setMoveToHereMode(this.props.state.moveToHere);
 		}
 
 		if (!prevProps.show && this.props.show) {
@@ -413,6 +437,255 @@ class GcodeViewer extends Component<Props> {
 		if (view && this.viewer3d) {
 			this.viewer3d.snapCameraToView(view);
 		}
+	}
+
+	// --- "Move To Here" placement mode --------------------------------------
+
+	// Arm/disarm the press-and-hold gesture. While armed, orbit rotation is
+	// locked (pan + zoom stay live) so the click maps predictably onto the XY
+	// plane, the cursor becomes a crosshair, and pointer listeners are live.
+	setMoveToHereMode(enabled: boolean) {
+		// Placement is a primary-visualizer concept; never arm on the secondary.
+		if (enabled && this.props.isSecondary) {
+			return;
+		}
+
+		this.moveToHereActive = enabled;
+		const dom = this.containerRef;
+
+		if (enabled) {
+			this.viewer3d?.setRotateEnabled(false);
+			if (dom) {
+				dom.style.cursor = "crosshair";
+				dom.addEventListener("pointerdown", this.handleMoveToHerePointerDown);
+			}
+			window.addEventListener("pointermove", this.handleMoveToHerePointerMove);
+			window.addEventListener("pointerup", this.handleMoveToHerePointerUp);
+			window.addEventListener("pointercancel", this.handleMoveToHerePointerUp);
+		} else {
+			this.viewer3d?.setRotateEnabled(true);
+			if (dom) {
+				dom.style.cursor = "";
+				dom.removeEventListener(
+					"pointerdown",
+					this.handleMoveToHerePointerDown,
+				);
+			}
+			window.removeEventListener(
+				"pointermove",
+				this.handleMoveToHerePointerMove,
+			);
+			window.removeEventListener("pointerup", this.handleMoveToHerePointerUp);
+			window.removeEventListener(
+				"pointercancel",
+				this.handleMoveToHerePointerUp,
+			);
+			this.cancelMoveToHereHold();
+		}
+	}
+
+	machineIsReadyToMove(): boolean {
+		const st = reduxStore.getState();
+		const isConnected = !!_get(st, "connection.isConnected");
+		const activeState = _get(st, "controller.state.status.activeState");
+		return isConnected && activeState === GRBL_ACTIVE_STATE_IDLE;
+	}
+
+	handleMoveToHerePointerDown = (e: PointerEvent) => {
+		if (!this.moveToHereActive) {
+			return;
+		}
+		// Primary (left mouse / touch) button only.
+		if (e.button !== undefined && e.button !== 0) {
+			return;
+		}
+		// Track a single pointer at a time (ignore multi-touch gestures).
+		if (this.mthPointerId !== null) {
+			return;
+		}
+		if (!this.machineIsReadyToMove()) {
+			toast.info("Machine must be connected and idle to move");
+			return;
+		}
+
+		this.mthPointerId = e.pointerId;
+		this.mthStart = { x: e.clientX, y: e.clientY };
+		this.showMoveToHereIndicator(e.clientX, e.clientY);
+
+		const { clientX, clientY } = e;
+		this.mthTimer = setTimeout(() => {
+			this.commitMoveToHere(clientX, clientY);
+		}, MOVE_TO_HERE_HOLD_MS);
+	};
+
+	handleMoveToHerePointerMove = (e: PointerEvent) => {
+		if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
+			return;
+		}
+		if (!this.mthStart) {
+			return;
+		}
+		const dx = e.clientX - this.mthStart.x;
+		const dy = e.clientY - this.mthStart.y;
+		// Movement beyond the threshold means the user is panning, not placing.
+		if (Math.hypot(dx, dy) > MOVE_TO_HERE_CANCEL_PX) {
+			this.cancelMoveToHereHold();
+		}
+	};
+
+	handleMoveToHerePointerUp = (e: PointerEvent) => {
+		if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
+			return;
+		}
+		// Released before the hold completed - cancel the placement.
+		this.cancelMoveToHereHold();
+	};
+
+	cancelMoveToHereHold() {
+		if (this.mthTimer) {
+			clearTimeout(this.mthTimer);
+			this.mthTimer = null;
+		}
+		this.removeMoveToHereIndicator();
+		this.mthPointerId = null;
+		this.mthStart = null;
+	}
+
+	commitMoveToHere(clientX: number, clientY: number) {
+		this.cancelMoveToHereHold();
+
+		if (!this.machineIsReadyToMove()) {
+			toast.info("Machine must be connected and idle to move");
+			this.props.actions.camera.disableMoveToHere();
+			return;
+		}
+
+		// gviewer renders rotary toolpaths on an X-rotated root, so the picked
+		// world XY is not a meaningful work coordinate for those files.
+		if (this.isRotaryFile) {
+			toast.info("Move To Here isn't available for rotary files");
+			this.props.actions.camera.disableMoveToHere();
+			return;
+		}
+
+		const target = this.getWorkCoordsFromClient(clientX, clientY);
+		if (!target) {
+			return;
+		}
+
+		const { units } = this.props.state;
+		const unitModal = units === METRIC_UNITS ? "G21" : "G20";
+		controller.command(
+			"gcode:safe",
+			getSafeXYMoveCode(target.x, target.y),
+			unitModal,
+		);
+
+		toast.success(
+			`Moving to X${target.x.toFixed(2)} Y${target.y.toFixed(2)}`,
+		);
+
+		// Auto-disarm after a successful move.
+		this.props.actions.camera.disableMoveToHere();
+	}
+
+	// Convert a viewport pixel into absolute work XY. gviewer raycasts the pixel
+	// onto the plane at the bit's current Z and returns scene coordinates, which
+	// equal work coordinates because the toolpath root sits at the origin.
+	getWorkCoordsFromClient(
+		clientX: number,
+		clientY: number,
+	): { x: number; y: number } | null {
+		if (!this.viewer3d) {
+			return null;
+		}
+		const hit = this.viewer3d.screenToWorld(clientX, clientY);
+		if (!hit) {
+			return null;
+		}
+		return {
+			x: Number(hit.x.toFixed(3)),
+			y: Number(hit.y.toFixed(3)),
+		};
+	}
+
+	showMoveToHereIndicator(clientX: number, clientY: number) {
+		this.removeMoveToHereIndicator();
+
+		const size = 48;
+		const r = size / 2 - 4;
+		const c = size / 2;
+		const circumference = 2 * Math.PI * r;
+		const ns = "http://www.w3.org/2000/svg";
+
+		// Fixed positioning relative to the viewport so the indicator lands
+		// exactly under the pointer regardless of ancestor positioning.
+		const wrapper = document.createElement("div");
+		wrapper.style.cssText = [
+			"position:fixed",
+			"pointer-events:none",
+			"z-index:9999",
+			`width:${size}px`,
+			`height:${size}px`,
+			"transform:translate(-50%,-50%)",
+			`left:${clientX}px`,
+			`top:${clientY}px`,
+		].join(";");
+
+		const svg = document.createElementNS(ns, "svg");
+		svg.setAttribute("width", String(size));
+		svg.setAttribute("height", String(size));
+
+		const bg = document.createElementNS(ns, "circle");
+		bg.setAttribute("cx", String(c));
+		bg.setAttribute("cy", String(c));
+		bg.setAttribute("r", String(r));
+		bg.setAttribute("fill", "rgba(0,0,0,0.35)");
+		bg.setAttribute("stroke", "rgba(255,255,255,0.4)");
+		bg.setAttribute("stroke-width", "3");
+
+		const progress = document.createElementNS(ns, "circle");
+		progress.setAttribute("cx", String(c));
+		progress.setAttribute("cy", String(c));
+		progress.setAttribute("r", String(r));
+		progress.setAttribute("fill", "none");
+		progress.setAttribute("stroke", "#4ade80");
+		progress.setAttribute("stroke-width", "3");
+		progress.setAttribute("stroke-linecap", "round");
+		progress.setAttribute("stroke-dasharray", `${circumference}`);
+		progress.setAttribute("stroke-dashoffset", `${circumference}`);
+		progress.setAttribute("transform", `rotate(-90 ${c} ${c})`);
+
+		const dot = document.createElementNS(ns, "circle");
+		dot.setAttribute("cx", String(c));
+		dot.setAttribute("cy", String(c));
+		dot.setAttribute("r", "2");
+		dot.setAttribute("fill", "#4ade80");
+
+		svg.appendChild(bg);
+		svg.appendChild(progress);
+		svg.appendChild(dot);
+		wrapper.appendChild(svg);
+		document.body.appendChild(wrapper);
+
+		if (typeof progress.animate === "function") {
+			progress.animate(
+				[
+					{ strokeDashoffset: circumference },
+					{ strokeDashoffset: 0 },
+				],
+				{ duration: MOVE_TO_HERE_HOLD_MS, fill: "forwards" },
+			);
+		}
+
+		this.mthIndicator = wrapper;
+	}
+
+	removeMoveToHereIndicator() {
+		if (this.mthIndicator && this.mthIndicator.parentElement) {
+			this.mthIndicator.parentElement.removeChild(this.mthIndicator);
+		}
+		this.mthIndicator = null;
 	}
 
 	// --- imperative API consumed by the connected container (index.tsx) -----

--- a/src/app/src/features/Visualizer/definitions.ts
+++ b/src/app/src/features/Visualizer/definitions.ts
@@ -142,6 +142,8 @@ export interface State {
 	};
 	cameraMode: CAMERA_MODES_T;
 	cameraPosition: CAMERA_POSITIONS_T; // 'Top', '3D', 'Front', 'Left', 'Right'
+	moveToHere: boolean; // "Move To Here" placement mode is armed
+	isConnected?: boolean; // Injected at render from connection state
 	isAgitated: boolean; // Defaults to false
 	currentTheme: Map<string, string>;
 	currentTab: number;
@@ -203,6 +205,8 @@ export interface Actions {
 		toLeftSideView: () => void;
 		toRightSideView: () => void;
 		toFreeView: () => void;
+		toggleMoveToHere: () => void;
+		disableMoveToHere: () => void;
 	};
 	handleLiteModeToggle: () => void;
 	lineWarning: {

--- a/src/app/src/features/Visualizer/index.tsx
+++ b/src/app/src/features/Visualizer/index.tsx
@@ -48,7 +48,7 @@ import _ from "lodash";
 import debounce from "lodash/debounce";
 import get from "lodash/get";
 import includes from "lodash/includes";
-import { FrownIcon } from "lucide-react";
+import { Crosshair, FrownIcon } from "lucide-react";
 import PropTypes from "prop-types";
 import pubsub from "pubsub-js";
 import { Component } from "react";
@@ -109,6 +109,15 @@ const VIEWCUBE_CONTROL_GAP_PX = 12;
 const LIGHTWEIGHT_TOGGLE_POSITION = {
 	left: VIEWCUBE_OFFSET_PX + VIEWCUBE_SIZE_PX / 2,
 	bottom: VIEWCUBE_OFFSET_PX + VIEWCUBE_SIZE_PX + VIEWCUBE_CONTROL_GAP_PX,
+};
+// "Move To Here" toggle sits stacked directly above the lightweight toggle.
+const FLOATING_BUTTON_SIZE_PX = 44; // h-11 / w-11
+const MOVE_TO_HERE_TOGGLE_POSITION = {
+	left: LIGHTWEIGHT_TOGGLE_POSITION.left,
+	bottom:
+		LIGHTWEIGHT_TOGGLE_POSITION.bottom +
+		FLOATING_BUTTON_SIZE_PX +
+		VIEWCUBE_CONTROL_GAP_PX,
 };
 
 class Visualizer extends Component {
@@ -579,6 +588,21 @@ class Visualizer extends Component {
 			toFreeView: () => {
 				this.setState({ cameraPosition: "Free" });
 			},
+			// Arm/disarm "Move To Here": pressing-and-holding a spot in the
+			// viewport rapids the spindle there. Arming pins the camera to the
+			// Top view so the click maps cleanly onto the XY work plane.
+			toggleMoveToHere: () => {
+				this.setState((state) => {
+					const moveToHere = !state.moveToHere;
+					return {
+						moveToHere,
+						cameraPosition: moveToHere ? "Top" : state.cameraPosition,
+					};
+				});
+			},
+			disableMoveToHere: () => {
+				this.setState({ moveToHere: false });
+			},
 		},
 		handleLiteModeToggle: () => {
 			const { liteMode, liteOption } = this.state;
@@ -884,6 +908,7 @@ class Visualizer extends Component {
 			},
 			cameraMode: this.config.get("cameraMode", CAMERA_MODE_PAN),
 			cameraPosition: "3D", // 'Top', '3D', 'Front', 'Left', 'Right'
+			moveToHere: false, // "Move To Here" placement mode is armed
 			isAgitated: false, // Defaults to false
 			currentTheme: getVisualizerTheme(),
 			currentTab: 0,
@@ -1623,6 +1648,35 @@ class Visualizer extends Component {
 						)}
 
 						{!showVisualizer && webGLAvailable && <VisualizerPlaceholder />}
+
+						{state.isConnected && (
+							<Tooltip
+								content="Move To Here: press and hold a spot to move the spindle there"
+								side="top"
+							>
+								<button
+									type="button"
+									style={MOVE_TO_HERE_TOGGLE_POSITION}
+									className={cx(
+										"absolute z-[10000] inline-flex h-11 w-11 -translate-x-1/2 items-center justify-center rounded-full border bg-dark-darker/70 shadow-[0_10px_30px_rgba(0,_0,_0,_0.25)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-dark-darker active:scale-[0.98] active:bg-dark-darker/85 mb-5",
+										{
+											"border-[rgba(14,_246,_174,_0.95)] text-[rgba(14,_246,_174,_0.95)] shadow-[0_0_0_1px_rgba(14,_246,_174,_0.35),0_10px_30px_rgba(0,_0,_0,_0.35)] hover:border-[rgba(14,_246,_174,_0.95)] hover:text-[rgba(14,_246,_174,_0.95)] hover:shadow-[0_0_0_1px_rgba(14,_246,_174,_0.45),0_12px_32px_rgba(0,_0,_0,_0.4)]":
+												state.moveToHere,
+											"border-gray-400/40 text-gray-300 hover:border-gray-200/70 hover:text-gray-100 hover:shadow-[0_12px_32px_rgba(0,_0,_0,_0.35)]":
+												!state.moveToHere,
+										},
+									)}
+									aria-label="Move To Here"
+									aria-pressed={state.moveToHere}
+									onClick={() => actions.camera.toggleMoveToHere()}
+								>
+									<Crosshair
+										aria-hidden="true"
+										className="pointer-events-none h-5 w-5 shrink-0"
+									/>
+								</button>
+							</Tooltip>
+						)}
 
 						<Tooltip content={liteModeActionLabel} side="top">
 							<button


### PR DESCRIPTION
Reimplements the press-and-hold click-to-move gesture on top of the visualizer redesign, where the hand-rolled THREE scene (Visualizer.jsx, CombinedCamera, TrackballControls) is replaced by the @sienci/gviewer package.

The gesture, progress-ring indicator, hold/cancel thresholds, idle-gating and toast feedback are preserved; only the parts that reached into the old scene internals are rewritten against gviewer's API:

- Picking now uses viewer3d.screenToWorld(clientX, clientY), which raycasts the pixel onto the plane at the bit's current Z and returns work coordinates directly (the toolpath root sits at the origin), replacing the old camera/cuttingTool differential raycast.
- Arming locks rotation via viewer3d.setRotateEnabled(false) (pan + zoom stay live) and pins the Top view, replacing TrackballControls.noRotate.
- Rotary files are gated out, since gviewer rotates the toolpath root about X so the picked XY is not a work coordinate there.

Wiring:
- definitions.ts: moveToHere/isConnected state + toggle/disableMoveToHere camera actions.
- index.tsx: crosshair toggle button (connected-only) stacked above the lightweight toggle; arming pins the Top view.
- GcodeViewer.tsx: owns the pointer gesture, picking and commit since it holds the gviewer instance and container canvas.
- SafeMove.ts: unchanged retract+rapid g-code helper, mirroring GoTo.tsx.

Depends on the @sienci/gviewer screenToWorld/setRotateEnabled additions