### PR TITLE
Don't force-maximize the main window on launch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -349,6 +349,8 @@ const main = () => {
 			const bounds = {
 				minWidth: 1044,
 				minHeight: 768,
+				width: 1280,
+				height: 800,
 				...store.get("bounds"),
 			};
 			if (usePendantView) {
@@ -387,7 +389,15 @@ const main = () => {
 					title: `gSender ${pkg.version}`,
 					kiosk,
 				};
-				window = await windowManager.openWindow(url, options, splashScreen);
+				// Don't force-maximize on launch (annoying on large monitors).
+				// Open at the saved bounds, or the sensible default above on first
+				// run; the close handler persists the last size/position.
+				window = await windowManager.openWindow(
+					url,
+					options,
+					splashScreen,
+					false,
+				);
 			}
 
 			window.on("ready-to-show", () => {


### PR DESCRIPTION
## Problem

`WindowManager.openWindow` defaults `shouldMaximize = true` and calls `window.maximize()` on every launch. This overrides the window bounds that are saved on close, so the window always fills the screen regardless of how it was last sized/positioned. On large monitors this is disruptive — the app can't be opened at a reasonable size.

## Fix

- Pass `shouldMaximize = false` from the main (non-pendant) window creation in `src/main.js`, so the saved bounds are honored.
- Give first-run a sensible `1280x800` default (alongside the existing `minWidth/minHeight`).

The existing `window.on('close')` handler already persists `window.getBounds()`; those bounds are now respected on the next launch instead of being clobbered by `maximize()`.

## Notes

Single-file change (`src/main.js`), no behavior change for the pendant/kiosk paths. Branch is based on the `v1.7.0-Edge-1` tag; if `main.js` has drifted on `dev` the change is trivial to re-anchor (it's just the `shouldMaximize` argument on the `openWindow` call plus default width/height on the bounds object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)