### PR TITLE
Fall back to preceding comment lines for the M6 tool-change dialog

### DIFF
--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -568,6 +568,24 @@ class GrblController {
 					// Handle specific cases for macro and pause, ignore is default and comments line out with no other action
 					// If toolchange is at very beginning of file, ignore it
 					if (toolChangeOption !== "Ignore") {
+						// The M6 line itself carries no inline comment - fall
+						// back to the comment line(s) directly above it (many
+						// post processors put the tool description there),
+						// prefixed with the tool word so the dialog always
+						// identifies the tool.
+						if (!commentString) {
+							const preceding = this.getPrecedingComments(sent);
+							const hasToolWord =
+								toolLabel &&
+								(preceding === toolLabel ||
+									preceding.startsWith(`${toolLabel} `));
+							commentString = hasToolWord
+								? preceding
+								: [toolLabel, preceding]
+										.filter(Boolean)
+										.join(" - ");
+						}
+
 						this.workflow.pause({ data: "M6", comment: commentString });
 
 						if (toolChangeOption === "Code") {
@@ -2355,6 +2373,39 @@ class GrblController {
 		} else {
 			this.write(data + "\n", context);
 		}
+	}
+
+	/**
+	 * Collect the comment-only lines immediately preceding a sender line.
+	 * Many post processors (Fusion 360 among them) emit the tool/operation
+	 * description on its own comment line right above the M6 block instead
+	 * of inline, so an M6 line without an inline comment can still be
+	 * described to the user by walking back over the preceding comments.
+	 * Walks upward from lines[index - 1], stops at the first non-comment
+	 * line, and returns at most three comment lines joined in file order.
+	 */
+	getPrecedingComments(index) {
+		const lines = _.get(this.sender, "state.lines", []);
+		const parts = [];
+		for (let i = index - 1; i >= 0 && parts.length < 3; i--) {
+			const prev = String(lines[i]).trim();
+			const semi = prev.match(/^;(.*)$/);
+			const paren = prev.match(/^\(([^)]*)\)$/);
+			if (!semi && !paren) {
+				break;
+			}
+			const text = (semi ? semi[1] : paren[1]).trim();
+			if (text) {
+				parts.unshift(text);
+			}
+		}
+		// Control characters (a stray \r from mixed line endings, U+2028/29)
+		// would corrupt the "%pre_complete ;<comment>" feeder marker this
+		// string gets embedded into, so flatten them to spaces.
+		return parts
+			.join(" ")
+			.replace(/[\u0000-\u001f\u2028\u2029]+/g, " ")
+			.trim();
 	}
 
 	convertGcodeToArray(gcode) {

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -604,6 +604,24 @@ class GrblHalController {
 					// Handle specific cases for macro and pause, ignore is default and comments line out with no other action
 					// If toolchange is at very beginning of file, ignore it
 					if (toolChangeOption !== "Ignore") {
+						// The M6 line itself carries no inline comment - fall
+						// back to the comment line(s) directly above it (many
+						// post processors put the tool description there),
+						// prefixed with the tool word so the dialog always
+						// identifies the tool.
+						if (!commentString) {
+							const preceding = this.getPrecedingComments(sent);
+							const hasToolWord =
+								toolLabel &&
+								(preceding === toolLabel ||
+									preceding.startsWith(`${toolLabel} `));
+							commentString = hasToolWord
+								? preceding
+								: [toolLabel, preceding]
+										.filter(Boolean)
+										.join(" - ");
+						}
+
 						this.workflow.pause({ data: "M6", comment: commentString });
 
 						if (toolChangeOption === "Code") {
@@ -2853,6 +2871,39 @@ class GrblHalController {
 				source: WRITE_SOURCE_FEEDER,
 			});
 		}
+	}
+
+	/**
+	 * Collect the comment-only lines immediately preceding a sender line.
+	 * Many post processors (Fusion 360 among them) emit the tool/operation
+	 * description on its own comment line right above the M6 block instead
+	 * of inline, so an M6 line without an inline comment can still be
+	 * described to the user by walking back over the preceding comments.
+	 * Walks upward from lines[index - 1], stops at the first non-comment
+	 * line, and returns at most three comment lines joined in file order.
+	 */
+	getPrecedingComments(index) {
+		const lines = _.get(this.sender, "state.lines", []);
+		const parts = [];
+		for (let i = index - 1; i >= 0 && parts.length < 3; i--) {
+			const prev = String(lines[i]).trim();
+			const semi = prev.match(/^;(.*)$/);
+			const paren = prev.match(/^\(([^)]*)\)$/);
+			if (!semi && !paren) {
+				break;
+			}
+			const text = (semi ? semi[1] : paren[1]).trim();
+			if (text) {
+				parts.unshift(text);
+			}
+		}
+		// Control characters (a stray \r from mixed line endings, U+2028/29)
+		// would corrupt the "%pre_complete ;<comment>" feeder marker this
+		// string gets embedded into, so flatten them to spaces.
+		return parts
+			.join(" ")
+			.replace(/[\u0000-\u001f\u2028\u2029]+/g, " ")
+			.trim();
 	}
 
 	convertGcodeToArray(gcode) {


### PR DESCRIPTION
## Problem

In **Code** tool-change mode (and the wizard modes), the dialog shown at an M6 only displays a comment when it sits **on the same line** as the M6 — the sender `dataFilter` builds `commentString` from the single line being sent. Most post processors (Fusion 360 among them) emit the tool/operation description on its own comment line directly *above* the M6 block:

```gcode
(D1 drill 0.8mm)
T20 M6
```

so in practice the confirm dialog shows no comment at all, and the operator has no idea which tool to fit — especially painful mid-program in multi-tool jobs.

## Change

If the M6 line itself carries no inline comment, walk back over the comment-only lines immediately preceding it (up to three, stopping at the first non-comment line) and use those as the comment, prefixed with the tool word (skipped when the comment already starts with it) so the dialog always identifies the requested tool. With the file above, the dialog now shows:

> Comment: **T20 - D1 drill 0.8mm**

- `getPrecedingComments(index)` added next to `convertGcodeToArray` on both controllers; the `Sender` already holds the full line array and `state.sent` is still the current index inside `dataFilter`, so the preceding lines are directly addressable.
- The fallback runs only inside the M6 branch when the tool-change option is not `Ignore`; M0/M1 comment behavior and every other path are untouched.
- Control characters (a stray CR from mixed line endings, U+2028/29) are flattened to spaces, so the comment can never corrupt the `%pre_complete ;<comment>` feeder marker it gets embedded into. (An M6 preceded by `(rough\r\npass)`-style mixed EOLs would otherwise leave the workflow paused with no dialog.)
- Applied identically to `GrblController` and `GrblHalController`.

## Testing

- Simulated the exact helper + fallback against real Fusion 360 posts (5-tool job) and hand-written files: Fusion operation comments surface correctly; files with no preceding comment fall back to the bare tool word; CR/U+2028 injection cases produce a clean single-line comment.
- Running on a Sienci AltMill MK2 4x4 (SLB-EXT/grblHAL, gSender 1.6.3 with this patch transplanted) in Code mode with pre/post hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)