### PR TITLE
Fix unit-suffix overlapping value in number inputs

### DIFF
--- a/src/app/src/components/ControlledInput/index.tsx
+++ b/src/app/src/components/ControlledInput/index.tsx
@@ -12,6 +12,7 @@ type InputProps = ComponentProps<"input"> & {
 	label?: string | ReactNode;
 	sizing?: "xs" | "sm" | "md" | "lg";
 	wrapperClassName?: string;
+	invalid?: boolean;
 	clearOnEnter?: boolean;
 	immediateOnChange?: boolean; // New prop to enable immediate onChange calls
 };

--- a/src/app/src/components/UnitInput/index.tsx
+++ b/src/app/src/components/UnitInput/index.tsx
@@ -21,21 +21,26 @@ export function UnitInput({
 	return (
 		<div
 			className={cx(
-				"border border-gray-300 rounded flex flex-row items-stretch flex-1 justify-between pl-2",
+				"border border-gray-300 rounded flex flex-row items-center flex-1 justify-between pl-2 pr-2",
 				{
 					"opacity-50": disabled,
 				},
 			)}
 		>
 			{label && <Label className="flex items-center">{label}</Label>}
-			<ControlledInput
-				type="number"
-				className="w-[7ch] border-none margin-none p-0 focus:border-none focus:outline-none text-center"
-				value={disabled ? "0" : value}
-				onChange={onChange}
-				suffix={units}
-				disabled={disabled}
-			/>
+			<div className="flex flex-row items-center">
+				<ControlledInput
+					type="number"
+					wrapperClassName="w-auto"
+					className="w-[7ch] border-none margin-none p-0 focus:border-none focus:outline-none text-center"
+					value={disabled ? "0" : value}
+					onChange={onChange}
+					disabled={disabled}
+				/>
+				<span className="shrink-0 pl-1 text-xs text-gray-500 dark:text-white">
+					{units}
+				</span>
+			</div>
 		</div>
 	);
 }

--- a/src/app/src/components/shadcn/Input.tsx
+++ b/src/app/src/components/shadcn/Input.tsx
@@ -6,6 +6,9 @@ type InputProps = React.ComponentProps<"input"> & {
 	label?: string | React.ReactNode;
 	sizing?: "xs" | "sm" | "md" | "lg";
 	wrapperClassName?: string;
+	// Marks the field as invalid so the bordered box (which owns the border when a
+	// suffix is present) turns red. Text color can still be set via `className`.
+	invalid?: boolean;
 	type?: string;
 };
 
@@ -17,6 +20,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			suffix,
 			label,
 			sizing = "md",
+			invalid,
 			type,
 			...props
 		},
@@ -27,6 +31,23 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			sm: "h-8 text-sm px-2",
 			md: "h-10 text-md px-3",
 			lg: "h-12 text-lg px-4",
+		}[sizing];
+
+		// When a suffix is present, the bordered box becomes the flex container and
+		// the suffix is laid out as a normal (non-overlapping) sibling of the input.
+		// This reserves the suffix's own width in flow, so the value can never render
+		// on top of the unit regardless of alignment, value length, or box width.
+		const boxSize = {
+			xs: "h-6 px-2",
+			sm: "h-8 px-2",
+			md: "h-10 px-3",
+			lg: "h-12 px-4",
+		}[sizing];
+		const textSize = {
+			xs: "text-sm",
+			sm: "text-sm",
+			md: "text-sm", // was a non-existent "text-md" (silent no-op)
+			lg: "text-lg",
 		}[sizing];
 
 		return (
@@ -40,25 +61,48 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 						{label}
 					</label>
 				)}
