### PR TITLE
Bugfix for directory selection in config page

### DIFF
--- a/src/app/src/features/Config/components/SettingInputs/PathSelection.tsx
+++ b/src/app/src/features/Config/components/SettingInputs/PathSelection.tsx
@@ -17,7 +17,9 @@ const PathSelection = ({ value, onChange }: Props) => {
 			(window as any).ipcRenderer.on(
 				"returned-directory-dialog-data",
 				(_: any, directory: string) => {
-					onChange(directory);
+					if (directory) {
+						onChange(directory);
+					}
 				},
 			);
 		}


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
Issue:
- go to config page
- navigate to “settings backup location”
- click “choose folder”
- press cancel on the popup
- chosen folder changes to “0”

Expected behaviour:
- current chosen folder doesn’t change

What I did:
- check if directory variable is not undefined before replacing

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Refactor

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Cypress tests added/updated
- [ ] Manually tested in Chrome
- [ ] Manually tested in Safari
- [ ] Manually tested in Firefox
- [x] Manually tested in Electron
