### PR TITLE
Features/close pendant view - MI 2522

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -167,6 +167,18 @@ function copyPreloadFile(target) {
 	const dest = path.join(destDir, "preload.js");
 	fs.mkdirSync(destDir, { recursive: true });
 	fs.copyFileSync(src, dest);
+
+	// The desktop app also embeds the pendant view (main.js's "use pendant
+	// view as default UI" window), which needs preload-pendant.js alongside
+	// its own preload.js. copyPendantPreloadFile() only copies this into
+	// dist/gsender-pendant (the standalone pendant binary), so it's copied
+	// here too for the desktop build's dist/gsender.
+	const pendantSrc = path.join(
+		__dirname,
+		"src/electron-app/preload-pendant.js",
+	);
+	const pendantDest = path.join(destDir, "preload-pendant.js");
+	fs.copyFileSync(pendantSrc, pendantDest);
 }
 
 function copyPendantPreloadFile(target) {

--- a/scripts/prepare-default-plugins.js
+++ b/scripts/prepare-default-plugins.js
@@ -35,6 +35,28 @@ const runYarn = (packageDir, args) => {
 
 const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"));
 
+const isPluginSdkInstallStale = (packageDir) => {
+	const installedPackageJsonPath = path.join(
+		packageDir,
+		"node_modules",
+		"@sienci",
+		"gsender-plugin-sdk",
+		"package.json",
+	);
+	if (!fs.existsSync(installedPackageJsonPath)) {
+		return false;
+	}
+
+	const sdkPackageJsonPath = path.join(PLUGIN_SDK_DIR, "package.json");
+	if (!fs.existsSync(sdkPackageJsonPath)) {
+		return false;
+	}
+
+	const installedVersion = readJson(installedPackageJsonPath).version;
+	const expectedVersion = readJson(sdkPackageJsonPath).version;
+	return installedVersion !== expectedVersion;
+};
+
 const ensureDependenciesInstalled = (packageDir) => {
 	const packageJsonPath = path.join(packageDir, "package.json");
 	if (!fs.existsSync(packageJsonPath)) {
@@ -42,9 +64,29 @@ const ensureDependenciesInstalled = (packageDir) => {
 	}
 
 	const nodeModulesPath = path.join(packageDir, "node_modules");
-	if (!fs.existsSync(nodeModulesPath)) {
+	if (!fs.existsSync(nodeModulesPath) || isPluginSdkInstallStale(packageDir)) {
 		runYarn(packageDir, ["install", "--non-interactive"]);
 	}
+};
+
+const isPluginSdkDistComplete = () => {
+	const packageJsonPath = path.join(PLUGIN_SDK_DIR, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return true;
+	}
+
+	const { exports: sdkExports } = readJson(packageJsonPath);
+	if (!sdkExports) {
+		return fs.existsSync(PLUGIN_SDK_ENTRY);
+	}
+
+	return Object.values(sdkExports).every((subpathExport) => {
+		const importPath = subpathExport?.import;
+		if (!importPath) {
+			return true;
+		}
+		return fs.existsSync(path.join(PLUGIN_SDK_DIR, importPath));
+	});
 };
 
 const ensurePluginSdkBuilt = () => {
@@ -53,7 +95,7 @@ const ensurePluginSdkBuilt = () => {
 		return;
 	}
 
-	if (fs.existsSync(PLUGIN_SDK_ENTRY)) {
+	if (isPluginSdkDistComplete()) {
 		return;
 	}
 

--- a/src/electron-app/pendant-window.js
+++ b/src/electron-app/pendant-window.js
@@ -21,7 +21,7 @@
  *
  */
 
-import { BrowserWindow } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 import pkg from "../package.json";
 
 // Shared by the standalone pendant binary (pendant-main.js) and the main
@@ -46,6 +46,8 @@ export function createPendantWindow(isDev, preloadPath) {
 		},
 	});
 	require("@electron/remote/main").enable(window.webContents);
+
+	ipcMain.on("pendant:quit-app", () => app.quit());
 
 	window.once("ready-to-show", () => {
 		window.show();

--- a/src/electron-app/preload-pendant.js
+++ b/src/electron-app/preload-pendant.js
@@ -39,4 +39,5 @@ window.pendantAPI = {
 	pickGcodeFile: () => ipcRenderer.invoke("pendant:pick-gcode-file"),
 	readGcodeFile: (filePath) =>
 		ipcRenderer.invoke("pendant:read-gcode-file", filePath),
+	quitApp: () => ipcRenderer.send("pendant:quit-app"),
 };

--- a/src/main.js
+++ b/src/main.js
@@ -370,11 +370,59 @@ const main = () => {
 
 			let window;
 			if (usePendantView) {
+				// Registered before loadURL below: the pendant SPA (src/pendant/)
+				// invokes "pendant:get-host" as soon as its bootstrap script runs,
+				// which can happen before loadURL's promise resolves. Mirrors the
+				// standalone pendant binary's handlers in src/pendant-main.js.
+				ipcMain.handle("pendant:get-host", () => {
+					if (!hostInformation.address || !hostInformation.port) {
+						return undefined;
+					}
+					return `${hostInformation.address}:${hostInformation.port}`;
+				});
+
+				ipcMain.handle("pendant:pick-gcode-file", async () => {
+					const result = await dialog.showOpenDialog(window ?? undefined, {
+						properties: ["openFile"],
+						filters: [
+							{
+								name: "G-Code Files",
+								extensions: ["gcode", "gc", "nc", "tap", "cnc", "g"],
+							},
+							{ name: "All Files", extensions: ["*"] },
+						],
+					});
+
+					if (result.canceled || !result.filePaths.length) return undefined;
+
+					const filePath = result.filePaths[0];
+					const content = await fs.promises.readFile(filePath, "utf8");
+					const { size } = await fs.promises.stat(filePath);
+					return {
+						path: filePath,
+						name: path.basename(filePath),
+						size,
+						content,
+					};
+				});
+
+				ipcMain.handle("pendant:read-gcode-file", async (_event, filePath) => {
+					if (typeof filePath !== "string" || !filePath) return undefined;
+					const content = await fs.promises.readFile(filePath, "utf8");
+					const { size } = await fs.promises.stat(filePath);
+					return {
+						path: filePath,
+						name: path.basename(filePath),
+						size,
+						content,
+					};
+				});
+
 				kiosk = true;
 				const pendantUrl = `${url}/pendant`;
 				window = createPendantWindow(
 					false,
-					path.join(__dirname, "electron-app/preload-pendant.js"),
+					path.join(__dirname, "preload-pendant.js"),
 				);
 				window.once("ready-to-show", () => {
 					splashScreen.close();
@@ -711,17 +759,22 @@ const main = () => {
 
 				// The pendant view runs in native kiosk/fullscreen mode, which can
 				// block the process from exiting cleanly (macOS in particular) unless
-				// we leave fullscreen first. Fall back to a timeout in case the
-				// "leave-full-screen" event never fires.
+				// we leave fullscreen first. Schedule the fallback timeout before
+				// touching kiosk/fullscreen state so a native exception there can't
+				// prevent the restart from ever happening.
 				if (
 					window &&
 					!window.isDestroyed() &&
 					(window.isKiosk() || window.isFullScreen())
 				) {
 					window.once("leave-full-screen", finishRestart);
-					window.setKiosk(false);
-					window.setFullScreen(false);
 					setTimeout(finishRestart, 1000);
+					try {
+						window.setKiosk(false);
+						window.setFullScreen(false);
+					} catch (err) {
+						log.error(`Failed to leave kiosk/fullscreen before restart: ${err}`);
+					}
 				} else {
 					finishRestart();
 				}

--- a/src/main.js
+++ b/src/main.js
@@ -701,8 +701,30 @@ const main = () => {
 
 			//Handle app restart with remote settings
 			ipcMain.on("remoteMode-restart", (event, headlessSettings) => {
-				app.relaunch(); // flags are handled in server/index.js
-				app.exit(0);
+				let didRestart = false;
+				const finishRestart = () => {
+					if (didRestart) return;
+					didRestart = true;
+					app.relaunch(); // flags are handled in server/index.js
+					app.exit(0);
+				};
+
+				// The pendant view runs in native kiosk/fullscreen mode, which can
+				// block the process from exiting cleanly (macOS in particular) unless
+				// we leave fullscreen first. Fall back to a timeout in case the
+				// "leave-full-screen" event never fires.
+				if (
+					window &&
+					!window.isDestroyed() &&
+					(window.isKiosk() || window.isFullScreen())
+				) {
+					window.once("leave-full-screen", finishRestart);
+					window.setKiosk(false);
+					window.setFullScreen(false);
+					setTimeout(finishRestart, 1000);
+				} else {
+					finishRestart();
+				}
 			});
 		} catch (err) {
 			log.error(err);

--- a/src/pendant/src/components/PendantTopBar.tsx
+++ b/src/pendant/src/components/PendantTopBar.tsx
@@ -2,8 +2,11 @@ import ConnectionWidget from "./ConnectionWidget";
 import { cancelJog } from "app/features/Jogging/utils/Jogging";
 import { useTypedSelector } from "app/hooks/useTypedSelector";
 import type { RootState } from "app/store/redux";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { ComponentType } from "react";
+import { useLongPress } from "use-long-press";
+import { Confirm } from "app/components/ConfirmationDialog/ConfirmationDialogLib.ts";
+import { isElectron, quitApp } from "../electron-bridge";
 import {
 	Circle,
 	CircleCheck,
@@ -328,8 +331,82 @@ const STATE_BADGES: Record<string, BadgeConfig> = {
 	},
 };
 
+const QUIT_HOLD_MS = 1000;
+const QUIT_RING_RADIUS = 19;
+const QUIT_RING_CIRCUMFERENCE = 2 * Math.PI * QUIT_RING_RADIUS;
+
+function useLogoHoldToQuit() {
+	const [progress, setProgress] = useState(0);
+	const [isHolding, setIsHolding] = useState(false);
+	const startTimeRef = useRef(0);
+	const rafRef = useRef<number | null>(null);
+
+	const stopProgressLoop = useCallback(() => {
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => stopProgressLoop, [stopProgressLoop]);
+
+	const startProgressLoop = useCallback(() => {
+		const update = (now: number) => {
+			const elapsed = now - startTimeRef.current;
+			setProgress(Math.min(elapsed / QUIT_HOLD_MS, 1));
+			rafRef.current = requestAnimationFrame(update);
+		};
+		rafRef.current = requestAnimationFrame(update);
+	}, []);
+
+	const bind = useLongPress(
+		() => {
+			setIsHolding(false);
+			stopProgressLoop();
+			setProgress(0);
+			Confirm({
+				title: "Quit gSender?",
+				content: "Are you sure you want to quit gSender?",
+				confirmLabel: "Quit",
+				cancelLabel: "Cancel",
+				onConfirm: () => quitApp(),
+			});
+		},
+		{
+			threshold: QUIT_HOLD_MS,
+			cancelOnMovement: true,
+			filterEvents: (event) => {
+				if (!isElectron()) {
+					return false;
+				}
+				if ("button" in event && typeof event.button === "number") {
+					return event.button === 0;
+				}
+				return true;
+			},
+			onStart: () => {
+				startTimeRef.current = performance.now();
+				setProgress(0);
+				setIsHolding(true);
+				startProgressLoop();
+			},
+			onCancel: () => {
+				stopProgressLoop();
+				setProgress(0);
+				setIsHolding(false);
+			},
+			onFinish: () => {
+				stopProgressLoop();
+			},
+		},
+	);
+
+	return { bind, progress, isHolding };
+}
+
 export default function PendantTopBar() {
 	const isDark = useIsDark();
+	const { bind, progress, isHolding } = useLogoHoldToQuit();
 	const isConnected = useTypedSelector(
 		(s: RootState) => s.connection.isConnected,
 	);
@@ -388,9 +465,36 @@ export default function PendantTopBar() {
 
 	return (
 		<header className="h-14 px-3 flex items-center gap-3 bg-gray-50 border-b border-gray-200 dark:bg-surface-base dark:border-outline shrink-0 select-none relative drag-region">
-			{/* Logo */}
-			<div className="flex items-center gap-2 shrink-0">
+			{/* Logo — hold to quit */}
+			<div
+				className="relative flex items-center gap-2 shrink-0 no-drag touch-manipulation"
+				onContextMenu={(event) => event.preventDefault()}
+				{...bind()}
+			>
 				<img src={iconRound} alt="gSender" className="w-9 h-9" />
+				{isHolding && (
+					<svg
+						width={44}
+						height={44}
+						viewBox="0 0 44 44"
+						className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none -rotate-90"
+						aria-hidden
+					>
+						<circle
+							cx={22}
+							cy={22}
+							r={QUIT_RING_RADIUS}
+							fill="none"
+							stroke="rgba(220,38,38,0.85)"
+							strokeWidth={3}
+							strokeLinecap="round"
+							strokeDasharray={QUIT_RING_CIRCUMFERENCE}
+							strokeDashoffset={
+								QUIT_RING_CIRCUMFERENCE * (1 - Math.min(Math.max(progress, 0), 1))
+							}
+						/>
+					</svg>
+				)}
 			</div>
 
 			{/* Touch-forward connection widget */}

--- a/src/pendant/src/electron-bridge.ts
+++ b/src/pendant/src/electron-bridge.ts
@@ -16,6 +16,7 @@ interface PendantAPI {
 	getHost: () => Promise<string | undefined>;
 	pickGcodeFile: () => Promise<GcodeFilePayload | undefined>;
 	readGcodeFile: (path: string) => Promise<GcodeFilePayload | undefined>;
+	quitApp: () => void;
 }
 
 declare global {
@@ -45,4 +46,9 @@ export async function readGcodeFile(
 	path: string,
 ): Promise<GcodeFilePayload | undefined> {
 	return api()?.readGcodeFile(path);
+}
+
+/** Quits the Electron app (pendant binary or desktop app embedding the pendant view). */
+export function quitApp(): void {
+	api()?.quitApp();
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -241,6 +241,14 @@ const appMain = () => {
 				route,
 				serveStatic(asset.path, {
 					maxAge: asset.maxAge,
+					setHeaders: (res, filePath) => {
+						// index.html isn't content-hashed like the JS/CSS chunks it
+						// references, so it must never be cached long-term or a stale
+						// entry point can keep loading a stale bundle indefinitely.
+						if (path.basename(filePath) === "index.html") {
+							res.setHeader("Cache-Control", "no-cache");
+						}
+					},
 				}),
 			);
 		});


### PR DESCRIPTION
**What changed**
- add hold-logo-for-1s-to-quit on the pendant (standalone + desktop pendant mode), with a confirm dialog
- fix restart-on-disable doing nothing / crashing when toggling pendant mode off
- fix desktop pendant mode blank screen + hold-to-quit not working (missing preload path, missing pendant:get-host IPC handler in main.js)
- fix stale pendant UI persisting after rebuild (index.html was cached for a year)
- fix yarn build failing on plugin-sdk's missing ./vite export

**How to test**
pendant device: hold logo 1s -> ring fills -> "Quit gSender?" -> confirm quits, cancel doesn't
desktop: enable "Use pendant view as default UI", restart, repeat hold-to-quit test in the embedded pendant window
desktop: disable the toggle from pendant settings, confirm Restart -> app actually exits and relaunches to normal UI
rebuild pendant UI (npm run vite:build:pendant), relaunch desktop pendant mode, confirm change shows up without clearing cache
yarn build from a clean checkout should succeed, no "Missing ./vite specifier" error
Notes
not tested on windows/linux packaging, macOS/arm64 only
no automated tests added, all manual

@ShilpaKAjin 