### PR TITLE
Portrait macro bar with drag-and-drop reordering

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -380,6 +380,14 @@ export const SettingsMenu: SettingsMenuSection[] = [
                         min: 0,
                         max: 4,
                     },
+                    {
+                        label: 'Portrait macro bar',
+                        key: 'workspace.portraitMacroBar',
+                        description:
+                            'Show a quick-access macro bar at the bottom of the screen in portrait mode.',
+                        type: 'boolean',
+                        defaultValue: false,
+                    },
                 ],
             },
             {

--- a/src/app/src/store/defaultState/index.ts
+++ b/src/app/src/store/defaultState/index.ts
@@ -58,6 +58,7 @@ const defaultState: State = {
         atcEnabled: false,
         safeRetractHeight: 0,
         customDecimalPlaces: 0,
+        portraitMacroBar: false,
         jobsFinished: 0,
         jobsCancelled: 0,
         timeSpentRunning: 0,

--- a/src/app/src/workspace/Carve/index.tsx
+++ b/src/app/src/workspace/Carve/index.tsx
@@ -7,6 +7,7 @@ import Visualizer from 'app/features/Visualizer';
 import { Column } from '../Column';
 import { ToolArea } from '../ToolArea';
 import { ToolTimelineWrapper } from 'app/features/ATC/components/ToolTimeline';
+import { PortraitMacroBar } from '../PortraitMacroBar';
 
 export const Carve = () => {
     const { pathname } = useLocation();
@@ -15,7 +16,7 @@ export const Carve = () => {
     const shouldHide = pathname !== '/';
 
     return (
-        <div className={cx({ hidden: shouldHide }, 'h-full')}>
+        <div className={cx({ hidden: shouldHide }, 'relative h-full')}>
             <div
                 className={cx(
                     'flex',
@@ -42,21 +43,24 @@ export const Carve = () => {
 
             <div
                 className={cx(
-                    'flex',
+                    'flex flex-col',
                     isPortrait
                         ? 'h-[55%] min-h-0 max-h-[55%]'
                         : 'h-[25%] max-xl:h-[24%] max-xl:max-h-[24%] max-h-[25%] min-h-48 max-xl:min-h-max',
                 )}
             >
-                <div className={isPortrait ? 'w-2/3' : 'w-full'}>
-                    <ToolArea />
-                </div>
-
-                {isPortrait && (
-                    <div className="w-1/3 min-w-[400px]">
-                        <Column />
+                <div className={cx('flex', isPortrait && 'flex-1 min-h-0')}>
+                    <div className={isPortrait ? 'w-2/3' : 'w-full'}>
+                        <ToolArea />
                     </div>
-                )}
+
+                    {isPortrait && (
+                        <div className="w-1/3 min-w-[400px]">
+                            <Column />
+                        </div>
+                    )}
+                </div>
+                <PortraitMacroBar />
             </div>
         </div>
     );

--- a/src/app/src/workspace/PortraitMacroBar/index.tsx
+++ b/src/app/src/workspace/PortraitMacroBar/index.tsx
@@ -136,17 +136,8 @@ export const PortraitMacroBar = () => {
         fetchMacros();
 
         const onFocus = () => fetchMacros();
-        const onVisibilityChange = () => {
-            if (document.visibilityState === 'visible') {
-                fetchMacros();
-            }
-        };
         window.addEventListener('focus', onFocus);
-        document.addEventListener('visibilitychange', onVisibilityChange);
-        return () => {
-            window.removeEventListener('focus', onFocus);
-            document.removeEventListener('visibilitychange', onVisibilityChange);
-        };
+        return () => window.removeEventListener('focus', onFocus);
     }, [isPortrait, enabled]);
 
     const canRun = isConnected && (workflow.state === WORKFLOW_STATE_IDLE || workflow.state === WORKFLOW_STATE_PAUSED);

--- a/src/app/src/workspace/PortraitMacroBar/index.tsx
+++ b/src/app/src/workspace/PortraitMacroBar/index.tsx
@@ -136,8 +136,17 @@ export const PortraitMacroBar = () => {
         fetchMacros();
 
         const onFocus = () => fetchMacros();
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                fetchMacros();
+            }
+        };
         window.addEventListener('focus', onFocus);
-        return () => window.removeEventListener('focus', onFocus);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        return () => {
+            window.removeEventListener('focus', onFocus);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+        };
     }, [isPortrait, enabled]);
 
     const canRun = isConnected && (workflow.state === WORKFLOW_STATE_IDLE || workflow.state === WORKFLOW_STATE_PAUSED);

--- a/src/app/src/workspace/PortraitMacroBar/index.tsx
+++ b/src/app/src/workspace/PortraitMacroBar/index.tsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useMediaQuery } from 'react-responsive';
+import cx from 'classnames';
+import {
+    DndContext,
+    closestCenter,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    DragEndEvent,
+    DragStartEvent,
+    DragOverlay,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    rectSortingStrategy,
+    useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { FaGripVertical } from 'react-icons/fa';
+
+import api from 'app/api';
+import controller from 'app/lib/controller';
+import { toast } from 'app/lib/toaster';
+import { WORKFLOW_STATE_IDLE, WORKFLOW_STATE_PAUSED } from 'app/constants';
+import { useTypedSelector } from 'app/hooks/useTypedSelector';
+import { useWorkspaceState } from 'app/hooks/useWorkspaceState';
+
+type MacroItem = {
+    id: string;
+    name: string;
+    description: string;
+};
+
+function MacroButtonInner({
+    macro,
+    canRun,
+    onClick,
+    className,
+}: {
+    macro: MacroItem;
+    canRun: boolean;
+    onClick?: () => void;
+    className?: string;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            disabled={!canRun}
+            className={cx(
+                'w-full px-4 py-3 rounded-lg text-base font-semibold h-14 line-clamp-2',
+                'border-2 transition-colors duration-150',
+                canRun
+                    ? 'bg-white dark:bg-dark-lighter border-blue-500 dark:border-blue-400 text-blue-700 dark:text-blue-300'
+                    : 'bg-gray-200 dark:bg-dark-lighter border-gray-300 dark:border-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed',
+                className,
+            )}
+        >
+            {macro.name}
+        </button>
+    );
+}
+
+function SortableMacroButton({
+    macro,
+    canRun,
+    onRun,
+    isDragging,
+}: {
+    macro: MacroItem;
+    canRun: boolean;
+    onRun: (macro: MacroItem) => void;
+    isDragging?: boolean;
+}) {
+    const { attributes, listeners, setNodeRef, transform, transition } =
+        useSortable({ id: macro.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={cx('relative w-full', isDragging && 'invisible')}
+        >
+            <MacroButtonInner macro={macro} canRun={canRun} onClick={() => onRun(macro)} />
+            <div
+                {...attributes}
+                {...listeners}
+                className={cx(
+                    'absolute top-1 left-1 p-1 rounded cursor-grab active:cursor-grabbing',
+                    'text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400',
+                    'touch-none',
+                )}
+                title="Drag to reorder"
+            >
+                <FaGripVertical className="w-4 h-4" />
+            </div>
+        </div>
+    );
+}
+
+export const PortraitMacroBar = () => {
+    const isPortrait = useMediaQuery({ query: '(orientation: portrait)' });
+    const { portraitMacroBar: enabled = false } = useWorkspaceState();
+    const isConnected = useTypedSelector(
+        (state) => state.connection.isConnected,
+    );
+    const workflow = useTypedSelector(
+        (state) => state.controller.workflow,
+    );
+    const [macros, setMacros] = useState<MacroItem[]>([]);
+    const [activeId, setActiveId] = useState<string | null>(null);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    );
+
+    useEffect(() => {
+        if (!isPortrait || !enabled) return;
+
+        const fetchMacros = async () => {
+            try {
+                const res = await api.macros.fetch();
+                const records = res?.data?.records ?? [];
+                setMacros(records);
+            } catch {
+                // silently ignore
+            }
+        };
+
+        fetchMacros();
+
+        const onFocus = () => fetchMacros();
+        window.addEventListener('focus', onFocus);
+        return () => window.removeEventListener('focus', onFocus);
+    }, [isPortrait, enabled]);
+
+    const canRun = isConnected && (workflow.state === WORKFLOW_STATE_IDLE || workflow.state === WORKFLOW_STATE_PAUSED);
+
+    const handleRun = useCallback(
+        (macro: MacroItem) => {
+            if (!canRun) return;
+            controller.command('macro:run', macro.id, controller.context, (err: Error | null) => {
+                if (err) {
+                    toast.error(`Failed to run macro "${macro.name}"`, { position: 'bottom-right' });
+                    return;
+                }
+                toast.info(`Started running macro "${macro.name}"!`, { position: 'bottom-right' });
+            });
+        },
+        [canRun],
+    );
+
+    const handleDragStart = useCallback((event: DragStartEvent) => {
+        setActiveId(event.active.id);
+    }, []);
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            setActiveId(null);
+            const { active, over } = event;
+            if (!over || active.id === over.id) return;
+
+            setMacros((items) => {
+                const oldIndex = items.findIndex((m) => m.id === active.id);
+                const newIndex = items.findIndex((m) => m.id === over.id);
+                const reordered = arrayMove(items, oldIndex, newIndex);
+
+                // persist new order to server
+                reordered.forEach((macro, index) => {
+                    api.macros.update(macro.id, { rowIndex: index });
+                });
+
+                return reordered;
+            });
+        },
+        [],
+    );
+
+    const handleDragCancel = useCallback(() => {
+        setActiveId(null);
+    }, []);
+
+    if (!isPortrait || !enabled || macros.length === 0) return null;
+
+    const activeMacro = activeId ? macros.find((m) => m.id === activeId) : null;
+
+    return (
+        <div className="z-50 border border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-dark px-2 py-2 max-xl:px-1 max-xl:py-1 overflow-y-auto max-h-[160px] rounded-lg">
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
+            >
+                <SortableContext items={macros.map((m) => m.id)} strategy={rectSortingStrategy}>
+                    <div className="grid grid-cols-5 gap-2">
+                        {macros.map((macro) => (
+                            <SortableMacroButton
+                                key={macro.id}
+                                macro={macro}
+                                canRun={canRun}
+                                onRun={handleRun}
+                                isDragging={macro.id === activeId}
+                            />
+                        ))}
+                    </div>
+                </SortableContext>
+                <DragOverlay>
+                    {activeMacro ? (
+                        <MacroButtonInner macro={activeMacro} canRun={canRun} />
+                    ) : null}
+                </DragOverlay>
+            </DndContext>
+        </div>
+    );
+};

--- a/src/app/src/workspace/PortraitMacroBar/index.tsx
+++ b/src/app/src/workspace/PortraitMacroBar/index.tsx
@@ -135,9 +135,8 @@ export const PortraitMacroBar = () => {
 
         fetchMacros();
 
-        const onFocus = () => fetchMacros();
-        window.addEventListener('focus', onFocus);
-        return () => window.removeEventListener('focus', onFocus);
+        const interval = setInterval(fetchMacros, 3000);
+        return () => clearInterval(interval);
     }, [isPortrait, enabled]);
 
     const canRun = isConnected && (workflow.state === WORKFLOW_STATE_IDLE || workflow.state === WORKFLOW_STATE_PAUSED);

