### PR TITLE
Fix ethernet reconnect on disconnect resume, write server log to user…

### DIFF
--- a/src/app/src/lib/connection.ts
+++ b/src/app/src/lib/connection.ts
@@ -3,6 +3,7 @@ import WidgetConfig from 'app/features/WidgetConfig/WidgetConfig';
 import controller from './controller';
 import { isIPv4 } from './utils';
 import store from 'app/store';
+import { toast } from 'app/lib/toaster';
 
 export const connectToLastDevice = (callback: () => any) => {
     const connectionConfig = new WidgetConfig('connection');
@@ -12,6 +13,7 @@ export const connectToLastDevice = (callback: () => any) => {
     const defaultFirmware = store.get('workspace.defaultFirmware', GRBL);
 
     const isNetwork = isIPv4(port); // Do we look like an IP address?
+    const ethernetPort = connectionConfig.get('ethernetPort', 23);
 
     controller.openPort(
         port,
@@ -21,9 +23,14 @@ export const connectToLastDevice = (callback: () => any) => {
             rtscts: false,
             network: isNetwork,
             defaultFirmware,
+            ethernetPort,
         },
         (err: any) => {
             if (err) {
+                toast.error(
+                    `Unable to reconnect to ${port} - ${err.message || err}`,
+                    { position: 'bottom-right' },
+                );
                 return;
             }
             callback && callback();

--- a/src/server/lib/logger.js
+++ b/src/server/lib/logger.js
@@ -21,6 +21,8 @@
  *
  */
 
+import fs from 'fs';
+import path from 'path';
 import util from 'util';
 import chalk from 'chalk';
 import winston from 'winston';
@@ -35,12 +37,30 @@ const getStackTrace = () => {
 
 const VERBOSITY_MAX = 3; // -vvv
 
+// Resolve the log file next to main.log and grbl.log in the Electron user data
+// directory. A relative filename would resolve against the working directory,
+// which for an installed app is the read-only program directory.
+const resolveLogFile = () => {
+    try {
+        const { app } = require('electron');
+        if (app) {
+            const logDirectory = path.join(app.getPath('userData'), 'logs');
+            fs.mkdirSync(logDirectory, { recursive: true });
+            return path.join(logDirectory, 'server.log');
+        }
+    } catch (err) {
+        // Running outside of Electron
+    }
+
+    return 'gsender_server_log.txt';
+};
+
 const { combine, colorize, timestamp, printf } = winston.format;
 
 // https://github.com/winstonjs/winston/blob/master/README.md#creating-your-own-logger
 const logger = winston.createLogger({
     exitOnError: false,
-    level: settings.winston.level,
+    level: process.env.GSENDER_LOG_LEVEL || settings.winston.level,
     silent: false,
     transports: [
         new winston.transports.Console({
@@ -52,8 +72,15 @@ const logger = winston.createLogger({
             handleExceptions: true
         }),
         new winston.transports.File({
-            filename: 'gsender_server_log.txt',
-            level: 'info'
+            filename: resolveLogFile(),
+            format: combine(
+                timestamp(),
+                printf(log => `${log.timestamp} - ${log.level} ${log.message}`)
+            ),
+            maxsize: 5 * 1024 * 1024,
+            maxFiles: 3,
+            tailable: true,
+            handleExceptions: true
         })
     ]
 });


### PR DESCRIPTION
connectToLastDevice omitted ethernetPort from the openPort options, so the Resume button on the "Port Disconnected" dialog dialled the controller on port 0 and failed immediately. The error was then swallowed, leaving the dialog dismissed with no connection and no feedback. Pass the configured ethernet port and surface failures with a toast.

The winston file transport used a relative filename, which resolved against the working directory of the installed app and silently failed to write. Point it at logs/server.log in the Electron user data directory, next to main.log and grbl.log, with rotation. The level can now be raised with GSENDER_LOG_LEVEL for diagnostics.