### PR TITLE
[MI-2512]: Notifications Not Logging Alarms/Errors

### DIFF
--- a/src/app/src/store/redux/sagas/controllerSagas.tsx
+++ b/src/app/src/store/redux/sagas/controllerSagas.tsx
@@ -919,6 +919,10 @@ export function* initialize(): Generator<null, void, unknown> {
 
 		if (ALARM_ERROR_TYPES.includes(error.type)) {
 			updateAlarmsErrors(error);
+			toast.error(
+				`${error.type === ALARM ? "Alarm" : "Error"} ${error.code}: ${error.description}`,
+				{ position: "bottom-right" },
+			);
 		}
 
 		pubsub.publish("error", error);


### PR DESCRIPTION
## Description
Notifications section stopped logging alarms/errors.
It turns out the toasts for alarms/errors were removed.
I fixed it so toasts appear when an alarm/error is triggered, and the notifications now log the alarms/errors properly.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Refactor

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Cypress tests added/updated
- [ ] Manually tested in Chrome
- [ ] Manually tested in Safari
- [x] Manually tested in Firefox


