### PR TITLE
Detect probed tools by non-zero Z offset and refresh the tool table

### DIFF
--- a/src/app/src/features/ATC/utils/ATCFunctions.ts
+++ b/src/app/src/features/ATC/utils/ATCFunctions.ts
@@ -30,12 +30,26 @@ export function mapToolNicknamesAndStatus(
     Object.values(tools).forEach((tool) => {
         tool = { ...tool };
         tool.nickname = lookupToolName(tool.id);
-        const flags = getToolFlags(tool.id, rackSize, tool.toolOffsets.z);
+        const flags = getToolFlags(
+            tool.id,
+            rackSize,
+            get(tool, 'toolOffsets.z', 0),
+        );
         tool.status = flags.probeState;
         tool.isManual = flags.isManual;
         toolsArray.push(tool);
     });
     return toolsArray;
+}
+
+// A tool that has never been probed has an offset of exactly zero, since the
+// controller zeroes unwritten tool table entries. The sign of a probed offset
+// depends on the tool change macro's reference scheme - it is negative when the
+// macro stores the raw machine Z of the tool setter trigger, and positive when
+// it stores tool length above a datum - so only zero/non-zero is meaningful.
+export function isToolProbed(zOffset: number): boolean {
+    const offset = Number(zOffset);
+    return Number.isFinite(offset) && offset !== 0;
 }
 
 export function getToolFlags(
@@ -44,13 +58,17 @@ export function getToolFlags(
     zOffset: number,
 ): ToolFlags {
     return {
-        probeState: zOffset < 0 ? 'probed' : 'unprobed',
+        probeState: isToolProbed(zOffset) ? 'probed' : 'unprobed',
         isManual: toolNumber > rackSize,
     };
 }
 
 function setToolStatus(tool: ToolInstance, rackSize): ToolInstance {
-    const flags = getToolFlags(tool.id, rackSize, tool.toolOffsets.z);
+    const flags = getToolFlags(
+        tool.id,
+        rackSize,
+        get(tool, 'toolOffsets.z', 0),
+    );
     tool.status = flags.probeState;
     tool.isManual = flags.isManual;
     return tool;
@@ -103,7 +121,9 @@ export function releaseToolFromSpindle() {
 }
 
 export function loadTool(toolID) {
-    controller.command('gcode', [`M6 T${toolID}`]);
+    // M6 runs the tool change macro, which probes the tool and writes its offset
+    // with G10 L1, so the tool table has to be re-read afterwards.
+    controller.command('gcode', [`M6 T${toolID}`, '$#']);
 }
 
 export function loadAndSaveToRack(toolID) {

--- a/src/app/src/features/JobControl/index.tsx
+++ b/src/app/src/features/JobControl/index.tsx
@@ -19,6 +19,7 @@ import { SenderStatus } from 'app/lib/definitions/sender_feeder';
 import { JSX, useEffect, useState } from 'react';
 import pubsub from 'pubsub-js';
 import { SDCardProgress } from 'app/features/JobControl/SDCardProgress.tsx';
+import { isToolProbed } from 'app/features/ATC/utils/ATCFunctions.ts';
 import cx from 'classnames';
 
 interface JobControlProps {
@@ -149,7 +150,7 @@ const JobControl: React.FC<JobControlProps> = ({
             const zOffset = get(offsets, 'toolOffsets.z', 0);
 
             // Tool selected with Offsets
-            if (zOffset < 0) {
+            if (isToolProbed(zOffset)) {
                 return [
                     true,
                     {

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -707,6 +707,11 @@ class GrblHalController {
 					this.command("gcode", "[global.state.testWCS]");
 				}, 200);
 				this.emit("gcode_error_checking_file", this.sender.state, "finished");
+			} else if (this.sender.state.toolChanges > 0) {
+				// A tool change macro probes the incoming tool and stores its
+				// offset with G10 L1, so the tool table is stale once a job with
+				// tool changes finishes. Nothing is streaming now, so re-read it.
+				this.command("gcode", "$#");
 			}
 		});
 		this.sender.on("requestData", () => {
@@ -1089,6 +1094,10 @@ class GrblHalController {
 		});
 
 		this.runner.on("parameters", (res) => {
+			this.emit("serialport:read", res.raw);
+		});
+
+		this.runner.on("tool", (res) => {
 			this.emit("serialport:read", res.raw);
 		});
 

--- a/src/server/controllers/Grblhal/GrblHalRunner.js
+++ b/src/server/controllers/Grblhal/GrblHalRunner.js
@@ -310,17 +310,18 @@ class GrblHalRunner extends events.EventEmitter {
             return;
         }
         if (type === GrblHalLineParserResultTool) {
-            delete payload.raw;
+            const { raw, ...tool } = payload;
             const nextSettings = {
                 ...this.settings,
                 toolTable: {
                     ...this.settings.toolTable,
-                    [payload.id]: payload
+                    [tool.id]: tool
                 }
             };
             if (!_.isEqual(this.settings.toolTable, nextSettings.toolTable)) {
                 this.settings = nextSettings;
             }
+            this.emit('tool', { ...tool, raw });
             return;
         }
         if (type === GrblHalLineParserResultParameters) {


### PR DESCRIPTION
Identify probed ATC tools by a non-zero Z offset instead of a negative one, so both positive and negative tool-offset reference schemes are supported. Consolidate the probe check into a single isToolProbed() predicate and guard the tool.toolOffsets.z reads.

Also re-read the grblHAL tool table (via $#) after an M6 tool load and when a job with tool changes ends, and echo [T:] tool-table lines to the console so offsets stay current without relying on mid-job PRB parsing.