### PR TITLE
Plugin system enhancements: host visualizer bridge and plugin busy state

### DIFF
--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -99,6 +99,7 @@ viewer.focusToModel();
 |-----|-------------|
 | `gsender.machine.getContext()` | Current machine / controller context |
 | `gsender.machine.command(cmd, ...args)` | Run a host machine command |
+| `gsender.machine.setBusy(busy, label?)` | Flag the machine as busy for a feeder-driven op (stable status, host auto-releases) |
 | `gsender.workspace.getState()` | One-shot workspace snapshot |
 | `gsender.redux.getState()` | One-shot full Redux state |
 | `gsender.gcode.loadToVisualizer(gcode, name?)` | Load G-code into the main visualizer/job |

--- a/packages/plugin-sdk/src/bridge.ts
+++ b/packages/plugin-sdk/src/bridge.ts
@@ -3,11 +3,51 @@ export const PLUGIN_BRIDGE_CHANNEL = "gsender:plugin-bridge";
 export type PluginBridgeRequestType =
 	| "machine:get:context"
 	| "machine:command"
+	| "machine:busy:set"
 	| "gcode:load:to:visualizer"
 	| "workspace:get:state"
-	| "redux:get:state";
+	| "redux:get:state"
+	| "viewer:screen-to-world"
+	| "viewer:world-to-screen"
+	| "viewer:camera:set"
+	| "viewer:camera:lock-rotate"
+	| "viewer:pick:arm"
+	| "viewer:pick:disarm"
+	| "viewer:overlay:set";
 