-				<div className="relative flex items-center">
-					<input
+				{suffix ? (
+					<div
 						className={cn(
-							"flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-							"text-robin-500 pr-10 dark:bg-dark dark:text-white dark:border-gray-500",
-							inputSize,
-							className,
+							"flex items-center rounded-md border border-input bg-background ring-offset-background",
+							"dark:bg-dark dark:border-gray-500",
+							boxSize,
+							invalid && "border-red-500 dark:border-red-500",
 						)}
-						ref={ref}
-						title=""
-						type={type}
-						{...props}
-					/>
-					{suffix && (
-						<div className="absolute right-2 text-xs flex items-center pointer-events-none text-gray-500 dark:text-white">
+					>
+						<input
+							className={cn(
+								"flex-1 min-w-0 h-full bg-transparent border-0 p-0",
+								"text-robin-500 dark:text-white placeholder:text-muted-foreground",
+								"focus:outline-none focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+								textSize,
+								className,
+							)}
+							ref={ref}
+							title=""
+							type={type}
+							{...props}
+						/>
+						<div className="shrink-0 pl-2 text-xs flex items-center pointer-events-none text-gray-500 dark:text-white">
 							{suffix}
 						</div>
-					)}
-				</div>
+					</div>
+				) : (
+					<div className="relative flex items-center">
+						<input
+							className={cn(
+								"flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+								"text-robin-500 pr-10 dark:bg-dark dark:text-white dark:border-gray-500",
+								inputSize,
+								className,
+							)}
+							ref={ref}
+							title=""
+							type={type}
+							{...props}
+						/>
+					</div>
+				)}
 			</div>
 		);
 	},

--- a/src/app/src/features/MovementTuning/Steps/index.tsx
+++ b/src/app/src/features/MovementTuning/Steps/index.tsx
@@ -441,7 +441,7 @@ const Steps = () => {
 													setMoveDistance(Number(e.target.value))
 												}
 												disabled={currentStep !== 1}
-												className="w-28"
+												wrapperClassName="w-28"
 												suffix={units ?? "mm"}
 											/>
 										</div>
@@ -489,7 +489,7 @@ const Steps = () => {
 													setMeasuredDistance(Number(e.target.value))
 												}
 												disabled={currentStep !== 2}
-												className="w-28"
+												wrapperClassName="w-28"
 												suffix={units ?? "mm"}
 											/>
 										</div>

--- a/src/app/src/features/Surfacing/index.tsx
+++ b/src/app/src/features/Surfacing/index.tsx
@@ -207,8 +207,9 @@ const SurfacingTool = () => {
 										suffix={units}
 										min={0.00001}
 										max={10000}
+										invalid={isCutDepthExceedingMax}
 										className={cx("rounded", inputStyle, {
-											"text-red-500 border-red-500": isCutDepthExceedingMax,
+											"text-red-500": isCutDepthExceedingMax,
 										})}
 										wrapperClassName="w-full"
 										value={surfacing.skimDepth}
@@ -228,8 +229,9 @@ const SurfacingTool = () => {
 										suffix={units}
 										min={0.00001}
 										max={10000}
+										invalid={isCutDepthExceedingMax}
 										className={cx(inputStyle, {
-											"text-red-500 border-red-500": isCutDepthExceedingMax,
+											"text-red-500": isCutDepthExceedingMax,
 										})}
 										wrapperClassName="w-full"
 										value={surfacing.maxDepth}


### PR DESCRIPTION
Number inputs with a unit suffix (mm, in, mm/min, %, RPM, etc.) could
render the unit on top of the value. The suffix was an absolutely-
positioned overlay relying on fixed right-padding that callers (and
tailwind-merge) routinely collapsed.

Fix: when a suffix is present, lay it out in normal flow as a sibling of
the input so it reserves its own width - overlap is now impossible
regardless of value length, alignment, or box width. Visual appearance
(border, background, colors, light/dark) is unchanged.

Changes:
- shadcn/Input: in-flow suffix layout; new `invalid` prop for error
  borders; drop the no-op `text-md` class.
- ControlledInput: forward `invalid`.
- UnitInput: render unit as a sibling (fixes DRO Go To inputs).
- Surfacing: use `invalid` for the cut-depth error border.
- MovementTuning: move fixed width to wrapperClassName.

Old
<img width="321" height="189" alt="image" src="https://github.com/user-attachments/assets/9c6b45ff-a5f5-4895-bdf0-f42481ffaeb0" />


New
<img width="341" height="178" alt="image" src="https://github.com/user-attachments/assets/06b0966f-5392-464c-b520-36f8f969b21f" />
