### PR TITLE
Detect probed tools by non-zero Z offset rather than negative

### DIFF
--- a/src/app/src/features/ATC/utils/ATCFunctions.ts
+++ b/src/app/src/features/ATC/utils/ATCFunctions.ts
@@ -121,7 +121,9 @@ export function releaseToolFromSpindle() {
 }
 
 export function loadTool(toolID) {
-    controller.command('gcode', [`M6 T${toolID}`]);
+    // M6 runs the tool change macro, which probes the tool and writes its offset
+    // with G10 L1, so the tool table has to be re-read afterwards.
+    controller.command('gcode', [`M6 T${toolID}`, '$#']);
 }
 
 export function loadAndSaveToRack(toolID) {

--- a/src/app/src/features/ATC/utils/ATCFunctions.ts
+++ b/src/app/src/features/ATC/utils/ATCFunctions.ts
@@ -30,12 +30,26 @@ export function mapToolNicknamesAndStatus(
     Object.values(tools).forEach((tool) => {
         tool = { ...tool };
         tool.nickname = lookupToolName(tool.id);
-        const flags = getToolFlags(tool.id, rackSize, tool.toolOffsets.z);
+        const flags = getToolFlags(
+            tool.id,
+            rackSize,
+            get(tool, 'toolOffsets.z', 0),
+        );
         tool.status = flags.probeState;
         tool.isManual = flags.isManual;
         toolsArray.push(tool);
     });
     return toolsArray;
+}
+
+// A tool that has never been probed has an offset of exactly zero, since the
+// controller zeroes unwritten tool table entries. The sign of a probed offset
+// depends on the tool change macro's reference scheme - it is negative when the
+// macro stores the raw machine Z of the tool setter trigger, and positive when
+// it stores tool length above a datum - so only zero/non-zero is meaningful.
+export function isToolProbed(zOffset: number): boolean {
+    const offset = Number(zOffset);
+    return Number.isFinite(offset) && offset !== 0;
 }
 
 export function getToolFlags(
@@ -44,13 +58,17 @@ export function getToolFlags(
     zOffset: number,
 ): ToolFlags {
     return {
-        probeState: zOffset < 0 ? 'probed' : 'unprobed',
+        probeState: isToolProbed(zOffset) ? 'probed' : 'unprobed',
         isManual: toolNumber > rackSize,
     };
 }
 
 function setToolStatus(tool: ToolInstance, rackSize): ToolInstance {
-    const flags = getToolFlags(tool.id, rackSize, tool.toolOffsets.z);
+    const flags = getToolFlags(
+        tool.id,
+        rackSize,
+        get(tool, 'toolOffsets.z', 0),
+    );
     tool.status = flags.probeState;
     tool.isManual = flags.isManual;
     return tool;

--- a/src/app/src/features/JobControl/index.tsx
+++ b/src/app/src/features/JobControl/index.tsx
@@ -19,6 +19,7 @@ import { SenderStatus } from 'app/lib/definitions/sender_feeder';
 import { JSX, useEffect, useState } from 'react';
 import pubsub from 'pubsub-js';
 import { SDCardProgress } from 'app/features/JobControl/SDCardProgress.tsx';
+import { isToolProbed } from 'app/features/ATC/utils/ATCFunctions.ts';
 import cx from 'classnames';
 
 interface JobControlProps {
@@ -149,7 +150,7 @@ const JobControl: React.FC<JobControlProps> = ({
             const zOffset = get(offsets, 'toolOffsets.z', 0);
 
             // Tool selected with Offsets
-            if (zOffset < 0) {
+            if (isToolProbed(zOffset)) {
                 return [
                     true,
                     {

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -1006,6 +1006,10 @@ class GrblHalController {
             this.emit('serialport:read', res.raw);
         });
 
+        this.runner.on('tool', (res) => {
+            this.emit('serialport:read', res.raw);
+        });
+
         this.runner.on('feedback', (res) => {
             this.emit('serialport:read', res.raw);
         });

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -650,6 +650,11 @@ class GrblHalController {
                     this.command('gcode', '[global.state.testWCS]');
                 }, 200);
                 this.emit('gcode_error_checking_file', this.sender.state, 'finished');
+            } else if (this.sender.state.toolChanges > 0) {
+                // A tool change macro probes the incoming tool and stores its
+                // offset with G10 L1, so the tool table is stale once a job with
+                // tool changes finishes. Nothing is streaming now, so re-read it.
+                this.command('gcode', '$#');
             }
         });
         this.sender.on('requestData', () => {

--- a/src/server/controllers/Grblhal/GrblHalRunner.js
+++ b/src/server/controllers/Grblhal/GrblHalRunner.js
@@ -310,69 +310,28 @@ class GrblHalRunner extends events.EventEmitter {
             return;
         }
         if (type === GrblHalLineParserResultTool) {
-            delete payload.raw;
+            const { raw, ...tool } = payload;
             const nextSettings = {
                 ...this.settings,
                 toolTable: {
                     ...this.settings.toolTable,
-                    [payload.id]: payload
+                    [tool.id]: tool
                 }
             };
             if (!_.isEqual(this.settings.toolTable, nextSettings.toolTable)) {
                 this.settings = nextSettings;
             }
+            this.emit('tool', { ...tool, raw });
             return;
         }
         if (type === GrblHalLineParserResultParameters) {
             const { name, value } = payload;
-            // Update tool offsets for current tool based on PRB results
-            // This is necessary in order to update offsets mid tool change or toolpath
-            // Ignore prb output for tool 0 (empty) since nothing to update
-            // Ignore PRB if no success on probe
-            const currentTool = this.state.status.currentTool;
-            const isProbeSuccess = name === 'PRB' && value.result === 1;
-            const isCurrentToolSet = currentTool > 0;
-            const toolTable = _.get(this.settings, 'toolTable', {});
-            const isToolTablePopulated = !_.isEmpty(toolTable);
-            const hasCurrentToolEntry = _.has(toolTable, currentTool);
-            const shouldUpdateToolOffsets = isProbeSuccess &&
-                isCurrentToolSet &&
-                isToolTablePopulated &&
-                hasCurrentToolEntry;
-
-            if (isProbeSuccess && isCurrentToolSet && !shouldUpdateToolOffsets) {
-                log.warn(
-                    `[PRB] Skipping tool offset update for current tool T${currentTool}. ` +
-                        `isToolTablePopulated=${isToolTablePopulated}, ` +
-                        `hasCurrentToolEntry=${hasCurrentToolEntry}`
-                );
-            }
-
-            if (shouldUpdateToolOffsets) {
-                const currentToolData = toolTable[currentTool] || {};
-                const currentToolOffsets = _.isPlainObject(currentToolData.toolOffsets)
-                    ? currentToolData.toolOffsets
-                    : {};
-                const nextSettings = {
-                    ...this.settings,
-                    toolTable: {
-                        ...this.settings.toolTable,
-                        [currentTool]: {
-                            ...currentToolData,
-                            toolOffsets: {
-                                ...currentToolOffsets,
-                                x: Number(value.x),
-                                y: Number(value.y),
-                                z: Number(value.z)
-                            }
-                        }
-                    }
-                };
-
-                if (!_.isEqual(this.settings.toolTable, nextSettings.toolTable)) {
-                    this.settings = nextSettings;
-                }
-            }
+            // A [PRB:] result is a machine coordinate, not a tool offset - the two
+            // only coincide when the tool change macro happens to store the raw
+            // trigger position. Writing it into the tool table clobbered the real
+            // offset on any successful probe, including an ordinary workpiece
+            // touch off. The tool table is refreshed from $# after every tool
+            // change and probe, so let that be the source of truth.
             const nextSettings = {
                 ...this.settings,
                 parameters: {

--- a/src/server/controllers/Grblhal/GrblHalRunner.js
+++ b/src/server/controllers/Grblhal/GrblHalRunner.js
@@ -326,12 +326,54 @@ class GrblHalRunner extends events.EventEmitter {
         }
         if (type === GrblHalLineParserResultParameters) {
             const { name, value } = payload;
-            // A [PRB:] result is a machine coordinate, not a tool offset - the two
-            // only coincide when the tool change macro happens to store the raw
-            // trigger position. Writing it into the tool table clobbered the real
-            // offset on any successful probe, including an ordinary workpiece
-            // touch off. The tool table is refreshed from $# after every tool
-            // change and probe, so let that be the source of truth.
+            // Update tool offsets for current tool based on PRB results
+            // This is necessary in order to update offsets mid tool change or toolpath
+            // Ignore prb output for tool 0 (empty) since nothing to update
+            // Ignore PRB if no success on probe
+            const currentTool = this.state.status.currentTool;
+            const isProbeSuccess = name === 'PRB' && value.result === 1;
+            const isCurrentToolSet = currentTool > 0;
+            const toolTable = _.get(this.settings, 'toolTable', {});
+            const isToolTablePopulated = !_.isEmpty(toolTable);
+            const hasCurrentToolEntry = _.has(toolTable, currentTool);
+            const shouldUpdateToolOffsets = isProbeSuccess &&
+                isCurrentToolSet &&
+                isToolTablePopulated &&
+                hasCurrentToolEntry;
+
+            if (isProbeSuccess && isCurrentToolSet && !shouldUpdateToolOffsets) {
+                log.warn(
+                    `[PRB] Skipping tool offset update for current tool T${currentTool}. ` +
+                        `isToolTablePopulated=${isToolTablePopulated}, ` +
+                        `hasCurrentToolEntry=${hasCurrentToolEntry}`
+                );
+            }
+
+            if (shouldUpdateToolOffsets) {
+                const currentToolData = toolTable[currentTool] || {};
+                const currentToolOffsets = _.isPlainObject(currentToolData.toolOffsets)
+                    ? currentToolData.toolOffsets
+                    : {};
+                const nextSettings = {
+                    ...this.settings,
+                    toolTable: {
+                        ...this.settings.toolTable,
+                        [currentTool]: {
+                            ...currentToolData,
+                            toolOffsets: {
+                                ...currentToolOffsets,
+                                x: Number(value.x),
+                                y: Number(value.y),
+                                z: Number(value.z)
+                            }
+                        }
+                    }
+                };
+
+                if (!_.isEqual(this.settings.toolTable, nextSettings.toolTable)) {
+                    this.settings = nextSettings;
+                }
+            }
             const nextSettings = {
                 ...this.settings,
                 parameters: {


### PR DESCRIPTION
## Problem

The ATC tool table badge treats a tool as probed only when its stored Z offset is negative:

```ts
probeState: zOffset < 0 ? 'probed' : 'unprobed',
```

That assumption holds only for the reference scheme used by the bundled ATC-I macros, which store the raw machine Z of the tool setter trigger (`#<tool_offset> = [#[5203 + [#5220 * 20]] + #5063]`). On a Z-max homed machine that value is always negative, so the sign happens to work as a proxy.

Tool change macros that instead store tool length above a datum write a **positive** offset. grblHAL supports both — a tool offset is just a number in the tool table, and `G43 H<n>` applies it either way. On those machines every tool reads as unprobed, no matter how many times it is probed, and the pre-job check falsely raises "Current Tool Not Probed".

Real tool table from a SuperLongBoard running a macro-driven ATC (`$#` over telnet), five probed tools, all reported unprobed by gSender:

```
[T:1|0.000,0.000,15.135,0.000|0.000|6,0,0||1]
[T:2|0.000,0.000,19.735,0.000|0.000|6,0,0||2]
[T:3|0.000,0.000,11.660,0.000|0.000|6,0,0||3]
[T:4|0.000,0.000,11.960,0.000|0.000|6,0,0||4]
[T:5|0.000,0.000,7.795,0.000|0.000|6,0,0||5]
[T:6|0.000,0.000,0.000,0.000|0.000|6,0,0||6]
...
```

## Fix

An unprobed tool table entry is zeroed by the controller, so the meaningful test is **non-zero**, not negative. That is correct for both reference schemes and does not change behaviour for the bundled macros.

The rule was implemented twice — once for the badge in `getToolFlags()` and again in the pre-job "Current Tool Not Probed" check in `JobControl` — and both had to be fixed. Collapsed into a single exported `isToolProbed()` predicate so they cannot drift again. Also guarded two unguarded `tool.toolOffsets.z` accesses that would throw on an entry without `toolOffsets`.

## `[T:]` lines are now echoed to the console

`GrblHalRunner` parsed `[T:]` into the tool table, deleted `raw`, and returned without emitting an event, and `GrblHalController` had no `tool` handler. Every other `$#` line type is echoed. The result was that `$#` in the gSender console appeared to report **no tool table at all**, while telnet to the same controller showed all 32 entries — which made the offsets driving the badge impossible to inspect from within gSender. Now emitted like `parameters`, `feedback`, and the rest.

## `[PRB:]` no longer overwrites cached tool offsets, and the refresh gaps it was hiding are closed

`GrblHalRunner` copied successful `[PRB:]` results into the current tool's `toolOffsets` in the cached tool table. A probe result is a machine coordinate, not a tool offset; the two coincide only under the trigger-position scheme above. It also fired on **any** successful probe, including an ordinary workpiece Z touch off, overwriting the current tool's real offset with an unrelated coordinate.

The comment on that code said it was needed to update offsets "mid tool change or toolpath", and it was — but by inferring a value rather than reading one, and the inferred value was only coincidentally close to right. Removing it exposed two places where the tool table was genuinely never refreshed, both fixed here:

- **`loadTool()` did not send `$#`.** It was the only ATC action that didn't; `unloadTool()`, `releaseToolFromSpindle()` and `loadAndSaveToRack()` all do. `M6` runs the tool change macro, which probes the tool and writes its offset with `G10 L1`, so a freshly probed tool kept its pre-probe offset in the cache and showed as unprobed until some unrelated action happened to refresh it.
- **A job containing `M6` left the table stale.** `$#` can't be injected mid-stream without disturbing the sender's character-counted buffer accounting, so it is now sent once from the `sender.on('end')` handler when `toolChanges > 0`. Skipped in check mode, where the file isn't executed and no offsets are written.

Net effect: cached offsets are always read back from the controller rather than inferred from a probe result.

## Testing

On a SuperLongBoard (grblHAL 1.1f, `N_TOOLS=32`) with a macro-driven ATC storing positive offsets:

- Zeroed the tool table with `G10 L1 P<n> Z0`, confirmed all tools read unprobed, re-probed and confirmed they flip to probed with the offset shown.
- Loaded an off-rack tool (`M6 T11`) through the manual load flow; the macro probed it, `$#` reported `[T:11|0.000,0.000,40.875,...]`, and the badge now updates without any further action.
- `$#` lists the tool table in the gSender console.
