### PR TITLE
Add Voron Cascade machine profile

### DIFF
--- a/src/app/src/features/Config/assets/MachineDefaults/defaultMachineProfiles.ts
+++ b/src/app/src/features/Config/assets/MachineDefaults/defaultMachineProfiles.ts
@@ -406,5 +406,16 @@ export default [
             depth: 450,
             height: 465,
         },
+    },    {
+        id: 60,
+        company: '',
+        name: 'Voron Cascade',
+        type: '',
+        version: '',
+        mm: {
+            width: 260,
+            depth: 220,
+            height: 100,
+        },
     },
 ];

--- a/src/app/src/features/Config/assets/MachineDefaults/defaultMachineProfiles.ts
+++ b/src/app/src/features/Config/assets/MachineDefaults/defaultMachineProfiles.ts
@@ -406,7 +406,8 @@ export default [
             depth: 450,
             height: 465,
         },
-    },    {
+    },
+    {
         id: 60,
         company: '',
         name: 'Voron Cascade',


### PR DESCRIPTION
Adds the Voron Cascade CNC to the gSender machine profile list.

Machine working area:

* X: 260 mm
* Y: 220 mm
* Z: 100 mm

The machine uses grblHAL with a BTT Scylla H723 controller.

This PR only adds the machine profile entry used by gSender's machine selector. It does not modify firmware defaults or existing machine profiles.

Additional grblHAL/Web Builder machine profile information is maintained here:
https://github.com/coolboysalam/grblhal-profiles