--- a/src/app/src/workspace/PortraitMacroBar/tests/PortraitMacroBar.test.tsx
+++ b/src/app/src/workspace/PortraitMacroBar/tests/PortraitMacroBar.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Test 1: SettingsMenu contains the portrait macro bar toggle
+describe('Portrait macro bar setting', () => {
+    test('SettingsMenu includes portraitMacroBar toggle', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const settingsPath = path.resolve(__dirname, '../../../features/Config/assets/SettingsMenu.ts');
+        const content = fs.readFileSync(settingsPath, 'utf8');
+        expect(content).toContain("key: 'workspace.portraitMacroBar'");
+        expect(content).toContain('type: \'boolean\'');
+        expect(content).toContain('portrait');
+    });
+});
+
+// Test 2: Default state includes the setting
+describe('Default state', () => {
+    test('defaultState has portraitMacroBar set to false', () => {
+        const { default: defaultState } = require('app/store/defaultState');
+        expect(defaultState.workspace.portraitMacroBar).toBe(false);
+    });
+});
+
+// Test 3: Workspace interface includes the type
+describe('Workspace TypeScript interface', () => {
+    test('definitions.ts declares portraitMacroBar as boolean', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const definitionsPath = path.resolve(
+            __dirname,
+            '../../definitions.ts',
+        );
+        const content = fs.readFileSync(definitionsPath, 'utf8');
+        expect(content).toContain('portraitMacroBar: boolean');
+    });
+});
+
+// Test 4: PortraitMacroBar component exists and exports correctly
+describe('PortraitMacroBar module', () => {
+    test('exports PortraitMacroBar as a named export', () => {
+        const mod = require('../index');
+        expect(typeof mod.PortraitMacroBar).toBe('function');
+    });
+});
+
+// Test 5: Carve component imports and renders PortraitMacroBar
+describe('Carve component integration', () => {
+    test('Carve imports PortraitMacroBar', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const carvePath = path.resolve(
+            __dirname,
+            '../../Carve/index.tsx',
+        );
+        const content = fs.readFileSync(carvePath, 'utf8');
+        expect(content).toContain("import { PortraitMacroBar } from '../PortraitMacroBar'");
+        expect(content).toContain('<PortraitMacroBar />');
+    });
+
+    test('Carve uses flex-col in bottom section for macro bar layout', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const carvePath = path.resolve(
+            __dirname,
+            '../../Carve/index.tsx',
+        );
+        const content = fs.readFileSync(carvePath, 'utf8');
+        expect(content).toContain('flex flex-col');
+    });
+});
+
+// Test 6: PortraitMacroBar component structure
+describe('PortraitMacroBar component structure', () => {
+    test('uses useWorkspaceState for the toggle', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('useWorkspaceState');
+        expect(content).toContain('portraitMacroBar');
+    });
+
+    test('polls for macro changes', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('setInterval');
+        expect(content).toContain('fetchMacros');
+    });
+
+    test('returns null when not in portrait mode or disabled', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('if (!isPortrait || !enabled');
+    });
+
+    test('uses @dnd-kit for drag and drop', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('@dnd-kit/core');
+        expect(content).toContain('@dnd-kit/sortable');
+    });
+
+    test('calls api.macros.fetch to load macros', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('api.macros.fetch');
+    });
+
+    test('calls api.macros.update for drag reordering', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('api.macros.update');
+    });
+
+    test('disables buttons when not connected', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('disabled={!canRun}');
+    });
+
+    test('uses fixed button height with text truncation', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const componentPath = path.resolve(__dirname, '../index.tsx');
+        const content = fs.readFileSync(componentPath, 'utf8');
+        expect(content).toContain('h-14');
+        expect(content).toContain('line-clamp-2');
+    });
+});

