### PR TITLE
WIP: Surface an unapplied tool length offset in the DRO

### DIFF
--- a/src/app/src/features/DRO/component/ToolOffsetWarning.tsx
+++ b/src/app/src/features/DRO/component/ToolOffsetWarning.tsx
@@ -1,0 +1,41 @@
+import { AlertTriangle } from 'lucide-react';
+
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from 'app/components/shadcn/Tooltip';
+
+import { useToolOffsetApplied } from '../utils/useToolOffsetApplied';
+
+export function ToolOffsetWarning() {
+    const toolOffsetApplied = useToolOffsetApplied();
+
+    if (toolOffsetApplied) {
+        return null;
+    }
+
+    return (
+        <TooltipProvider delayDuration={300}>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <div
+                        className="flex flex-row gap-1 items-center justify-center py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-500 cursor-default"
+                        role="status"
+                    >
+                        <AlertTriangle className="w-3 h-3 shrink-0" />
+                        <span>Tool offset not applied</span>
+                    </div>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-72">
+                    The loaded tool has a length in the tool table, but the
+                    controller is in G49 so the work Z below does not include
+                    it. Run a tool change or send G43 to apply it, and set a
+                    startup line ($N0=G43) to have it re-applied automatically
+                    after homing.
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}

--- a/src/app/src/features/DRO/index.tsx
+++ b/src/app/src/features/DRO/index.tsx
@@ -46,6 +46,7 @@ import {
 } from 'app/components/shadcn/AlertDialog';
 import { UnitBadge } from 'app/features/DRO/component/UnitBadge.tsx';
 import { Parking } from 'app/features/DRO/component/Parking.tsx';
+import { ToolOffsetWarning } from 'app/features/DRO/component/ToolOffsetWarning.tsx';
 
 import useKeybinding from 'app/lib/useKeybinding';
 import useShuttleEvents from 'app/hooks/useShuttleEvents';
@@ -434,6 +435,7 @@ function DRO({
                     homingEnabled={homingEnabled}
                 />
             </div>
+            <ToolOffsetWarning />
             <div className="w-full flex flex-row justify-between px-3 max-xl:px-5 max-xl:-mt-[4px] max-xl:-mb-[4px]">
                 <Label>{homingMode ? 'Home' : 'Zero'}</Label>
                 <Label>Go to</Label>

--- a/src/app/src/features/DRO/utils/useToolOffsetApplied.ts
+++ b/src/app/src/features/DRO/utils/useToolOffsetApplied.ts
@@ -1,0 +1,46 @@
+import get from 'lodash/get';
+
+import { GRBLHAL } from 'app/constants';
+import { useTypedSelector } from 'app/hooks/useTypedSelector';
+import { RootState } from 'app/store/redux';
+
+/*
+ * grblHAL clears the applied tool length offset on a cold start, but the tool table and
+ * (with $485) the current tool number both survive in NVS. The controller then reports a
+ * tool with a known length while G49 is active, so the work Z the DRO shows is short by
+ * that tool's offset until something issues a G43. Nothing re-applies it automatically -
+ * that is what a startup line ($N0=G43) or a tool change macro is for.
+ */
+export function useToolOffsetApplied(): boolean {
+    const controllerType = useTypedSelector(
+        (state: RootState) => state.controller.type,
+    );
+    const hasHomed = useTypedSelector(
+        (state: RootState) => state.controller.hasHomed,
+    );
+    const tlo = useTypedSelector((state: RootState) => state.controller.modal.tlo);
+    const currentTool = useTypedSelector(
+        (state: RootState) => state.controller.state.status?.currentTool,
+    );
+    const toolTable = useTypedSelector(
+        (state: RootState) => state.controller.settings.toolTable,
+    );
+
+    // Only warn on a G49 we have actually seen in a parser state report. G43.1/G43.2 apply
+    // an offset the tool table knows nothing about, and an undefined tlo means no $G reply
+    // has landed yet, so neither is grounds for calling the offset missing.
+    if (controllerType !== GRBLHAL || !hasHomed || tlo !== 'G49') {
+        return true;
+    }
+
+    if (!currentTool || currentTool <= 0) {
+        return true;
+    }
+
+    const toolLength = Number(
+        get(toolTable, [currentTool, 'toolOffsets', 'z'], 0),
+    );
+
+    // A zero or unreadable length gives us nothing to warn about
+    return !toolLength;
+}

--- a/src/app/src/lib/definitions/gcode_virtualization.ts
+++ b/src/app/src/lib/definitions/gcode_virtualization.ts
@@ -20,7 +20,7 @@ export type FEEDRATE = 'G93' | 'G94' | 'G95';
 // Cutter Radius Compensation
 export type CUTTER = `G${string}`;
 // Tool Length Offset
-export type TLO = 'G43.1' | 'G49';
+export type TLO = 'G43' | 'G43.1' | 'G43.2' | 'G49';
 // Program Mode
 export type PROGRAM = 'M0' | 'M1' | 'M2' | 'M30';
 // Spingle State

--- a/src/server/controllers/Grbl/constants.js
+++ b/src/server/controllers/Grbl/constants.js
@@ -70,6 +70,10 @@ export const GRBL_MODAL_GROUPS = [
         group: 'feedrate',
         modes: ['G93', 'G94']
     },
+    { // Tool Length Offset (Defaults to G49)
+        group: 'tlo',
+        modes: ['G43.1', 'G49']
+    },
     { // Program Mode (Defaults to M0)
         group: 'program',
         modes: ['M0', 'M1', 'M2', 'M30']

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -2604,8 +2604,9 @@ class GrblHalController {
             (cmd === GRBLHAL_REALTIME_COMMANDS.COMPLETE_REALTIME_REPORT) ||
             this.actionMask.replyStatusReport;
 
+        // GCODE_REPORT carries a trailing newline, so it can never match the trimmed command
         this.actionMask.replyParserState =
-            (cmd === GRBLHAL_REALTIME_COMMANDS.GCODE_REPORT) ||
+            (cmd === GRBLHAL_REALTIME_COMMANDS.GCODE_REPORT.trim()) ||
             this.actionMask.replyParserState;
 
         this.connection.write(data, {

--- a/src/server/controllers/Grblhal/constants.js
+++ b/src/server/controllers/Grblhal/constants.js
@@ -82,6 +82,10 @@ export const GRBL_HAL_MODAL_GROUPS = [
         group: 'feedrate',
         modes: ['G93', 'G94']
     },
+    { // Tool Length Offset (Defaults to G49)
+        group: 'tlo',
+        modes: ['G43', 'G43.1', 'G43.2', 'G49']
+    },
     { // Program Mode (Defaults to M0)
         group: 'program',
         modes: ['M0', 'M1', 'M2', 'M30']


### PR DESCRIPTION
## The problem

After a fresh power-on, grblHAL zeroes the applied tool length offset. The tool table survives in NVS, and with `$485` the current tool number does too, but the *applied* offset does not: `gc_init()` memsets the parser state on a cold start, leaving G49 active.

The result is a controller that reports `T:1` with a perfectly good length sitting in tool table slot 1, while measuring from the spindle gauge line. Nothing re-applies the offset on its own. On my machine the Z DRO read 14.635mm short until I re-probed the tool, because the probe macro ends with a `G43` and that was the only thing putting the offset back.

This is not a display-only issue. The machine moves wrong too. Anything that just folds the TLO into the readout would make the DRO lie in the other direction.

## Why gSender could not see it

`GRBL_MODAL_GROUPS` and `GRBL_HAL_MODAL_GROUPS` had no group for the tool length offset words. `GrblLineParserResultParserState` / `GrblHalLineParserResultParserState` match each `$G` word against those tables and `continue` on a miss, so `G43`, `G43.1`, `G43.2` and `G49` were parsed and then discarded. gSender had the tool table, the current tool and the TLO parameter all in hand and still had no way to know the offset was not applied.

## Changes

- Add a `tlo` modal group to both controllers (`G43`/`G43.1`/`G43.2`/`G49` for grblHAL, `G43.1`/`G49` for grbl). These words were already being received and thrown away; they now populate `controller.modal.tlo`.
- Widen the `TLO` type to match what grblHAL actually reports (`report.c` emits `G43`, `G43.1` and `G43.2`, not just `G43.1`).
- Add a `ToolOffsetWarning` banner to the DRO, backed by a `useToolOffsetApplied` hook.
- Fix the `$G` echo in `GrblHalController.write()`. `replyParserState` was compared against `GRBLHAL_REALTIME_COMMANDS.GCODE_REPORT`, which is `'$G\n'`, but `cmd` has already been trimmed, so the comparison could never be true and a manually typed `$G` printed nothing at all. The grbl controller uses a literal `'$G'` and was unaffected; the grblHAL side regressed when the literal was swapped for the constant.

## When the warning fires

Only when every one of these holds:

- controller is grblHAL
- the machine has homed
- `T:` reports a tool above zero
- that tool's table entry has a non-zero Z offset
- `modal.tlo` is a `G49` that has actually been observed in a `[GC:]` report

No G-code is sent. It is a warning only.

## Deliberately not doing

**No automatic `G43`.** The real fix belongs in firmware, as a startup line (`$N0=G43` re-applies the persisted tool's offset after every successful `$H`, since a bare `G43` defaults its H word to the current tool). Having gSender inject the command would paper over exactly the kind of missing configuration this is meant to reveal.

`modal.tlo` is intentionally left undefined until a real parser-state report arrives, rather than defaulting to `G49`. Every path where we do not actually know resolves to no warning: no `[GC:]` reply yet, `G43.1`/`G43.2` dynamic offsets that the tool table knows nothing about, plain grbl, unhomed, tool 0, or a zero/unreadable table entry.

## Testing status

Untested on hardware beyond the diagnosis itself. Marking as draft.
