### PR TITLE
Quick Serialport Controller Event Fixes

### DIFF
--- a/src/server/lib/Connection.js
+++ b/src/server/lib/Connection.js
@@ -163,7 +163,7 @@ class Connection extends EventEmitter {
                 this.connection.removeListener('error', this.connectionEventListener.error);*/
 				log.error(`Error opening serial port "${port}":`, err);
 				this.emit("serialport:error", { err: err, port: port });
-				this.emit("serialport:close", {}, 1);
+				this.emit("serialport:close", {});
 				callback(err); // notify error
 				return;
 			}

--- a/src/server/services/cncengine/CNCEngine.js
+++ b/src/server/services/cncengine/CNCEngine.js
@@ -209,12 +209,12 @@ class CNCEngine {
 			};
 
 			const connectionListeners = {
-				"serialport:open": (port, baudrate, controllerType, inuse) => {
-					this.emit("serialport:open", port, baudrate, controllerType, inuse);
+				"serialport:open": (options) => {
+					this.emit("serialport:open", options);
 				},
-				"serialport:close": (options, received) => {
+				"serialport:close": (options) => {
 					this.connection = null;
-					this.emit("serialport:close", options, received);
+					this.emit("serialport:close", options);
 				},
 				firmwareFound: (
 					controllerType = GRBL,
@@ -625,10 +625,6 @@ class CNCEngine {
 						callback(null);
 					});
 				}
-
-				socket.emit("serialport:close", {
-					port: port,
-				});
 			});
 
 			socket.on("command", (port, cmd, ...args) => {


### PR DESCRIPTION
## Description

- remove double serialport:close emit
- arguments passed to serialport:close/open are now in one object, so remove incorrect variable passing
- `received` var is never used anywhere, so don't bother sending it

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Hotfix
- [ ] Refactor

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Cypress tests added/updated
- [x] Manually tested in Chrome
- [ ] Manually tested in Safari
- [ ] Manually tested in Firefox