-export type PluginBridgeTopic = "workspace" | "redux";
+export type PluginBridgeTopic = "workspace" | "redux" | "viewer";
+
+// --- Viewer bridge types ------------------------------------------------------
+// Shared shapes for the `viewer:*` surface. The host defines identical types on
+// its end of the bridge — keep these exactly in sync with that contract.
+
+/** Camera presets accepted by `viewer:camera:set`. */
+export type CameraView = "top" | "3d" | "front" | "left" | "right";
+
+/**
+ * A marker drawn on the host visualizer's overlay via `viewer:overlay:set`.
+ * Coordinates are in world space (the same space `screenToWorld` returns).
+ */
+export interface OverlayMarker {
+	id: string;
+	x: number;
+	y: number;
+	z?: number; // world coordinates
+	shape?: "circle" | "cross" | "ring"; // default 'circle'
+	color?: string; // CSS color
+	size?: number; // px, default 6
+	label?: string;
+}
+
+/** Events pushed on the `"viewer"` topic while a pick is armed. */
+export type ViewerPickEvent =
+	| {
+			kind: "pick";
+			world: { x: number; y: number; z: number };
+			screen: { x: number; y: number };
+	  }
+	// 0..1 while a press-and-hold pick is in progress
+	| { kind: "hold-progress"; t: number };
 
 export type PluginBridgeRequest = {
 	id: string;

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,12 +1,22 @@
 export {
+	type CameraView,
+	type OverlayMarker,
 	PLUGIN_BRIDGE_CHANNEL,
 	type PluginBridgeRequest,
 	type PluginBridgeRequestType,
 	type PluginBridgeResponse,
 	type PluginBridgeTopic,
+	type ViewerPickEvent,
 } from "./bridge.js";
 
-import { getTopicSnapshot, request, subscribeTopic } from "./bridge.js";
+import {
+	type CameraView,
+	getTopicSnapshot,
+	type OverlayMarker,
+	request,
+	subscribeTopic,
+	type ViewerPickEvent,
+} from "./bridge.js";
 
 // --- Imperative client --------------------------------------------------------
 
@@ -14,6 +24,18 @@ export type GsenderClient = {
 	machine: {
 		getContext: () => Promise<unknown>;
 		command: (cmd: string, ...args: unknown[]) => Promise<unknown>;
+		/**
+		 * Flag the machine as busy (or clear it) for the span of an operation the
+		 * plugin drives through {@link machine.command}('gcode', …). While set, the
+		 * host holds a stable "running" status instead of letting it flicker Idle as
+		 * the feeder drains between moves — without replacing the loaded job.
+		 *
+		 * The host owns release: after `setBusy(true)` it watches the controller and
+		 * auto-clears once the machine has genuinely returned to idle, so calling
+		 * `setBusy(false)` is optional (a useful backstop on unmount/abort). Pass an
+		 * optional `label` to show in place of the status (e.g. the operation name).
+		 */
+		setBusy: (busy: boolean, label?: string) => Promise<void>;
 	};
 	workspace: {
 		getState: () => Promise<unknown>;
@@ -25,12 +47,47 @@ export type GsenderClient = {
 		/** Load a raw G-code program into gSender's main visualizer/job. */
 		loadToVisualizer: (gcode: string, name?: string) => Promise<unknown>;
 	};
+	viewer: {
+		/** Project a screen pixel onto the visualizer's work plane. */
+		screenToWorld: (
+			px: number,
+			py: number,
+		) => Promise<{ x: number; y: number; z: number } | null>;
+		/** Project a world coordinate to a screen pixel. */
+		worldToScreen: (
+			x: number,
+			y: number,
+			z?: number,
+		) => Promise<{ x: number; y: number } | null>;
+		camera: {
+			/** Snap the host camera to a preset view. */
+			set: (view: CameraView) => Promise<void>;
+			/** Lock/unlock camera rotation on the host visualizer. */
+			lockRotate: (locked: boolean) => Promise<void>;
+		};
+		/**
+		 * Arm point-picking on the host visualizer. Subscribes to pick events
+		 * first, then arms; resolves to a disposer that disarms and unsubscribes.
+		 * Rejects if the host refuses to arm (see preconditions in the README).
+		 */
+		armPick: (
+			mode: "click" | "hold",
+			cb: (e: ViewerPickEvent) => void,
+		) => Promise<() => void>;
+		/** Disarm point-picking (fire-and-forget on the host). */
+		disarmPick: () => Promise<void>;
+		/** Replace the overlay markers drawn on the host visualizer. */
+		setOverlay: (markers: OverlayMarker[]) => Promise<void>;
+	};
 };
 
 export const createGsenderClient = (): GsenderClient => ({
 	machine: {
 		getContext: () => request("machine:get:context"),
 		command: (cmd, ...args) => request("machine:command", { cmd, args }),
+		setBusy: async (busy, label) => {
+			await request("machine:busy:set", { busy, label });
+		},
 	},
 	workspace: {
 		getState: () => request("workspace:get:state"),
@@ -41,6 +98,57 @@ export const createGsenderClient = (): GsenderClient => ({
 	gcode: {
 		loadToVisualizer: (gcode, name) =>
 			request("gcode:load:to:visualizer", { gcode, name }),
+	},
+	viewer: {
+		screenToWorld: (px, py) =>
+			request<{ x: number; y: number; z: number } | null>(
+				"viewer:screen-to-world",
+				{ px, py },
+			),
+		worldToScreen: (x, y, z) =>
+			request<{ x: number; y: number } | null>("viewer:world-to-screen", {
+				x,
+				y,
+				z,
+			}),
+		camera: {
+			set: async (view) => {
+				await request("viewer:camera:set", { view });
+			},
+			lockRotate: async (locked) => {
+				await request("viewer:camera:lock-rotate", { locked });
+			},
+		},
+		armPick: async (mode, cb) => {
+			// Subscribe FIRST so no pick event is missed between arm and the
+			// first host push.
+			const notify = () => {
+				const event = getTopicSnapshot<ViewerPickEvent>("viewer");
+				if (event !== undefined) {
+					cb(event);
+				}
+			};
+			const unsubscribe = subscribeTopic("viewer", notify);
+
+			try {
+				await request("viewer:pick:arm", { mode });
+			} catch (error) {
+				unsubscribe();
+				throw error;
+			}
+
+			return () => {
+				unsubscribe();
+				// Fire-and-forget; swallow errors (host may already be gone).
+				request("viewer:pick:disarm").catch(() => {});
+			};
+		},
+		disarmPick: async () => {
+			await request("viewer:pick:disarm");
+		},
+		setOverlay: async (markers) => {
+			await request("viewer:overlay:set", { markers });
+		},
 	},
 });
 

--- a/packages/plugin-sdk/src/react.ts
+++ b/packages/plugin-sdk/src/react.ts
@@ -1,10 +1,18 @@
-import { useCallback, useRef, useSyncExternalStore } from "react";
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 
 import {
 	getTopicSnapshot,
 	type PluginBridgeTopic,
 	subscribeTopic,
+	type ViewerPickEvent,
 } from "./bridge.js";
+import { gsender } from "./index.js";
 
 // --- React hooks --------------------------------------------------------------
 // These run in the plugin's OWN React. They mirror gSender's `useWorkspaceState`
@@ -63,4 +71,70 @@ export const useTypedSelector = <Selected, State = unknown>(
 
 	lastSelected.current = { value: nextSelected };
 	return nextSelected;
+};
+
+/**
+ * Arm point-picking on the host visualizer for the lifetime of the component.
+ *
+ * Arms on mount (unless `opts.enabled === false`) and disarms on unmount or when
+ * disabled. The latest `handler` is kept in a ref, so re-renders that only change
+ * the handler don't re-arm the pick.
+ *
+ * @param mode `'click'` (single click) or `'hold'` (press-and-hold, which also
+ *   emits `hold-progress` events).
+ * @param handler Called with each `ViewerPickEvent` while armed.
+ * @param opts.enabled Set `false` to keep the pick disarmed (default `true`).
+ * @returns `armed` (whether the host accepted the arm) and `error` (the host's
+ *   rejection message, or `null`).
+ */
+export const useVisualizerPick = (
+	mode: "click" | "hold",
+	handler: (e: ViewerPickEvent) => void,
+	opts?: { enabled?: boolean },
+): { armed: boolean; error: string | null } => {
+	const enabled = opts?.enabled !== false;
+
+	const [armed, setArmed] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// Keep the latest handler without re-arming when it changes.
+	const handlerRef = useRef(handler);
+	handlerRef.current = handler;
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
+		let cancelled = false;
+		let dispose: (() => void) | null = null;
+
+		gsender.viewer
+			.armPick(mode, (event) => handlerRef.current(event))
+			.then((disposer) => {
+				if (cancelled) {
+					// Unmounted/disabled before arming resolved — tear down now.
+					disposer();
+					return;
+				}
+				dispose = disposer;
+				setArmed(true);
+				setError(null);
+			})
+			.catch((err: unknown) => {
+				if (cancelled) {
+					return;
+				}
+				setArmed(false);
+				setError(err instanceof Error ? err.message : String(err));
+			});
+
+		return () => {
+			cancelled = true;
+			setArmed(false);
+			dispose?.();
+		};
+	}, [mode, enabled]);
+
+	return { armed, error };
 };

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -146,3 +146,103 @@ viewer.focusToModel();
 ```
 
 Install the peers in the plugin: `npm install @sienci/gviewer three`.
+
+### Host visualizer bridge (`gsender.viewer`)
+
+Distinct from the embedded G-code preview above, the `gsender.viewer.*` API lets a
+plugin drive gSender's **main** visualizer over the bridge: pick points on the
+loaded toolpath, draw markers on it, and control the host camera. It's part of the
+base client (`@sienci/gsender-plugin-sdk`) — no bundler or extra peers required.
+
+#### `visualizer-overlay` contribution slot
+
+To surface a plugin over the main visualizer, declare a `visualizer-overlay`
+contribution in `gsender-plugin.json`:
+
+```json
+{
+	"contributions": [
+		{ "slot": "visualizer-overlay", "label": "Corner Finder", "icon": "target" }
+	]
+}
+```
+
+The host shows a floating toggle button (using your `label`/`icon`) on the main
+visualizer; clicking it opens the plugin panel docked over the canvas, where your
+UI can call the `gsender.viewer.*` API against the visualizer behind it.
+
+#### API
+
+| Method | Description |
+|--------|-------------|
+| `viewer.screenToWorld(px, py)` | Project a screen pixel to world `{x,y,z}` (or `null`). |
+| `viewer.worldToScreen(x, y, z?)` | Project a world point to a screen pixel `{x,y}` (or `null`). |
+| `viewer.camera.set(view)` | Snap the camera to `'top' \| '3d' \| 'front' \| 'left' \| 'right'`. |
+| `viewer.camera.lockRotate(locked)` | Lock/unlock camera rotation. |
+| `viewer.armPick(mode, cb)` | Arm point-picking (`'click'` or `'hold'`); resolves to a disposer. |
+| `viewer.disarmPick()` | Disarm point-picking. |
+| `viewer.setOverlay(markers)` | Replace the overlay markers drawn on the visualizer. |
+
+`armPick` subscribes to pick events **before** arming (so none are missed) and
+resolves to a disposer that both disarms and unsubscribes — call it when you're
+done. The callback receives `ViewerPickEvent`s:
+
+- `{ kind: 'pick', world: {x,y,z}, screen: {x,y} }` — a point was picked.
+- `{ kind: 'hold-progress', t }` — `t` runs `0..1` while a press-and-hold is in progress.
+
+Overlay markers use the shared `OverlayMarker` shape (world coordinates):
+
+```ts
+interface OverlayMarker {
+	id: string;
+	x: number; y: number; z?: number;    // world coordinates
+	shape?: "circle" | "cross" | "ring"; // default "circle"
+	color?: string;                       // CSS color
+	size?: number;                        // px, default 6
+	label?: string;
+}
+```
+
+**Example** — arm a click pick, drop a marker where the user clicks, then jump the
+camera to top:
+
+```ts
+import { gsender } from "@sienci/gsender-plugin-sdk";
+
+const dispose = await gsender.viewer.armPick("click", async (e) => {
+	if (e.kind !== "pick") return;
+	await gsender.viewer.setOverlay([
+		{ id: "hit", x: e.world.x, y: e.world.y, shape: "cross", color: "#f0f" },
+	]);
+	await gsender.viewer.camera.set("top");
+	dispose(); // one-shot: disarm after the first pick
+});
+```
+
+#### `useVisualizerPick` (React)
+
+```tsx
+import { useVisualizerPick } from "@sienci/gsender-plugin-sdk/react";
+
+function CornerFinder() {
+	const { armed, error } = useVisualizerPick("click", (e) => {
+		if (e.kind === "pick") console.log("picked", e.world);
+	});
+
+	if (error) return <p>Can't pick: {error}</p>;
+	return <p>{armed ? "Click a point on the visualizer…" : "Arming…"}</p>;
+}
+```
+
+It arms on mount (unless `opts.enabled === false`), disarms on unmount/disable,
+keeps the latest `handler` in a ref (re-renders don't re-arm), and reports whether
+arming succeeded (`armed`) plus the host's rejection message (`error`).
+
+#### Arming preconditions
+
+`armPick` / `useVisualizerPick` **reject** unless all of the following hold. The
+rejection surfaces as the thrown/`error` message from the host:
+
+- the primary visualizer is mounted,
+- the loaded file is **not** rotary, and
+- the machine is **connected and idle**.

--- a/src/app/src/features/MachineStatus/MachineStatus.tsx
+++ b/src/app/src/features/MachineStatus/MachineStatus.tsx
@@ -52,6 +52,11 @@ interface MachineStatusProps {
 	activeState: GRBL_ACTIVE_STATES_T | null;
 	isConnected: boolean;
 	port: string | null;
+	// A plugin can assert the machine is busy for the span of a feeder-driven
+	// operation; while set, we hold a stable "running" status instead of letting
+	// the pill flicker Idle as the feeder drains between moves.
+	pluginBusy: boolean;
+	pluginBusyLabel: string | null;
 }
 
 interface Message {
@@ -68,6 +73,8 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
 	alarmCode,
 	isConnected,
 	port,
+	pluginBusy,
+	pluginBusyLabel,
 }) => {
 	const isPortOpen = isConnected || !!port;
 	const [hasFreshControllerState, setHasFreshControllerState] = useState(
@@ -75,6 +82,18 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
 	);
 	const displayActiveState =
 		isPortOpen && hasFreshControllerState ? activeState : null;
+
+	// A plugin-asserted busy latch shows a stable label across the whole operation
+	// instead of letting the pill alternate "Running"/label as the feeder drains
+	// between moves. It only overrides the normal operational states (Idle/Run/
+	// Jog/Check) — safety-relevant states like Alarm/Hold/Door/Tool must always
+	// show through.
+	const showPluginBusy =
+		pluginBusy &&
+		(displayActiveState === GRBL_ACTIVE_STATE_IDLE ||
+			displayActiveState === GRBL_ACTIVE_STATE_RUN ||
+			displayActiveState === GRBL_ACTIVE_STATE_JOG ||
+			displayActiveState === GRBL_ACTIVE_STATE_CHECK);
 
 	useEffect(() => {
 		if (!isPortOpen) {
@@ -160,11 +179,13 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
 						{
 							"text-white bg-gray-800": !displayActiveState,
 							"bg-gray-500 text-white":
-								displayActiveState === GRBL_ACTIVE_STATE_IDLE,
+								displayActiveState === GRBL_ACTIVE_STATE_IDLE &&
+								!showPluginBusy,
 							"bg-green-600 text-white":
 								displayActiveState === GRBL_ACTIVE_STATE_RUN ||
 								displayActiveState === GRBL_ACTIVE_STATE_JOG ||
-								displayActiveState === GRBL_ACTIVE_STATE_CHECK,
+								displayActiveState === GRBL_ACTIVE_STATE_CHECK ||
+								showPluginBusy,
 							"bg-blue-500 text-white":
 								displayActiveState === GRBL_ACTIVE_STATE_HOME,
 							"bg-yellow-600 text-white":
@@ -193,7 +214,9 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
 								</div>
 							) : (
 								<span className="flex w-full font-light text-3xl max-sm:text-base sm:text-normal mb-1 justify-center">
-									{message[displayActiveState]}
+									{showPluginBusy
+										? (pluginBusyLabel ?? "Running")
+										: message[displayActiveState]}
 								</span>
 							)}
 						</>
@@ -231,11 +254,15 @@ export default connect((store) => {
 	const activeState = get(store, "controller.state.status.activeState", null);
 	const isConnected = get(store, "connection.isConnected", false);
 	const port = get(store, "connection.port", null);
+	const pluginBusy = get(store, "pluginState.busy", false);
+	const pluginBusyLabel = get(store, "pluginState.label", null);
 	return {
 		$22,
 		alarmCode,
 		activeState,
 		isConnected,
 		port,
+		pluginBusy,
+		pluginBusyLabel,
 	};
 })(MachineStatus);

--- a/src/app/src/features/Plugins/components/PluginVisualizerOverlayHost.tsx
+++ b/src/app/src/features/Plugins/components/PluginVisualizerOverlayHost.tsx
@@ -1,0 +1,187 @@
+import { Tooltip } from "app/components/Tooltip";
+import { GRBL_ACTIVE_STATE_IDLE } from "app/constants";
+import { visualizerBridge } from "app/features/Visualizer/visualizerBridge";
+import { useTypedSelector } from "app/hooks/useTypedSelector";
+import cx from "classnames";
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { PiPuzzlePiece } from "react-icons/pi";
+
+import { usePlugins } from "../hooks/usePlugins";
+import type { PluginContribution, PluginRecord } from "../types";
+import PluginPanel from "./PluginPanel";
+
+// Geometry of the stacked floating toggles, matching the lightweight toggle in
+// the Visualizer. Each overlay-plugin toggle stacks upward from the base button.
+const BUTTON_SIZE_PX = 44; // h-11 / w-11
+const CONTROL_GAP_PX = 12;
+
+type Props = {
+	// Bottom offset (px) of the lightweight toggle — overlay buttons stack above it.
+	baseBottomPx: number;
+	// Shared left offset (px) of the floating toggle column.
+	leftPx: number;
+};
+
+const getOverlayContribution = (
+	plugin: PluginRecord,
+): PluginContribution | undefined =>
+	plugin.contributions.find((c) => c.slot === "visualizer-overlay");
+
+// Wraps the plugin iframe panel. On unmount (toggle off, plugin disabled, viewer
+// teardown) it defensively disarms any pick the plugin left armed and clears its
+// overlay markers so a closed plugin can't leave the viewer armed or littered.
+const OverlayPanel = ({
+	plugin,
+	title,
+	onClose,
+}: {
+	plugin: PluginRecord;
+	title: string;
+	onClose: () => void;
+}) => {
+	useEffect(() => {
+		return () => {
+			const handle = visualizerBridge.get();
+			handle?.disarmPick();
+			handle?.setOverlay([]);
+		};
+	}, []);
+
+	return (
+		<div className="absolute right-4 top-4 bottom-4 z-[10001] flex w-80 max-w-[calc(100%-2rem)] flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-[0_10px_30px_rgba(0,_0,_0,_0.35)] dark:border-dark-lighter dark:bg-dark">
+			<div className="flex items-center justify-between border-b border-gray-200 px-3 py-2 dark:border-dark-lighter">
+				<span className="truncate text-sm font-medium text-gray-700 dark:text-gray-200">
+					{title}
+				</span>
+				<button
+					type="button"
+					aria-label="Close plugin"
+					className="inline-flex h-6 w-6 items-center justify-center rounded text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-dark-lighter dark:hover:text-gray-100"
+					onClick={onClose}
+				>
+					<X aria-hidden="true" className="h-4 w-4" />
+				</button>
+			</div>
+			<div className="min-h-0 flex-1 p-2">
+				<PluginPanel plugin={plugin} />
+			</div>
+		</div>
+	);
+};
+
+// Renders a floating toggle button per visualizer-overlay plugin. Toggling a
+// button on mounts that plugin's sandboxed iframe as a floating panel over the
+// canvas; toggling off unmounts it. The iframe talks to the host through the
+// existing global plugin bridge (viewer:* requests / "viewer" topic), so no
+// per-panel wiring is needed here.
+const PluginVisualizerOverlayHost = ({ baseBottomPx, leftPx }: Props) => {
+	const { visualizerOverlayPlugins } = usePlugins();
+	// Only one overlay plugin may be open at a time. The viewer exposes a single
+	// shared surface (one armed pick, one overlay marker list, one camera), so two
+	// open plugins would fight over it and their panels would render on top of each
+	// other. Opening a plugin closes any other; enforcing exclusivity here means
+	// every current and future overlay plugin inherits it without extra wiring.
+	const [openId, setOpenId] = useState<string | null>(null);
+
+	// Whether the machine can currently accept a motion command. Toggles for
+	// plugins that declare `requiresIdle` are greyed out and non-interactive
+	// unless this holds (disconnected, cutting, hold, alarm, jog, etc. all gate).
+	const isConnected = useTypedSelector((state) => state.connection.isConnected);
+	const activeState = useTypedSelector(
+		(state) => state.controller.state?.status?.activeState,
+	);
+	const machineReady = isConnected && activeState === GRBL_ACTIVE_STATE_IDLE;
+
+	// Drop open state if the open plugin is no longer available (disabled/removed).
+	useEffect(() => {
+		setOpenId((prev) =>
+			prev && visualizerOverlayPlugins.some((p) => p.id === prev)
+				? prev
+				: null,
+		);
+	}, [visualizerOverlayPlugins]);
+
+	if (visualizerOverlayPlugins.length === 0) {
+		return null;
+	}
+
+	// Toggle a plugin, closing any other that was open (mutual exclusion).
+	const toggle = (id: string) => {
+		setOpenId((prev) => (prev === id ? null : id));
+	};
+
+	return (
+		<>
+			{visualizerOverlayPlugins.map((plugin, index) => {
+				const contribution = getOverlayContribution(plugin);
+				const label = contribution?.label || plugin.name;
+				const isOpen = openId === plugin.id;
+				// Grey out and block a motion plugin's toggle when the machine can't
+				// accept the command. Keep an already-open panel's toggle live so it
+				// can still be closed (the panel itself surfaces the "not idle" state).
+				const gated = !!contribution?.requiresIdle && !machineReady && !isOpen;
+				// Stack each toggle one button-height above the previous.
+				const bottom =
+					baseBottomPx + (index + 1) * (BUTTON_SIZE_PX + CONTROL_GAP_PX);
+
+				return (
+					<div key={plugin.id}>
+						<Tooltip
+							content={gated ? `${label} — machine must be idle` : label}
+							side="top"
+						>
+							<button
+								type="button"
+								style={{ left: leftPx, bottom }}
+								className={cx(
+									"absolute z-[10000] inline-flex h-11 w-11 -translate-x-1/2 items-center justify-center rounded-full border bg-dark-darker/70 shadow-[0_10px_30px_rgba(0,_0,_0,_0.25)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-dark-darker active:scale-[0.98] active:bg-dark-darker/85 mb-5",
+									{
+										"border-[rgba(14,_246,_174,_0.95)] text-[rgba(14,_246,_174,_0.95)] shadow-[0_0_0_1px_rgba(14,_246,_174,_0.35),0_10px_30px_rgba(0,_0,_0,_0.35)] hover:border-[rgba(14,_246,_174,_0.95)] hover:text-[rgba(14,_246,_174,_0.95)] hover:shadow-[0_0_0_1px_rgba(14,_246,_174,_0.45),0_12px_32px_rgba(0,_0,_0,_0.4)]":
+											isOpen,
+										"border-gray-400/40 text-gray-300 hover:border-gray-200/70 hover:text-gray-100 hover:shadow-[0_12px_32px_rgba(0,_0,_0,_0.35)]":
+											!isOpen && !gated,
+										"cursor-not-allowed border-gray-600/30 text-gray-500 opacity-40":
+											gated,
+									},
+								)}
+								aria-label={label}
+								aria-pressed={isOpen}
+								aria-disabled={gated}
+								onClick={() => {
+									if (!gated) {
+										toggle(plugin.id);
+									}
+								}}
+							>
+								{contribution?.icon ? (
+									<span
+										aria-hidden="true"
+										className="pointer-events-none text-lg leading-none"
+									>
+										{contribution.icon}
+									</span>
+								) : (
+									<PiPuzzlePiece
+										aria-hidden="true"
+										className="pointer-events-none h-5 w-5 shrink-0"
+									/>
+								)}
+							</button>
+						</Tooltip>
+
+						{isOpen && (
+							<OverlayPanel
+								plugin={plugin}
+								title={label}
+								onClose={() => toggle(plugin.id)}
+							/>
+						)}
+					</div>
+				);
+			})}
+		</>
+	);
+};
+
+export default PluginVisualizerOverlayHost;

--- a/src/app/src/features/Plugins/hooks/usePlugins.ts
+++ b/src/app/src/features/Plugins/hooks/usePlugins.ts
@@ -57,6 +57,10 @@ export const usePlugins = () => {
 		p.contributions.some((c) => c.slot === "tools-tab"),
 	);
 
+	const visualizerOverlayPlugins = activePlugins.filter((p) =>
+		p.contributions.some((c) => c.slot === "visualizer-overlay"),
+	);
+
 	return {
 		plugins,
 		pluginsDir,
@@ -67,5 +71,6 @@ export const usePlugins = () => {
 		activePlugins,
 		toolsPagePlugins,
 		toolsTabPlugins,
+		visualizerOverlayPlugins,
 	};
 };

--- a/src/app/src/features/Plugins/types.ts
+++ b/src/app/src/features/Plugins/types.ts
@@ -3,13 +3,33 @@ export type PluginContributionSlot =
 	| "tools-page"
 	| "settings-section"
 	| "navbar"
-	| "standalone";
+	| "standalone"
+	| "visualizer-overlay";
+
+// A declarative marker the host draws over the visualizer canvas on behalf of
+// an overlay plugin. Coordinates are in world/scene space; the host re-projects
+// them to screen space every frame so they track camera pan/zoom. Plugins never
+// draw on the canvas themselves — they hand the host this list.
+export interface OverlayMarker {
+	id: string;
+	x: number;
+	y: number;
+	z?: number; // world coordinates
+	shape?: "circle" | "cross" | "ring"; // default 'circle'
+	color?: string; // CSS color
+	size?: number; // px, default 6
+	label?: string;
+}
 
 export type PluginContribution = {
 	slot: PluginContributionSlot;
 	label?: string;
 	route?: string;
 	icon?: string;
+	// For "visualizer-overlay" contributions that drive machine motion: when
+	// true, the host greys out and blocks the overlay toggle unless the machine
+	// is connected and idle (i.e. actually able to accept the command).
+	requiresIdle?: boolean;
 };
 
 export type PluginRecord = {
@@ -35,9 +55,17 @@ export type PluginsResponse = {
 export type PluginBridgeRequestType =
 	| "machine:get:context"
 	| "machine:command"
+	| "machine:busy:set"
 	| "workspace:get:state"
 	| "redux:get:state"
-	| "gcode:load:to:visualizer";
+	| "gcode:load:to:visualizer"
+	| "viewer:screen-to-world"
+	| "viewer:world-to-screen"
+	| "viewer:camera:set"
+	| "viewer:camera:lock-rotate"
+	| "viewer:pick:arm"
+	| "viewer:pick:disarm"
+	| "viewer:overlay:set";
 
 export type PluginBridgeRequest = {
 	id: string;
@@ -52,8 +80,10 @@ export type PluginBridgeResponse = {
 	error?: string;
 };
 
-// Reactive state that plugins can subscribe to for live updates.
-export type PluginBridgeTopic = "workspace" | "redux";
+// Reactive state that plugins can subscribe to for live updates. "viewer" is a
+// push-only event stream (pick/hold-progress events) rather than a state
+// snapshot topic.
+export type PluginBridgeTopic = "workspace" | "redux" | "viewer";
 
 export type PluginBridgeSubscribe = {
 	id: string;

--- a/src/app/src/features/Plugins/utils/pluginBridge.ts
+++ b/src/app/src/features/Plugins/utils/pluginBridge.ts
@@ -1,9 +1,13 @@
-import { VISUALIZER_PRIMARY } from "app/constants";
+import { GRBL_ACTIVE_STATE_IDLE, VISUALIZER_PRIMARY } from "app/constants";
+import type { VisualizerBridgeHandle } from "app/features/Visualizer/visualizerBridge";
+import { visualizerBridge } from "app/features/Visualizer/visualizerBridge";
 import controller from "app/lib/controller";
 import { uploadGcodeFileToServer } from "app/lib/fileupload";
 import store from "app/store";
 import reduxStore from "app/store/redux";
+import { setPluginBusy } from "app/store/redux/slices/pluginState.slice";
 import type {
+	OverlayMarker,
 	PLUGIN_BRIDGE_CHANNEL,
 	PluginBridgeRequest,
 	PluginBridgeResponse,
@@ -23,9 +27,30 @@ const getTopicSnapshot = (topic: PluginBridgeTopic): unknown => {
 			return getWorkspaceSnapshot();
 		case "redux":
 			return getReduxSnapshot();
+		// "viewer" is a push-only event stream (pick/hold-progress); there is no
+		// meaningful initial snapshot, so subscribers get null until an event fires.
+		case "viewer":
+			return null;
 		default:
 			return null;
 	}
+};
+
+const requireVisualizer = (): VisualizerBridgeHandle => {
+	const handle = visualizerBridge.get();
+	if (!handle) {
+		throw new Error("Visualizer is not available");
+	}
+	return handle;
+};
+
+// Defense-in-depth idle gate mirroring the app's `activeState === 'Idle'` checks:
+// picking drives real machine moves, so refuse unless connected and idle.
+const machineIsConnectedAndIdle = (): boolean => {
+	const state = reduxStore.getState();
+	const isConnected = !!state.connection?.isConnected;
+	const activeState = state.controller?.state?.status?.activeState;
+	return isConnected && activeState === GRBL_ACTIVE_STATE_IDLE;
 };
 
 const getMachineContext = () => {
@@ -52,15 +77,120 @@ const runMachineCommand = async (payload: Record<string, unknown> = {}) => {
 		throw new Error("cmd is required");
 	}
 
-	return new Promise((resolve, reject) => {
-		controller.command(cmd, ...args, (err: Error | null, data: unknown) => {
-			if (err) {
-				reject(err);
-				return;
-			}
-			resolve(data);
-		});
-	});
+	// `controller.command` is fire-and-forget: it emits over the socket and the
+	// server never acks (see CNCEngine `socket.on('command')`). Waiting on a
+	// callback here would hang forever — resolve once the command is dispatched.
+	controller.command(cmd, ...args);
+	return { ok: true };
+};
+
+// --- Plugin-asserted busy latch ------------------------------------------------
+// A plugin can flag the machine as busy for the whole span of a feeder-driven
+// operation (e.g. Screw Spot drilling a batch of holes). The feeder streams
+// line-by-line, so the raw controller `activeState` dips to Idle between moves
+// and the status pill would otherwise flicker. Raising this latch lets the UI
+// show a stable status without touching the loaded job (unlike a real sender
+// run, which would replace the loaded file).
+//
+// The host owns the *release* so plugins don't have to detect completion (the
+// feeder gives them no "finished" callback): once set, we watch the controller
+// and auto-clear after the machine has genuinely returned to Idle and stayed
+// there. `armed` guards against releasing during the latency between the call
+// and the first move — we only start the release countdown after we've seen the
+// machine actually leave Idle at least once.
+const BUSY_IDLE_DEBOUNCE_MS = 1500; // sustained Idle before we call it done
+const BUSY_ARM_GRACE_MS = 15000; // release if no motion ever starts
+const BUSY_MAX_MS = 15 * 60 * 1000; // absolute cap so it can never stick on
+
+let busyUnsubscribe: (() => void) | null = null;
+let busyIdleTimer: ReturnType<typeof setTimeout> | null = null;
+let busyGraceTimer: ReturnType<typeof setTimeout> | null = null;
+let busyMaxTimer: ReturnType<typeof setTimeout> | null = null;
+let busyArmed = false; // has the machine left Idle since we were set?
+
+const clearBusyTimers = () => {
+	for (const t of [busyIdleTimer, busyGraceTimer, busyMaxTimer]) {
+		if (t) {
+			clearTimeout(t);
+		}
+	}
+	busyIdleTimer = null;
+	busyGraceTimer = null;
+	busyMaxTimer = null;
+};
+
+const releasePluginBusy = () => {
+	clearBusyTimers();
+	if (busyUnsubscribe) {
+		busyUnsubscribe();
+		busyUnsubscribe = null;
+	}
+	busyArmed = false;
+	if (reduxStore.getState().pluginState?.busy) {
+		reduxStore.dispatch(setPluginBusy({ busy: false }));
+	}
+};
+
+const onBusyStateChange = () => {
+	const state = reduxStore.getState();
+	if (!state.connection?.isConnected) {
+		releasePluginBusy();
+		return;
+	}
+	const activeState = state.controller?.state?.status?.activeState;
+	const isIdle = activeState === GRBL_ACTIVE_STATE_IDLE;
+	if (!isIdle) {
+		// Machine is doing something — arm release and cancel any pending
+		// idle/grace countdowns.
+		busyArmed = true;
+		if (busyGraceTimer) {
+			clearTimeout(busyGraceTimer);
+			busyGraceTimer = null;
+		}
+		if (busyIdleTimer) {
+			clearTimeout(busyIdleTimer);
+			busyIdleTimer = null;
+		}
+		return;
+	}
+	// Idle. Only begin the release countdown once we've actually seen motion, so
+	// command/round-trip latency after setBusy(true) can't release us early.
+	if (busyArmed && !busyIdleTimer) {
+		busyIdleTimer = setTimeout(releasePluginBusy, BUSY_IDLE_DEBOUNCE_MS);
+	}
+};
+
+const setMachineBusy = async (payload: Record<string, unknown> = {}) => {
+	const busy = !!payload.busy;
+	if (!busy) {
+		releasePluginBusy();
+		return { ok: true };
+	}
+
+	const label = typeof payload.label === "string" ? payload.label : null;
+
+	// (Re)arm for a fresh operation: tear down any prior watcher/timers first.
+	clearBusyTimers();
+	if (busyUnsubscribe) {
+		busyUnsubscribe();
+		busyUnsubscribe = null;
+	}
+	busyArmed = false;
+
+	reduxStore.dispatch(setPluginBusy({ busy: true, label }));
+	busyUnsubscribe = reduxStore.subscribe(onBusyStateChange);
+	// Safety nets: drop the latch if motion never starts, and an absolute cap so
+	// a wedged operation can never leave the pill stuck "busy" forever.
+	busyGraceTimer = setTimeout(() => {
+		if (!busyArmed) {
+			releasePluginBusy();
+		}
+	}, BUSY_ARM_GRACE_MS);
+	busyMaxTimer = setTimeout(releasePluginBusy, BUSY_MAX_MS);
+	// Evaluate immediately in case the machine is already moving.
+	onBusyStateChange();
+
+	return { ok: true };
 };
 
 const loadGCodeToVisualizer = async ({
@@ -86,6 +216,8 @@ const handleBridgeRequest = async (
 			return getMachineContext();
 		case "machine:command":
 			return runMachineCommand(request.payload);
+		case "machine:busy:set":
+			return setMachineBusy(request.payload);
 		case "workspace:get:state":
 			return getWorkspaceSnapshot();
 		case "redux:get:state":
@@ -94,6 +226,70 @@ const handleBridgeRequest = async (
 			return loadGCodeToVisualizer(
 				request.payload as { gcode: string; name: string },
 			);
+		case "viewer:screen-to-world": {
+			const handle = requireVisualizer();
+			const { px, py } = (request.payload ?? {}) as { px: number; py: number };
+			return handle.screenToWorld(px, py);
+		}
+		case "viewer:world-to-screen": {
+			const handle = requireVisualizer();
+			const { x, y, z } = (request.payload ?? {}) as {
+				x: number;
+				y: number;
+				z?: number;
+			};
+			return handle.worldToScreen(x, y, z);
+		}
+		case "viewer:camera:set": {
+			const handle = requireVisualizer();
+			const { view } = (request.payload ?? {}) as {
+				view: "top" | "3d" | "front" | "left" | "right";
+			};
+			handle.setCameraView(view);
+			return { ok: true };
+		}
+		case "viewer:camera:lock-rotate": {
+			const handle = requireVisualizer();
+			const { locked } = (request.payload ?? {}) as { locked: boolean };
+			handle.setRotateEnabled(!locked);
+			return { ok: true };
+		}
+		case "viewer:pick:arm": {
+			const handle = requireVisualizer();
+			if (handle.isRotaryFile()) {
+				throw new Error("Picking is not available for rotary files");
+			}
+			if (!machineIsConnectedAndIdle()) {
+				throw new Error("Machine must be connected and idle to pick a point");
+			}
+			const { mode } = (request.payload ?? {}) as {
+				mode?: "click" | "hold";
+			};
+			handle.armPick(
+				mode === "click" ? "click" : "hold",
+				(p) =>
+					broadcastViewerEvent({
+						kind: "pick",
+						world: p.world,
+						screen: p.screen,
+					}),
+				(t) => broadcastViewerEvent({ kind: "hold-progress", t }),
+			);
+			return { ok: true };
+		}
+		case "viewer:pick:disarm": {
+			const handle = requireVisualizer();
+			handle.disarmPick();
+			return { ok: true };
+		}
+		case "viewer:overlay:set": {
+			const handle = requireVisualizer();
+			const { markers } = (request.payload ?? {}) as {
+				markers?: OverlayMarker[];
+			};
+			handle.setOverlay(Array.isArray(markers) ? markers : []);
+			return { ok: true };
+		}
 		default:
 			throw new Error(`Unknown bridge request: ${request.type}`);
 	}
@@ -173,6 +369,21 @@ const broadcast = (topic: PluginBridgeTopic) => {
 			computed = true;
 		}
 		pushUpdate(sub, snapshot);
+	});
+};
+
+// Push a one-off event (pick / hold-progress) to every "viewer"-topic
+// subscriber. Unlike broadcast(), the payload is the event itself rather than a
+// recomputed state snapshot, since "viewer" is a push-only event stream.
+const broadcastViewerEvent = (event: unknown) => {
+	if (subscriptions.size === 0) {
+		return;
+	}
+	subscriptions.forEach((sub) => {
+		if (sub.topic !== "viewer") {
+			return;
+		}
+		pushUpdate(sub, event);
 	});
 };
 

--- a/src/app/src/features/Visualizer/GcodeViewer.tsx
+++ b/src/app/src/features/Visualizer/GcodeViewer.tsx
@@ -55,7 +55,6 @@ import {
 	FLEXOKI_DARK_THEME,
 	GRBL,
 	GRBL_ACTIVE_STATE_CHECK,
-	GRBL_ACTIVE_STATE_IDLE,
 	GRBL_ACTIVE_STATE_RUN,
 	GRBLHAL,
 	GRUVBOX_LIGHT_THEME,
@@ -85,17 +84,25 @@ const THEME_NAME_TO_PRESET: Record<string, GCodeViewerThemePresetName> = {
 const LIGHT_LIKE_PRESETS = new Set<GCodeViewerThemePresetName>(["light", "gruvbox-light", "ayu-light"]);
 
 import { outlineResponse } from "../../workers/Outline.response";
-import { getSafeXYMoveCode } from "app/features/DRO/utils/SafeMove";
 import {
 	computeKeepoutWorkRect,
 	computeMachineBedWorkRect,
 } from "app/features/DRO/utils/RapidPosition";
+import type { OverlayMarker } from "app/features/Plugins/types";
 import type { Actions, CAMERA_POSITIONS_T, State } from "./definitions";
+import {
+	visualizerBridge,
+	type VisualizerBridgeHandle,
+} from "./visualizerBridge";
 
-// "Move To Here": how long to hold before committing, and how far the pointer
-// may drift before the gesture is treated as a pan instead of a placement.
-const MOVE_TO_HERE_HOLD_MS = 500;
-const MOVE_TO_HERE_CANCEL_PX = 8;
+// Press-and-hold pick gesture: how long to hold before committing, and how far
+// the pointer may drift before the gesture is treated as an orbit/pan instead of
+// a placement.
+const PICK_HOLD_MS = 500;
+const PICK_CANCEL_PX = 8;
+
+// Default marker color when an overlay marker doesn't specify one.
+const OVERLAY_DEFAULT_COLOR = "rgba(14, 246, 174, 0.95)";
 
 // Maps gSender's camera positions onto gviewer ViewCube presets.
 const VIEW_MAP: Partial<Record<string, GCodeViewerCameraView>> = {
@@ -168,20 +175,64 @@ class GcodeViewer extends Component<Props> {
 
 	lastSpinning: boolean | null = null;
 
-	// "Move To Here" placement-mode state.
-	moveToHereActive = false;
+	// Generic pick-gesture state (armed by plugins through the visualizer bridge).
+	pickMode: "click" | "hold" | null = null;
 
-	mthPointerId: number | null = null;
+	pickOnPick:
+		| ((p: {
+				world: { x: number; y: number; z: number };
+				screen: { x: number; y: number };
+		  }) => void)
+		| null = null;
 
-	mthStart: { x: number; y: number } | null = null;
+	pickOnHoldProgress: ((t: number) => void) | null = null;
 
-	mthTimer: ReturnType<typeof setTimeout> | null = null;
+	pickPointerId: number | null = null;
 
-	mthIndicator: HTMLDivElement | null = null;
+	pickStart: { x: number; y: number } | null = null;
+
+	pickMoved = false;
+
+	pickHoldTimer: ReturnType<typeof setTimeout> | null = null;
+
+	pickHoldStart = 0;
+
+	pickHoldRaf: number | null = null;
+
+	pickIndicator: HTMLDivElement | null = null;
+
+	pickPriorView: CAMERA_POSITIONS_T | null = null;
+
+	// Declarative overlay markers the host draws over the canvas for a plugin.
+	overlayMarkers: OverlayMarker[] = [];
+
+	overlaySvg: SVGSVGElement | null = null;
+
+	overlayRaf: number | null = null;
+
+	// Imperative surface exposed to the plugin bridge. Methods read `this.viewer3d`
+	// lazily so the handle survives viewer recreation (lite-mode toggles, etc.).
+	bridgeHandle: VisualizerBridgeHandle = {
+		screenToWorld: (px, py) => this.viewer3d?.screenToWorld(px, py) ?? null,
+		worldToScreen: (x, y, z) => this.viewer3d?.worldToScreen(x, y, z) ?? null,
+		setRotateEnabled: (on) => this.viewer3d?.setRotateEnabled(on),
+		setCameraView: (view) => this.setCameraView(view),
+		isRotaryFile: () => this.isRotaryFile,
+		armPick: (mode, onPick, onHoldProgress) =>
+			this.armPick(mode, onPick, onHoldProgress),
+		disarmPick: () => this.disarmPick(),
+		setOverlay: (markers) => this.setOverlay(markers),
+	};
 
 	componentDidMount() {
 		this.createViewer();
 		this.subscribe();
+
+		// Only the primary viewer exposes the plugin-facing bridge handle; the
+		// secondary (surfacing preview) never registers.
+		if (!this.props.isSecondary) {
+			visualizerBridge.register(this.bridgeHandle);
+		}
 
 		// Render any geometry that arrived before mount.
 		const existing = _get(this.props.state, "gcode.visualization");
@@ -193,7 +244,11 @@ class GcodeViewer extends Component<Props> {
 	componentWillUnmount() {
 		this.unsubscribe();
 		this.reduxUnsub?.();
-		this.setMoveToHereMode(false);
+		this.disarmPick();
+		this.stopOverlay();
+		if (!this.props.isSecondary) {
+			visualizerBridge.unregister(this.bridgeHandle);
+		}
 		this.viewer3d?.dispose();
 		this.viewerSvg?.dispose();
 		this.viewer3d = null;
@@ -201,21 +256,8 @@ class GcodeViewer extends Component<Props> {
 	}
 
 	componentDidUpdate(prevProps: Props) {
-		// Re-snap on every arm, not just when the camera position value
-		// itself changes, since re-arming after a manual camera rotation
-		// leaves `cameraPosition` unchanged (still "Top").
-		const armingMoveToHere =
-			!prevProps.state.moveToHere && this.props.state.moveToHere;
-		if (
-			prevProps.cameraPosition !== this.props.cameraPosition ||
-			armingMoveToHere
-		) {
+		if (prevProps.cameraPosition !== this.props.cameraPosition) {
 			this.snapToView();
-		}
-
-		// "Move To Here" placement mode armed/disarmed.
-		if (prevProps.state.moveToHere !== this.props.state.moveToHere) {
-			this.setMoveToHereMode(this.props.state.moveToHere);
 		}
 
 		if (!prevProps.show && this.props.show) {
@@ -582,60 +624,104 @@ class GcodeViewer extends Component<Props> {
 		}
 	}
 
-	// --- "Move To Here" placement mode --------------------------------------
+	// Maps a bridge camera view name onto the app's camera actions, which update
+	// React state and (via componentDidUpdate) snap the gviewer camera.
+	setCameraView(view: "top" | "3d" | "front" | "left" | "right") {
+		const cam = this.props.actions.camera;
+		const map: Record<typeof view, (() => void) | undefined> = {
+			top: cam.toTopView,
+			"3d": cam.to3DView,
+			front: cam.toFrontView,
+			left: cam.toLeftSideView,
+			right: cam.toRightSideView,
+		};
+		map[view]?.();
+	}
 
-	// Arm/disarm the press-and-hold gesture. While armed, orbit rotation is
-	// locked (pan + zoom stay live) so the click maps predictably onto the XY
-	// plane, the cursor becomes a crosshair, and pointer listeners are live.
-	setMoveToHereMode(enabled: boolean) {
-		// Placement is a primary-visualizer concept; never arm on the secondary.
-		if (enabled && this.props.isSecondary) {
+	// Restore a previously-saved camera position (used when a hold pick disarms).
+	restoreCameraView(pos: CAMERA_POSITIONS_T) {
+		const cam = this.props.actions.camera;
+		const map: Partial<Record<CAMERA_POSITIONS_T, () => void>> = {
+			Top: cam.toTopView,
+			"3D": cam.to3DView,
+			Front: cam.toFrontView,
+			Left: cam.toLeftSideView,
+			Right: cam.toRightSideView,
+		};
+		map[pos]?.();
+	}
+
+	// --- generic pick gesture (armed by plugins via the visualizer bridge) --
+
+	// Arm the pick gesture. 'hold' is a press-and-hold placement (camera pinned
+	// to Top + orbit locked so the press maps cleanly onto the XY plane); 'click'
+	// is a single click/tap with a small movement threshold so orbit-drags don't
+	// register as picks. Refuses to arm on rotary files (the toolpath root is
+	// X-rotated, so picked XY isn't a meaningful work coordinate) and never arms
+	// on the secondary viewer.
+	armPick(
+		mode: "click" | "hold",
+		onPick: (p: {
+			world: { x: number; y: number; z: number };
+			screen: { x: number; y: number };
+		}) => void,
+		onHoldProgress?: (t: number) => void,
+	) {
+		if (this.props.isSecondary || this.isRotaryFile) {
 			return;
 		}
+		// Re-arming cleanly replaces any prior armed gesture.
+		this.disarmPick();
 
-		this.moveToHereActive = enabled;
+		this.pickMode = mode;
+		this.pickOnPick = onPick;
+		this.pickOnHoldProgress = onHoldProgress ?? null;
+
 		const dom = this.containerRef;
+		if (dom) {
+			dom.style.cursor = "crosshair";
+			dom.addEventListener("pointerdown", this.handlePickPointerDown);
+		}
+		window.addEventListener("pointermove", this.handlePickPointerMove);
+		window.addEventListener("pointerup", this.handlePickPointerUp);
+		window.addEventListener("pointercancel", this.handlePickPointerUp);
 
-		if (enabled) {
+		if (mode === "hold") {
+			this.pickPriorView = this.props.cameraPosition;
+			this.props.actions.camera.toTopView();
 			this.viewer3d?.setRotateEnabled(false);
-			if (dom) {
-				dom.style.cursor = "crosshair";
-				dom.addEventListener("pointerdown", this.handleMoveToHerePointerDown);
-			}
-			window.addEventListener("pointermove", this.handleMoveToHerePointerMove);
-			window.addEventListener("pointerup", this.handleMoveToHerePointerUp);
-			window.addEventListener("pointercancel", this.handleMoveToHerePointerUp);
-		} else {
-			this.viewer3d?.setRotateEnabled(true);
-			if (dom) {
-				dom.style.cursor = "";
-				dom.removeEventListener(
-					"pointerdown",
-					this.handleMoveToHerePointerDown,
-				);
-			}
-			window.removeEventListener(
-				"pointermove",
-				this.handleMoveToHerePointerMove,
-			);
-			window.removeEventListener("pointerup", this.handleMoveToHerePointerUp);
-			window.removeEventListener(
-				"pointercancel",
-				this.handleMoveToHerePointerUp,
-			);
-			this.cancelMoveToHereHold();
 		}
 	}
 
-	machineIsReadyToMove(): boolean {
-		const st = reduxStore.getState();
-		const isConnected = !!_get(st, "connection.isConnected");
-		const activeState = _get(st, "controller.state.status.activeState");
-		return isConnected && activeState === GRBL_ACTIVE_STATE_IDLE;
+	disarmPick() {
+		const dom = this.containerRef;
+		if (dom) {
+			dom.style.cursor = "";
+			dom.removeEventListener("pointerdown", this.handlePickPointerDown);
+		}
+		window.removeEventListener("pointermove", this.handlePickPointerMove);
+		window.removeEventListener("pointerup", this.handlePickPointerUp);
+		window.removeEventListener("pointercancel", this.handlePickPointerUp);
+		this.cancelPickHold();
+
+		// Undo the camera/orbit lock a hold gesture applied.
+		if (this.pickMode === "hold") {
+			this.viewer3d?.setRotateEnabled(true);
+			if (this.pickPriorView) {
+				this.restoreCameraView(this.pickPriorView);
+			}
+		}
+		this.pickPriorView = null;
+		this.pickMode = null;
+		this.pickOnPick = null;
+		this.pickOnHoldProgress = null;
+		this.pickPointerId = null;
+		this.pickStart = null;
+		this.pickMoved = false;
 	}
 
-	handleMoveToHerePointerDown = (e: PointerEvent) => {
-		if (!this.moveToHereActive) {
+	handlePickPointerDown = (e: PointerEvent) => {
+		if (!this.pickMode) {
 			return;
 		}
 		// Primary (left mouse / touch) button only.
@@ -643,117 +729,119 @@ class GcodeViewer extends Component<Props> {
 			return;
 		}
 		// Track a single pointer at a time (ignore multi-touch gestures).
-		if (this.mthPointerId !== null) {
-			return;
-		}
-		if (!this.machineIsReadyToMove()) {
-			toast.info("Machine must be connected and idle to move");
+		if (this.pickPointerId !== null) {
 			return;
 		}
 
-		this.mthPointerId = e.pointerId;
-		this.mthStart = { x: e.clientX, y: e.clientY };
-		this.showMoveToHereIndicator(e.clientX, e.clientY);
+		this.pickPointerId = e.pointerId;
+		this.pickStart = { x: e.clientX, y: e.clientY };
+		this.pickMoved = false;
 
+		if (this.pickMode === "hold") {
+			const { clientX, clientY } = e;
+			this.showPickIndicator(clientX, clientY);
+			this.pickHoldStart = performance.now();
+			// Emit hold progress 0..1 each frame so the plugin can mirror the ring.
+			const tick = () => {
+				const t = Math.min(
+					1,
+					(performance.now() - this.pickHoldStart) / PICK_HOLD_MS,
+				);
+				this.pickOnHoldProgress?.(t);
+				if (t < 1) {
+					this.pickHoldRaf = requestAnimationFrame(tick);
+				}
+			};
+			this.pickHoldRaf = requestAnimationFrame(tick);
+			this.pickHoldTimer = setTimeout(() => {
+				this.commitPick(clientX, clientY);
+			}, PICK_HOLD_MS);
+		}
+	};
+
+	handlePickPointerMove = (e: PointerEvent) => {
+		if (this.pickPointerId === null || e.pointerId !== this.pickPointerId) {
+			return;
+		}
+		if (!this.pickStart) {
+			return;
+		}
+		const dx = e.clientX - this.pickStart.x;
+		const dy = e.clientY - this.pickStart.y;
+		// Drift beyond the threshold means the user is panning/orbiting, not picking.
+		if (Math.hypot(dx, dy) > PICK_CANCEL_PX) {
+			if (this.pickMode === "hold") {
+				this.cancelPickHold();
+			} else {
+				this.pickMoved = true;
+			}
+		}
+	};
+
+	handlePickPointerUp = (e: PointerEvent) => {
+		if (this.pickPointerId === null || e.pointerId !== this.pickPointerId) {
+			return;
+		}
 		const { clientX, clientY } = e;
-		this.mthTimer = setTimeout(() => {
-			this.commitMoveToHere(clientX, clientY);
-		}, MOVE_TO_HERE_HOLD_MS);
-	};
-
-	handleMoveToHerePointerMove = (e: PointerEvent) => {
-		if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
+		if (this.pickMode === "click") {
+			const moved = this.pickMoved;
+			this.pickPointerId = null;
+			this.pickStart = null;
+			this.pickMoved = false;
+			// A drag was a pan/orbit; only a clean click fires a pick.
+			if (!moved) {
+				this.commitPick(clientX, clientY);
+			}
 			return;
 		}
-		if (!this.mthStart) {
-			return;
-		}
-		const dx = e.clientX - this.mthStart.x;
-		const dy = e.clientY - this.mthStart.y;
-		// Movement beyond the threshold means the user is panning, not placing.
-		if (Math.hypot(dx, dy) > MOVE_TO_HERE_CANCEL_PX) {
-			this.cancelMoveToHereHold();
-		}
+		// Hold released before the timer completed - cancel the placement.
+		this.cancelPickHold();
 	};
 
-	handleMoveToHerePointerUp = (e: PointerEvent) => {
-		if (this.mthPointerId === null || e.pointerId !== this.mthPointerId) {
-			return;
+	// Tear down the in-progress hold (timer + progress rAF + indicator) while
+	// leaving the gesture armed for another attempt.
+	cancelPickHold() {
+		const wasHolding =
+			this.pickHoldTimer !== null || this.pickHoldRaf !== null;
+		if (this.pickHoldTimer) {
+			clearTimeout(this.pickHoldTimer);
+			this.pickHoldTimer = null;
 		}
-		// Released before the hold completed - cancel the placement.
-		this.cancelMoveToHereHold();
-	};
-
-	cancelMoveToHereHold() {
-		if (this.mthTimer) {
-			clearTimeout(this.mthTimer);
-			this.mthTimer = null;
+		if (this.pickHoldRaf !== null) {
+			cancelAnimationFrame(this.pickHoldRaf);
+			this.pickHoldRaf = null;
 		}
-		this.removeMoveToHereIndicator();
-		this.mthPointerId = null;
-		this.mthStart = null;
+		this.removePickIndicator();
+		this.pickPointerId = null;
+		this.pickStart = null;
+		this.pickMoved = false;
+		if (wasHolding) {
+			this.pickOnHoldProgress?.(0);
+		}
 	}
 
-	commitMoveToHere(clientX: number, clientY: number) {
-		this.cancelMoveToHereHold();
-
-		if (!this.machineIsReadyToMove()) {
-			toast.info("Machine must be connected and idle to move");
-			this.props.actions.camera.disableMoveToHere();
+	commitPick(clientX: number, clientY: number) {
+		// A hold commit tears down its timer/indicator but stays armed so the
+		// plugin can decide whether to disarm.
+		if (this.pickMode === "hold") {
+			this.cancelPickHold();
+		}
+		if (this.isRotaryFile || !this.viewer3d) {
 			return;
 		}
-
-		// gviewer renders rotary toolpaths on an X-rotated root, so the picked
-		// world XY is not a meaningful work coordinate for those files.
-		if (this.isRotaryFile) {
-			toast.info("Move To Here isn't available for rotary files");
-			this.props.actions.camera.disableMoveToHere();
+		const world = this.viewer3d.screenToWorld(clientX, clientY);
+		if (!world) {
 			return;
 		}
-
-		const target = this.getWorkCoordsFromClient(clientX, clientY);
-		if (!target) {
-			return;
-		}
-
-		const { units } = this.props.state;
-		const unitModal = units === METRIC_UNITS ? "G21" : "G20";
-		controller.command(
-			"gcode:safe",
-			getSafeXYMoveCode(target.x, target.y),
-			unitModal,
-		);
-
-		toast.success(
-			`Moving to X${target.x.toFixed(2)} Y${target.y.toFixed(2)}`,
-		);
-
-		// Auto-disarm after a successful move.
-		this.props.actions.camera.disableMoveToHere();
-	}
-
-	// Convert a viewport pixel into absolute work XY. gviewer raycasts the pixel
-	// onto the plane at the bit's current Z and returns scene coordinates, which
-	// equal work coordinates because the toolpath root sits at the origin.
-	getWorkCoordsFromClient(
-		clientX: number,
-		clientY: number,
-	): { x: number; y: number } | null {
-		if (!this.viewer3d) {
-			return null;
-		}
-		const hit = this.viewer3d.screenToWorld(clientX, clientY);
-		if (!hit) {
-			return null;
-		}
-		return {
-			x: Number(hit.x.toFixed(3)),
-			y: Number(hit.y.toFixed(3)),
+		const screen = this.viewer3d.worldToScreen(world.x, world.y, world.z) ?? {
+			x: clientX,
+			y: clientY,
 		};
+		this.pickOnPick?.({ world, screen });
 	}
 
-	showMoveToHereIndicator(clientX: number, clientY: number) {
-		this.removeMoveToHereIndicator();
+	showPickIndicator(clientX: number, clientY: number) {
+		this.removePickIndicator();
 
 		const size = 48;
 		const r = size / 2 - 4;
@@ -817,18 +905,134 @@ class GcodeViewer extends Component<Props> {
 					{ strokeDashoffset: circumference },
 					{ strokeDashoffset: 0 },
 				],
-				{ duration: MOVE_TO_HERE_HOLD_MS, fill: "forwards" },
+				{ duration: PICK_HOLD_MS, fill: "forwards" },
 			);
 		}
 
-		this.mthIndicator = wrapper;
+		this.pickIndicator = wrapper;
 	}
 
-	removeMoveToHereIndicator() {
-		if (this.mthIndicator && this.mthIndicator.parentElement) {
-			this.mthIndicator.parentElement.removeChild(this.mthIndicator);
+	removePickIndicator() {
+		if (this.pickIndicator && this.pickIndicator.parentElement) {
+			this.pickIndicator.parentElement.removeChild(this.pickIndicator);
 		}
-		this.mthIndicator = null;
+		this.pickIndicator = null;
+	}
+
+	// --- plugin overlay layer ----------------------------------------------
+
+	// Replace the declarative marker list drawn over the canvas. The host owns
+	// this SVG layer (the sandboxed plugin can never draw on the canvas itself);
+	// markers are re-projected every frame so they track camera pan/zoom.
+	setOverlay(markers: OverlayMarker[]) {
+		this.overlayMarkers = Array.isArray(markers) ? markers : [];
+		if (this.overlayMarkers.length > 0) {
+			this.startOverlay();
+		} else {
+			this.stopOverlay();
+		}
+	}
+
+	startOverlay() {
+		if (this.overlayRaf !== null) {
+			return; // already running
+		}
+		if (!this.overlaySvg) {
+			const svg = document.createElementNS(
+				"http://www.w3.org/2000/svg",
+				"svg",
+			) as SVGSVGElement;
+			svg.style.cssText = [
+				"position:fixed",
+				"inset:0",
+				"width:100vw",
+				"height:100vh",
+				"pointer-events:none",
+				"z-index:10000",
+			].join(";");
+			document.body.appendChild(svg);
+			this.overlaySvg = svg;
+		}
+		const draw = () => {
+			this.drawOverlay();
+			this.overlayRaf = requestAnimationFrame(draw);
+		};
+		this.overlayRaf = requestAnimationFrame(draw);
+	}
+
+	stopOverlay() {
+		if (this.overlayRaf !== null) {
+			cancelAnimationFrame(this.overlayRaf);
+			this.overlayRaf = null;
+		}
+		if (this.overlaySvg?.parentElement) {
+			this.overlaySvg.parentElement.removeChild(this.overlaySvg);
+		}
+		this.overlaySvg = null;
+	}
+
+	drawOverlay() {
+		const svg = this.overlaySvg;
+		if (!svg || !this.viewer3d) {
+			return;
+		}
+		while (svg.firstChild) {
+			svg.removeChild(svg.firstChild);
+		}
+		const ns = "http://www.w3.org/2000/svg";
+
+		for (const marker of this.overlayMarkers) {
+			const s = this.viewer3d.worldToScreen(marker.x, marker.y, marker.z ?? 0);
+			if (!s) {
+				continue;
+			}
+			const color = marker.color ?? OVERLAY_DEFAULT_COLOR;
+			const size = marker.size ?? 6;
+			const shape = marker.shape ?? "circle";
+
+			if (shape === "ring") {
+				const c = document.createElementNS(ns, "circle");
+				c.setAttribute("cx", String(s.x));
+				c.setAttribute("cy", String(s.y));
+				c.setAttribute("r", String(size));
+				c.setAttribute("fill", "none");
+				c.setAttribute("stroke", color);
+				c.setAttribute("stroke-width", "1.5");
+				svg.appendChild(c);
+			} else if (shape === "cross") {
+				const line = (x1: number, y1: number, x2: number, y2: number) => {
+					const l = document.createElementNS(ns, "line");
+					l.setAttribute("x1", String(x1));
+					l.setAttribute("y1", String(y1));
+					l.setAttribute("x2", String(x2));
+					l.setAttribute("y2", String(y2));
+					l.setAttribute("stroke", color);
+					l.setAttribute("stroke-width", "1.5");
+					return l;
+				};
+				svg.appendChild(line(s.x - size, s.y, s.x + size, s.y));
+				svg.appendChild(line(s.x, s.y - size, s.x, s.y + size));
+			} else {
+				// Default: filled circle.
+				const c = document.createElementNS(ns, "circle");
+				c.setAttribute("cx", String(s.x));
+				c.setAttribute("cy", String(s.y));
+				c.setAttribute("r", String(size));
+				c.setAttribute("fill", color);
+				svg.appendChild(c);
+			}
+
+			if (marker.label) {
+				const t = document.createElementNS(ns, "text");
+				t.setAttribute("x", String(s.x + size + 4));
+				t.setAttribute("y", String(s.y + 4));
+				t.setAttribute("fill", color);
+				t.setAttribute("font-size", "12");
+				t.setAttribute("font-family", "sans-serif");
+				t.textContent = marker.label;
+				svg.appendChild(t);
+			}
+		}
 	}
 
 	// --- imperative API consumed by the connected container (index.tsx) -----

--- a/src/app/src/features/Visualizer/definitions.ts
+++ b/src/app/src/features/Visualizer/definitions.ts
@@ -152,7 +152,6 @@ export interface State {
 	};
 	cameraMode: CAMERA_MODES_T;
 	cameraPosition: CAMERA_POSITIONS_T; // 'Top', '3D', 'Front', 'Left', 'Right'
-	moveToHere: boolean; // "Move To Here" placement mode is armed
 	isConnected?: boolean; // Injected at render from connection state
 	isAgitated: boolean; // Defaults to false
 	currentTheme: Map<string, string>;
@@ -215,8 +214,6 @@ export interface Actions {
 		toLeftSideView: () => void;
 		toRightSideView: () => void;
 		toFreeView: () => void;
-		toggleMoveToHere: () => void;
-		disableMoveToHere: () => void;
 	};
 	handleLiteModeToggle: () => void;
 	lineWarning: {

--- a/src/app/src/features/Visualizer/index.tsx
+++ b/src/app/src/features/Visualizer/index.tsx
@@ -23,6 +23,7 @@
 
 import { Tooltip } from "app/components/Tooltip";
 import { Widget } from "app/components/Widget";
+import PluginVisualizerOverlayHost from "app/features/Plugins/components/PluginVisualizerOverlayHost";
 import { WorkspaceSelector } from "app/features/WorkspaceSelector/index.tsx";
 import combokeys from "app/lib/combokeys";
 import controller from "app/lib/controller";
@@ -48,7 +49,7 @@ import _ from "lodash";
 import debounce from "lodash/debounce";
 import get from "lodash/get";
 import includes from "lodash/includes";
-import { Crosshair, FrownIcon } from "lucide-react";
+import { FrownIcon } from "lucide-react";
 import PropTypes from "prop-types";
 import pubsub from "pubsub-js";
 import { Component } from "react";
@@ -109,15 +110,6 @@ const VIEWCUBE_CONTROL_GAP_PX = 12;
 const LIGHTWEIGHT_TOGGLE_POSITION = {
 	left: VIEWCUBE_OFFSET_PX + VIEWCUBE_SIZE_PX / 2,
 	bottom: VIEWCUBE_OFFSET_PX + VIEWCUBE_SIZE_PX + VIEWCUBE_CONTROL_GAP_PX,
-};
-// "Move To Here" toggle sits stacked directly above the lightweight toggle.
-const FLOATING_BUTTON_SIZE_PX = 44; // h-11 / w-11
-const MOVE_TO_HERE_TOGGLE_POSITION = {
-	left: LIGHTWEIGHT_TOGGLE_POSITION.left,
-	bottom:
-		LIGHTWEIGHT_TOGGLE_POSITION.bottom +
-		FLOATING_BUTTON_SIZE_PX +
-		VIEWCUBE_CONTROL_GAP_PX,
 };
 
 class Visualizer extends Component {
@@ -588,21 +580,6 @@ class Visualizer extends Component {
 			toFreeView: () => {
 				this.setState({ cameraPosition: "Free" });
 			},
-			// Arm/disarm "Move To Here": pressing-and-holding a spot in the
-			// viewport rapids the spindle there. Arming pins the camera to the
-			// Top view so the click maps cleanly onto the XY work plane.
-			toggleMoveToHere: () => {
-				this.setState((state) => {
-					const moveToHere = !state.moveToHere;
-					return {
-						moveToHere,
-						cameraPosition: moveToHere ? "Top" : state.cameraPosition,
-					};
-				});
-			},
-			disableMoveToHere: () => {
-				this.setState({ moveToHere: false });
-			},
 		},
 		handleLiteModeToggle: () => {
 			const { liteMode, liteOption } = this.state;
@@ -908,7 +885,6 @@ class Visualizer extends Component {
 			},
 			cameraMode: this.config.get("cameraMode", CAMERA_MODE_PAN),
 			cameraPosition: "3D", // 'Top', '3D', 'Front', 'Left', 'Right'
-			moveToHere: false, // "Move To Here" placement mode is armed
 			isAgitated: false, // Defaults to false
 			currentTheme: getVisualizerTheme(),
 			currentTab: 0,
@@ -1649,34 +1625,10 @@ class Visualizer extends Component {
 
 						{!showVisualizer && webGLAvailable && <VisualizerPlaceholder />}
 
-						{state.isConnected && (
-							<Tooltip
-								content="Move To Here: press and hold a spot to move the spindle there"
-								side="top"
-							>
-								<button
-									type="button"
-									style={MOVE_TO_HERE_TOGGLE_POSITION}
-									className={cx(
-										"absolute z-[10000] inline-flex h-11 w-11 -translate-x-1/2 items-center justify-center rounded-full border bg-dark-darker/70 shadow-[0_10px_30px_rgba(0,_0,_0,_0.25)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-dark-darker active:scale-[0.98] active:bg-dark-darker/85 mb-5",
-										{
-											"border-[rgba(14,_246,_174,_0.95)] text-[rgba(14,_246,_174,_0.95)] shadow-[0_0_0_1px_rgba(14,_246,_174,_0.35),0_10px_30px_rgba(0,_0,_0,_0.35)] hover:border-[rgba(14,_246,_174,_0.95)] hover:text-[rgba(14,_246,_174,_0.95)] hover:shadow-[0_0_0_1px_rgba(14,_246,_174,_0.45),0_12px_32px_rgba(0,_0,_0,_0.4)]":
-												state.moveToHere,
-											"border-gray-400/40 text-gray-300 hover:border-gray-200/70 hover:text-gray-100 hover:shadow-[0_12px_32px_rgba(0,_0,_0,_0.35)]":
-												!state.moveToHere,
-										},
-									)}
-									aria-label="Move To Here"
-									aria-pressed={state.moveToHere}
-									onClick={() => actions.camera.toggleMoveToHere()}
-								>
-									<Crosshair
-										aria-hidden="true"
-										className="pointer-events-none h-5 w-5 shrink-0"
-									/>
-								</button>
-							</Tooltip>
-						)}
+						<PluginVisualizerOverlayHost
+							baseBottomPx={LIGHTWEIGHT_TOGGLE_POSITION.bottom}
+							leftPx={LIGHTWEIGHT_TOGGLE_POSITION.left}
+						/>
 
 						<Tooltip content={liteModeActionLabel} side="top">
 							<button

--- a/src/app/src/features/Visualizer/visualizerBridge.ts
+++ b/src/app/src/features/Visualizer/visualizerBridge.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Sienci Labs Inc.
+ *
+ * This file is part of gSender.
+ *
+ * gSender is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, under version 3 of the License.
+ *
+ * gSender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gSender.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact for information regarding this program and its license
+ * can be sent through gSender@sienci.com or mailed to the main office
+ * of Sienci Labs Inc. in Waterloo, Ontario, Canada.
+ *
+ */
+
+import type { OverlayMarker } from "app/features/Plugins/types";
+
+// Imperative surface the primary visualizer exposes to the plugin bridge so
+// sandboxed plugin iframes (which can never touch the canvas directly) can pick
+// points on the loaded job, draw markers, and control the camera. The GcodeViewer
+// component owns the implementation and registers a handle on mount; the plugin
+// bridge (`viewer:*` requests) resolves against whatever handle is currently
+// registered.
+export interface VisualizerBridgeHandle {
+	screenToWorld(
+		px: number,
+		py: number,
+	): { x: number; y: number; z: number } | null;
+	worldToScreen(
+		x: number,
+		y: number,
+		z?: number,
+	): { x: number; y: number } | null;
+	setRotateEnabled(on: boolean): void;
+	setCameraView(view: "top" | "3d" | "front" | "left" | "right"): void;
+	isRotaryFile(): boolean;
+	armPick(
+		mode: "click" | "hold",
+		onPick: (p: {
+			world: { x: number; y: number; z: number };
+			screen: { x: number; y: number };
+		}) => void,
+		onHoldProgress?: (t: number) => void,
+	): void;
+	disarmPick(): void;
+	setOverlay(markers: OverlayMarker[]): void;
+}
+
+// Only the PRIMARY viewer registers a handle; the secondary (surfacing preview)
+// visualizer never does, so `get()` always resolves to the main job viewer.
+let current: VisualizerBridgeHandle | null = null;
+
+export const visualizerBridge = {
+	register(handle: VisualizerBridgeHandle): void {
+		current = handle;
+	},
+	unregister(handle: VisualizerBridgeHandle): void {
+		// Guard against a late-unmounting stale viewer clobbering a freshly
+		// registered one.
+		if (current === handle) {
+			current = null;
+		}
+	},
+	get(): VisualizerBridgeHandle | null {
+		return current;
+	},
+};

--- a/src/app/src/routes/tools.tsx
+++ b/src/app/src/routes/tools.tsx
@@ -12,7 +12,7 @@ const ToolsPage = () => {
 	const { toolsPagePlugins } = usePlugins();
 
 	return (
-		<div className="py-4 px-16 max-xl:px-8 pb-12 fixed-content-area w-full flex flex-col overflow-y-auto">
+		<div className="py-4 px-16 max-xl:px-8 h-full flex flex-col no-scrollbar">
 			<h1 className="text-3xl font-bold dark:text-white mb-2">
 				Tools
 			</h1>
@@ -21,7 +21,7 @@ const ToolsPage = () => {
 				Some are built in to gSender, some are third party plugins.
 			</p>
 
-			<div className="grid lg:grid-cols-3 grid-cols-2 gap-4">
+			<div className="flex-1 grid lg:grid-cols-3 grid-cols-2 gap-4 overflow-y-auto overflow-x-hidden">
 				<ToolCard
 					title="Surfacing"
 					description="Flatten your wasteboard or other non-flat stock"

--- a/src/app/src/store/redux/index.ts
+++ b/src/app/src/store/redux/index.ts
@@ -6,6 +6,7 @@ import controller from "./slices/controller.slice";
 import file from "./slices/fileInfo.slice";
 import gSenderInfo from "./slices/gSenderInfo.slice.ts";
 import helper from "./slices/helper.slice";
+import pluginState from "./slices/pluginState.slice";
 import preferences from "./slices/preferences.slice";
 import shortcuts from "./slices/shortcuts.slice.ts";
 import visualizer from "./slices/visualizer.slice";
@@ -21,6 +22,7 @@ export const store = configureStore({
 		helper,
 		gSenderInfo,
 		shortcuts,
+		pluginState,
 	},
 	middleware: (getDefaultMiddleware) =>
 		getDefaultMiddleware().concat(sagaMiddleware),

--- a/src/app/src/store/redux/slices/pluginState.slice.ts
+++ b/src/app/src/store/redux/slices/pluginState.slice.ts
@@ -1,0 +1,40 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+// Plugin-asserted machine state that the host UI and other plugins consume.
+//
+// `busy` lets a plugin flag the machine as persistently occupied for the whole
+// span of an operation it drives through the feeder (e.g. Screw Spot drilling a
+// batch of holes). The feeder streams line-by-line, so the raw controller
+// `activeState` dips to Idle between moves — this flag lets the UI keep showing
+// a stable "running" status instead of flickering. The host owns the release
+// lifecycle (see pluginBridge), so setting `busy` true is fire-and-set: the host
+// clears it once the machine has genuinely gone idle.
+export interface PluginReduxState {
+	busy: boolean;
+	// Optional human label shown in place of the machine status (e.g. the plugin
+	// name / operation). Null falls back to a generic "Running".
+	label: string | null;
+}
+
+const initialState: PluginReduxState = {
+	busy: false,
+	label: null,
+};
+
+const pluginStateSlice = createSlice({
+	name: "pluginState",
+	initialState,
+	reducers: {
+		setPluginBusy: (
+			state,
+			action: PayloadAction<{ busy: boolean; label?: string | null }>,
+		) => {
+			state.busy = action.payload.busy;
+			state.label = action.payload.busy ? (action.payload.label ?? null) : null;
+		},
+	},
+});
+
+export const { setPluginBusy } = pluginStateSlice.actions;
+
+export default pluginStateSlice.reducer;


### PR DESCRIPTION
## What's included

- **Host visualizer bridge (`gsender.viewer.*`)**: screen/world projection, camera control, point picking, and overlay markers over the main visualizer. Exposed through the SDK base client (`packages/plugin-sdk`) and wired host-side via `Visualizer/visualizerBridge.ts` and `GcodeViewer`.
- **`visualizer-overlay` contribution slot**: a floating host toggle button plus a plugin panel docked over the canvas (`PluginVisualizerOverlayHost`).
- **`useVisualizerPick` React hook** plus expanded plugin bridge and types.
- **Plugin-asserted machine-busy latch**: a plugin can hold a stable "running" status across a feeder-driven operation (`pluginState` slice consumed by `MachineStatus`), released by the host once the machine goes genuinely idle.
- **Docs**: `plugins/README.md` documents the host visualizer bridge surface.

## Move To Here is migrating to a plugin

This branch removes the core "Move To Here" feature from the visualizer: host state, actions, the toggle button, and the press-and-hold placement handlers in `GcodeViewer` (the inverse of #895). Its behaviour is superseded by the generic viewer bridge. Move To Here will ship as an external plugin that drives the bridge and issues its own move command, rather than living in core gSender.

Flagging this explicitly since it is a user-facing removal from core. Happy to keep it in core alongside the bridge if that is preferred.