--- a/src/app/src/workspace/definitions.ts
+++ b/src/app/src/workspace/definitions.ts
@@ -34,6 +34,7 @@ export interface Workspace {
     spindleFunctions: boolean;
     coolantFunctions: boolean;
     atcEnabled: boolean;
+    portraitMacroBar: boolean;
     collectUsageDataStatus: 'accepted' | 'denied' | 'pending';
     safeRetractHeight: number;
     customDecimalPlaces: number;


### PR DESCRIPTION
I have recently upgraded my cnc computer and added a touch screen that I have set in portrait mode. While gsender works great in landscape mode I found myself fat fingering the wrong macro's more than I would like to admit. I added a macro bar that is disabled by default but has an option in the normal settings to turn it on. It only will show up if it is in portrait aspect ration AND there are macros.

## Summary

Adds a quick-access macro bar at the bottom of the screen when using gSender in portrait orientation. This is particularly useful for touch-screen or tablet setups on CNC machines where portrait mode is the primary layout.

## What changed

- **New `PortraitMacroBar` component** — renders a grid of macro buttons at the bottom of the Carve page in portrait mode, with drag-and-drop reordering via `@dnd-kit`
- **Carve layout updated** — bottom section now uses `flex-col` so the macro bar occupies space naturally without hardcoded padding
- **Toggle setting** — users can enable/disable the macro bar from Settings > Basic > UI Settings > "Portrait macro bar"
- **TypeScript interface** — `portraitMacroBar` added to the `Workspace` type
<img width="1078" height="481" alt="image" src="https://github.com/user-attachments/assets/198f5d0d-811d-4390-b613-9d8e17e2a9f5" />



## How to test

1. Enable the setting in Settings > Basic > UI Settings > "Portrait macro bar"
2. Rotate to portrait orientation (or use a narrow viewport)
3. The macro bar appears at the bottom with your configured macros
4. Drag macros to reorder — the order persists across sessions
5. Disable the setting — bar disappears, no leftover padding
<img width="870" height="503" alt="image" src="https://github.com/user-attachments/assets/343c230f-0b4f-463f-8d02-cd16509c77a4" />

## Notes

- Follows the same patterns as `spindleFunctions` and `coolantFunctions` for the toggle (`useWorkspaceState`)
- When disabled, the bar takes no space — no absolute positioning or padding hacks
- Landscape mode is unaffected

<img width="1078" height="1919" alt="image" src="https://github.com/user-attachments/assets/c5b69250-daa7-4196-b451-eb38e7793d68" />

